### PR TITLE
refactor: `Slider` now manages its value via state

### DIFF
--- a/components/src/slider.rs
+++ b/components/src/slider.rs
@@ -3,14 +3,58 @@ use freya_elements as dioxus_elements;
 
 #[derive(Props)]
 pub struct SliderProps<'a> {
-    onmoved: EventHandler<'a, f64>,
-    width: f64,
+    pub onmoved: EventHandler<'a, f64>,
+    pub width: f64,
+    /// The value that the slider will use when first initialized.
+    #[props(optional)]
+    pub starting_value: Option<f64>,
 }
 
+/// Provides a slider that goes between 0 and the width of the slider. An
+/// initial value can be provided with the `starting_value` prop, but this will
+/// not change the slider value if updated.
+///
+/// # Example
+/// ```rs
+/// use dioxus::prelude::*;
+/// use freya::{dioxus_elements, *};
+///
+/// const INITIAL_SLIDER_OFFSET: f64 = 30.0;
+///
+/// fn main() {
+///     launch(app);
+/// }
+///
+/// fn app(cx: Scope) -> Element {
+///     let font_size = use_state(&cx, || 20.0 + INITIAL_SLIDER_OFFSET);
+///
+///     cx.render(rsx!(
+///         rect {
+///             width: "100%",
+///             height: "100%",
+///             background: "black",
+///             padding: "20",
+///             label {
+///                 font_size: "{font_size}",
+///                 font_family: "Inter",
+///                 height: "150",
+///                 "Hello World"
+///             }
+///             Slider {
+///                 width: 100.0,
+///                 starting_value: INITIAL_SLIDER_OFFSET,
+///                 onmoved: |e| {
+///                     font_size.set(e + 20.0); // Minimum is 20
+///                 }
+///             }
+///         }
+///     ))
+/// }
+/// ```
 #[allow(non_snake_case)]
 pub fn Slider<'a>(cx: Scope<'a, SliderProps>) -> Element<'a> {
     let hovering = use_state(&cx, || false);
-    let progress = use_state(&cx, || 0.0f64);
+    let progress = use_state(&cx, || cx.props.starting_value.unwrap_or(0.0));
     let clicking = use_state(&cx, || false);
 
     let onmouseleave = |_: UiEvent<MouseData>| {

--- a/components/src/slider.rs
+++ b/components/src/slider.rs
@@ -13,12 +13,17 @@ pub struct SliderProps<'a> {
 }
 
 #[inline]
-fn ensure_correct_slider_range(value: f64) {
-    assert!(
-        value >= 0.0 && value <= 1.0,
-        "The value passed into a slider must be between 0 and 1. The value passed in was: {}",
+fn ensure_correct_slider_range(value: f64) -> f64 {
+    if value < 0.0 {
+        // TODO: Better logging
+        println!("Slider value is less than 0.0, setting to 0.0");
+        0.0
+    } else if value > 1.0 {
+        println!("Slider value is greater than 1.0, setting to 1.0");
+        1.0
+    } else {
         value
-    );
+    }
 }
 
 /// A slider component. It can be uncontrolled, bound to a state or controlled
@@ -89,14 +94,10 @@ pub fn Slider<'a>(cx: Scope<'a, SliderProps>) -> Element<'a> {
     // We always need a state instance, although it will be overridden if the
     // `value` prop is passed in.
     let state = cx.props.state.unwrap_or_else(|| use_state(&cx, || -1.0));
-    let value = cx.props.value.unwrap_or_else(|| state.get());
+    let value = ensure_correct_slider_range(*cx.props.value.unwrap_or_else(|| state.get()));
 
     // Map the 0 to 1 values to the width of the slider
     let progress = value * cx.props.width;
-
-    // The slider's input value should *never*, be outside of the range 0-1.
-    // Panic if this happens
-    ensure_correct_slider_range(*value);
 
     let onmouseleave = |_: UiEvent<MouseData>| {
         if *clicking.get() == false {

--- a/components/src/slider.rs
+++ b/components/src/slider.rs
@@ -60,6 +60,14 @@ pub fn Slider<'a>(cx: Scope<'a, SliderProps>) -> Element<'a> {
     let clicking = use_state(&cx, || false);
     let progress = cx.props.value * cx.props.width;
 
+    // The slider's input value should *never*, be outside of the range 0-1.
+    // Panic if this happens
+    assert!(
+        cx.props.value.get().clone() >= 0.0 && cx.props.value.get().clone() <= 1.0,
+        "The value passed into a slider must be between 0 and 1. The value passed in was: {}",
+        cx.props.value.get().clone()
+    );
+
     let onmouseleave = |_: UiEvent<MouseData>| {
         if *clicking.get() == false {
             hovering.set(false);

--- a/components/src/slider.rs
+++ b/components/src/slider.rs
@@ -96,12 +96,7 @@ pub fn Slider<'a>(cx: Scope<'a, SliderProps>) -> Element<'a> {
 
     // The slider's input value should *never*, be outside of the range 0-1.
     // Panic if this happens
-    if let Some(state) = cx.props.state {
-        ensure_correct_slider_range(*state.get());
-    }
-    if let Some(value) = cx.props.value {
-        ensure_correct_slider_range(*value);
-    }
+    ensure_correct_slider_range(*value);
 
     let onmouseleave = |_: UiEvent<MouseData>| {
         if *clicking.get() == false {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -6,15 +6,13 @@
 use dioxus::prelude::*;
 use freya::{dioxus_elements, *};
 
-const MAX_FONT_SIZE: f64 = 100.0;
-
 fn main() {
     launch(app);
 }
 
 fn app(cx: Scope) -> Element {
     let percentage = use_state(&cx, || 0.2);
-    let font_size = percentage * MAX_FONT_SIZE + 20.0;
+    let font_size = percentage * 100.0 + 20.0;
 
     cx.render(rsx!(
         rect {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -6,12 +6,14 @@
 use dioxus::prelude::*;
 use freya::{dioxus_elements, *};
 
+const INITIAL_SLIDER_OFFSET: f64 = 30.0;
+
 fn main() {
     launch(app);
 }
 
 fn app(cx: Scope) -> Element {
-    let font_size = use_state(&cx, || 20.0);
+    let font_size = use_state(&cx, || 20.0 + INITIAL_SLIDER_OFFSET);
 
     cx.render(rsx!(
         rect {
@@ -27,6 +29,7 @@ fn app(cx: Scope) -> Element {
             }
             Slider {
                 width: 100.0,
+                starting_value: INITIAL_SLIDER_OFFSET,
                 onmoved: |e| {
                     font_size.set(e + 20.0); // Minimum is 20
                 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -36,7 +36,7 @@ fn app(cx: Scope) -> Element {
             }
             Slider {
                 width: 100.0,
-                value: percentage,
+                state: percentage,
             }
         }
     ))

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -6,14 +6,15 @@
 use dioxus::prelude::*;
 use freya::{dioxus_elements, *};
 
-const INITIAL_SLIDER_OFFSET: f64 = 30.0;
+const MAX_FONT_SIZE: f64 = 100.0;
 
 fn main() {
     launch(app);
 }
 
 fn app(cx: Scope) -> Element {
-    let font_size = use_state(&cx, || 20.0 + INITIAL_SLIDER_OFFSET);
+    let percentage = use_state(&cx, || 0.2);
+    let font_size = percentage.get() * MAX_FONT_SIZE + 20.0;
 
     cx.render(rsx!(
         rect {
@@ -27,12 +28,15 @@ fn app(cx: Scope) -> Element {
                 height: "150",
                 "Hello World"
             }
+            Button {
+                on_click: move |_| {
+                    percentage.set(0.2);
+                },
+                label { "Reset size" }
+            }
             Slider {
                 width: 100.0,
-                starting_value: INITIAL_SLIDER_OFFSET,
-                onmoved: |e| {
-                    font_size.set(e + 20.0); // Minimum is 20
-                }
+                value: percentage,
             }
         }
     ))

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -14,7 +14,7 @@ fn main() {
 
 fn app(cx: Scope) -> Element {
     let percentage = use_state(&cx, || 0.2);
-    let font_size = percentage.get() * MAX_FONT_SIZE + 20.0;
+    let font_size = percentage * MAX_FONT_SIZE + 20.0;
 
     cx.render(rsx!(
         rect {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -11,8 +11,8 @@ fn main() {
 }
 
 fn app(cx: Scope) -> Element {
-    let percentage = use_state(&cx, || 0.2);
-    let font_size = percentage * 100.0 + 20.0;
+    let percentage = use_state(&cx, || 20.0);
+    let font_size = percentage + 20.0;
 
     cx.render(rsx!(
         rect {
@@ -28,13 +28,19 @@ fn app(cx: Scope) -> Element {
             }
             Button {
                 on_click: move |_| {
-                    percentage.set(0.2);
+                    percentage.set(20.0);
                 },
-                label { "Reset size" }
+                label {
+                    width: "80", 
+                    "Reset size"
+                }
             }
             Slider {
                 width: 100.0,
-                state: percentage,
+                value: *percentage.get(),
+                onmoved: |p| {
+                    percentage.set(p);
+                }
             }
         }
     ))


### PR DESCRIPTION
Useful for syncing state between restarts, like [here](https://github.com/trickypr/carpet/blob/0e7868d8fc7c8b9313a460c91ce53eff178bf87c/src/frontend/sound.rs#L34).