### PR TITLE
feat: keydown & keyup events support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ dependencies = [
  "dioxus-core",
  "dioxus-hooks",
  "dioxus-html",
+ "glutin",
 ]
 
 [[package]]
@@ -858,11 +859,13 @@ dependencies = [
  "dioxus-html",
  "dioxus-native-core",
  "enumset",
+ "freya-elements",
  "freya-layers",
  "freya-layout",
  "freya-node-state",
  "gl",
  "glutin",
+ "serde_json",
  "skia-safe",
 ]
 
@@ -2726,6 +2729,7 @@ dependencies = [
  "raw-window-handle 0.4.3",
  "raw-window-handle 0.5.0",
  "sctk-adwaita",
+ "serde",
  "smithay-client-toolkit",
  "wasm-bindgen",
  "wayland-client",

--- a/components/src/input.rs
+++ b/components/src/input.rs
@@ -1,0 +1,66 @@
+use dioxus::{core::UiEvent, prelude::*};
+use dioxus_elements::events::{KeyCode, KeyboardData};
+use fermi::*;
+use freya_elements as dioxus_elements;
+use freya_hooks::use_focus;
+
+use crate::THEME;
+
+#[allow(non_snake_case)]
+pub fn Input<'a>(cx: Scope<'a, InputProps<'a>>) -> Element {
+    let theme = use_atom_ref(&cx, THEME);
+    let button_theme = &theme.read().button;
+    let (focused, focus) = use_focus(&cx);
+    let text = cx.props.value;
+    let onkeydown = move |e: UiEvent<KeyboardData>| {
+        if focused {
+            if let KeyCode::Space = e.data.code {
+                // Add a space
+                cx.props.onchange.call(format!("{} ", text));
+            } else if let KeyCode::Back = e.data.code {
+                // Remove the last character
+                let mut content = text.to_string();
+                content.pop();
+                cx.props.onchange.call(content);
+            } else {
+                // Add a new char
+                let text_char = e.data.char_to_str();
+                if let Some(text_char) = &text_char {
+                    cx.props.onchange.call(format!("{}{}", text, text_char));
+                }
+            }
+        }
+    };
+
+    render!(
+        container {
+            onkeydown: onkeydown,
+            onclick: move |_| {
+                focus();
+            },
+            width: "auto",
+            height: "auto",
+            direction: "both",
+            padding: "3",
+            container {
+                width: "100",
+                height: "35",
+                direction: "both",
+                color: "{button_theme.font_theme.color}",
+                shadow: "0 5 15 10 black",
+                radius: "5",
+                padding: "17",
+                background: "{button_theme.background}",
+                label {
+                    "{text}"
+                }
+            }
+        }
+    )
+}
+
+#[derive(Props)]
+pub struct InputProps<'a> {
+    pub value: &'a str,
+    pub onchange: EventHandler<'a, String>,
+}

--- a/components/src/lib.rs
+++ b/components/src/lib.rs
@@ -1,4 +1,5 @@
 mod button;
+mod input;
 mod router_link;
 mod scroll_view;
 mod slider;
@@ -6,6 +7,7 @@ mod switch;
 mod theme;
 
 pub use button::*;
+pub use input::*;
 pub use router_link::*;
 pub use scroll_view::*;
 pub use slider::*;

--- a/elements/Cargo.toml
+++ b/elements/Cargo.toml
@@ -16,3 +16,4 @@ bumpalo = "3.11.0"
 dioxus-core = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove-node-listeners"  }
 dioxus-html = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove-node-listeners"  }
 dioxus-hooks = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove-node-listeners"  }
+glutin = { version = "0.29.1", features = ["serde"]}

--- a/elements/src/events.rs
+++ b/elements/src/events.rs
@@ -1,0 +1,80 @@
+use glutin::event::{ModifiersState, VirtualKeyCode};
+
+pub type KeyCode = VirtualKeyCode;
+
+#[derive(Debug)]
+pub struct KeyboardData {
+    pub code: VirtualKeyCode,
+    pub modifiers: ModifiersState,
+}
+
+impl KeyboardData {
+    pub fn new(code: VirtualKeyCode, modifiers: ModifiersState) -> Self {
+        Self { code, modifiers }
+    }
+}
+
+impl KeyboardData {
+    pub fn char_to_str(&self) -> Option<String> {
+        let mut text = match &self.code {
+            VirtualKeyCode::Key1 => Some("1".to_string()),
+            VirtualKeyCode::Key2 => Some("2".to_string()),
+            VirtualKeyCode::Key3 => Some("3".to_string()),
+            VirtualKeyCode::Key4 => Some("4".to_string()),
+            VirtualKeyCode::Key5 => Some("5".to_string()),
+            VirtualKeyCode::Key6 => Some("6".to_string()),
+            VirtualKeyCode::Key7 => Some("7".to_string()),
+            VirtualKeyCode::Key8 => Some("8".to_string()),
+            VirtualKeyCode::Key9 => Some("9".to_string()),
+            VirtualKeyCode::Key0 => Some("0".to_string()),
+
+            VirtualKeyCode::A => Some("a".to_string()),
+            VirtualKeyCode::B => Some("b".to_string()),
+            VirtualKeyCode::C => Some("c".to_string()),
+            VirtualKeyCode::D => Some("d".to_string()),
+            VirtualKeyCode::E => Some("e".to_string()),
+            VirtualKeyCode::F => Some("f".to_string()),
+            VirtualKeyCode::G => Some("g".to_string()),
+            VirtualKeyCode::H => Some("h".to_string()),
+            VirtualKeyCode::I => Some("i".to_string()),
+            VirtualKeyCode::J => Some("j".to_string()),
+            VirtualKeyCode::K => Some("k".to_string()),
+            VirtualKeyCode::L => Some("l".to_string()),
+            VirtualKeyCode::M => Some("m".to_string()),
+            VirtualKeyCode::N => Some("n".to_string()),
+            VirtualKeyCode::O => Some("o".to_string()),
+            VirtualKeyCode::P => Some("p".to_string()),
+            VirtualKeyCode::Q => Some("q".to_string()),
+            VirtualKeyCode::R => Some("r".to_string()),
+            VirtualKeyCode::S => Some("s".to_string()),
+            VirtualKeyCode::T => Some("t".to_string()),
+            VirtualKeyCode::U => Some("u".to_string()),
+            VirtualKeyCode::V => Some("v".to_string()),
+            VirtualKeyCode::W => Some("w".to_string()),
+            VirtualKeyCode::X => Some("x".to_string()),
+            VirtualKeyCode::Y => Some("y".to_string()),
+            VirtualKeyCode::Z => Some("z".to_string()),
+
+            VirtualKeyCode::Numpad0 => Some("1".to_string()),
+            VirtualKeyCode::Numpad1 => Some("1".to_string()),
+            VirtualKeyCode::Numpad2 => Some("2".to_string()),
+            VirtualKeyCode::Numpad3 => Some("3".to_string()),
+            VirtualKeyCode::Numpad4 => Some("4".to_string()),
+            VirtualKeyCode::Numpad5 => Some("5".to_string()),
+            VirtualKeyCode::Numpad6 => Some("6".to_string()),
+            VirtualKeyCode::Numpad7 => Some("7".to_string()),
+            VirtualKeyCode::Numpad8 => Some("8".to_string()),
+            VirtualKeyCode::Numpad9 => Some("9".to_string()),
+
+            _ => None,
+        };
+
+        if let Some(text_char) = &text {
+            if self.modifiers == ModifiersState::SHIFT {
+                text = Some(text_char.to_uppercase());
+            }
+        }
+
+        text
+    }
+}

--- a/elements/src/lib.rs
+++ b/elements/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod events;
+
 pub use dioxus_core::AttributeValue;
 use dioxus_core::*;
 use std::fmt::Arguments;
@@ -186,6 +188,8 @@ pub mod on {
 
     use bumpalo::boxed::Box as BumpBox;
 
+    use crate::events::KeyboardData;
+
     macro_rules! event_directory {
         ( $(
             $( #[$attr:meta] )*
@@ -231,6 +235,8 @@ pub mod on {
         };
     }
 
+    type KeyboardEvent = UiEvent<KeyboardData>;
+
     event_directory! {
         MouseEvent(MouseData): [
             onclick
@@ -240,6 +246,10 @@ pub mod on {
         ];
         WheelEvent(WheelData): [
             onwheel
+        ];
+        KeyboardEvent(KeyboardData): [
+            onkeydown
+            onkeyup
         ];
     }
 }

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,0 +1,52 @@
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
+
+use dioxus::prelude::*;
+use freya::{
+    dioxus_elements::{self},
+    *,
+};
+
+fn main() {
+    launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    use_init_focus(&cx);
+
+    let values = use_state(&cx, || (String::new(), String::new()));
+
+    render!(
+        container {
+            padding: "15",
+            width: "100%",
+            height: "100%",
+            label {
+                color: "black",
+                "Your name:"
+            }
+            Input {
+                value: &values.0,
+                onchange: |e| {
+                    values.set((e, values.1.clone()))
+                }
+            },
+            label {
+                color: "black",
+                "Your age:"
+            }
+            Input {
+                value: &values.1,
+                onchange: |e| {
+                    values.set((values.0.clone(), e))
+                }
+            },
+            label {
+                color: "black",
+                "You are {values.0} and you are {values.1} years old."
+            }
+        }
+    )
+}

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -16,7 +16,7 @@ wireframe = []
 
 [dependencies]
 gl = "*"
-glutin = "*"
+glutin = { version = "0.29.1", features = ["serde"]}
 skia-safe = { version = "0.55.0", features = ["gl", "textlayout", "svg"] }
 dioxus-core = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove-node-listeners"  }
 dioxus-native-core = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove-node-listeners"  }
@@ -24,4 +24,6 @@ dioxus-html = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove
 enumset = "1.0.11"
 freya-layout = { path = "../layout", version = "0.1.0" }
 freya-node-state = { path = "../state", version = "0.1.0" }
+freya-elements = { path = "../elements", version = "0.1.0" }
 freya-layers = { path = "../layers", version = "0.1.0" }
+serde_json = "1.0.85"


### PR DESCRIPTION
# Changes

- Adds support for `keydown` and `keyup` events.
- Add a new `Input` component
- Add a new example showcasing the Input component:
![image](https://user-images.githubusercontent.com/38158676/194768183-6230a4f6-c1bd-4b98-bdf3-dead230b8fb8.png)
