### PR TITLE
feat: Center display mode

### DIFF
--- a/elements/src/lib.rs
+++ b/elements/src/lib.rs
@@ -70,6 +70,7 @@ builder_constructors! {
         shadow: String,
         radius: String,
         color: String,
+        display: String,
     };
     container {
         padding: String,
@@ -85,6 +86,7 @@ builder_constructors! {
         shadow: String,
         radius: String,
         color: String,
+        display: String,
     };
     label {
         color: String,

--- a/examples/center.rs
+++ b/examples/center.rs
@@ -1,0 +1,92 @@
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
+
+use dioxus::prelude::*;
+use freya::{dioxus_elements, *};
+
+fn main() {
+    launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    render!(
+        rect {
+            background: "rgb(150, 150, 150)",
+            height: "100%",
+            width: "100%",
+            display: "center",
+            direction: "both",
+            rect {
+                background: "rgb(255, 0, 255)",
+                padding: "30",
+                height: "75%",
+                width: "75%",
+                display: "center",
+                direction: "vertical",
+                rect {
+                    background: "rgb(0, 255, 0)",
+                    height: "33%",
+                    width: "50%",
+                }
+                label {
+                    color: "black",
+                    "Hello World"
+                }
+                rect {
+                    background: "rgb(255, 255, 0)",
+                    height: "33%",
+                    width: "50%",
+                    display: "center",
+                    direction: "horizontal",
+                    rect {
+                        background: "rgb(255, 255, 0)",
+                        height: "100%",
+                        width: "70%",
+                        display: "center",
+                        direction: "vertical",
+                        rect {
+                            background: "rgb(180, 180, 180)",
+                            height: "50%",
+                            width: "100%",
+                        }
+                        rect {
+                            background: "rgb(100, 100, 100)",
+                            height: "50%",
+                            width: "100%",
+                            rect {
+                                background: "rgb(200, 200, 200)",
+                                height: "100%",
+                                width: "100%",
+                                display: "center",
+                                direction: "horizontal",
+                                padding: "10",
+                                rect {
+                                    background: "red",
+                                    height: "100%",
+                                    width: "35%",
+                                }
+                                rect {
+                                    height: "100%",
+                                    width: "18",
+                                    display: "center",
+                                    direction: "vertical",
+                                    label {
+                                        color: "black",
+                                        "HI",
+                                    }
+                                }
+                                rect {
+                                    background: "black",
+                                    height: "100%",
+                                    width: "35%",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    )
+}

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -287,6 +287,7 @@ pub fn calculate_node<T>(
         font_collection,
     );
 
+    // Re calculate the children layouts after the parent has properly adjusted it's size and axis according to it's children
     if DisplayMode::Center == node_data.node.state.style.display {
         let space_left_vertically = (inner_area.height - inner_height) / 2.0;
         let space_left_horizontally = (inner_area.width - inner_width) / 2.0;
@@ -309,7 +310,6 @@ pub fn calculate_node<T>(
             }
         }
 
-        // Re calculate the children layouts after the centered has properly adjusted it's size and axis according to the children itself
         process_node_layout(
             node_data,
             &mut node_area,

--- a/state/src/node.rs
+++ b/state/src/node.rs
@@ -342,6 +342,13 @@ pub struct ShadowSettings {
     pub color: Color,
 }
 
+#[derive(Default, Clone, Debug, PartialEq)]
+pub enum DisplayMode {
+    #[default]
+    Normal,
+    Center,
+}
+
 #[derive(Default, Clone, Debug)]
 pub struct Style {
     pub background: Color,
@@ -350,6 +357,7 @@ pub struct Style {
     pub radius: f32,
     pub image_data: Option<Vec<u8>>,
     pub svg_data: Option<Vec<u8>>,
+    pub display: DisplayMode,
 }
 
 impl NodeDepState<()> for Style {
@@ -363,7 +371,8 @@ impl NodeDepState<()> for Style {
             "radius",
             "image_data",
             "svg_data",
-            "svg_content"
+            "svg_content",
+            "display"
         ])));
 
     fn reduce<'a>(&mut self, node: NodeView, _sibling: (), _ctx: &Self::Ctx) -> bool {
@@ -373,9 +382,11 @@ impl NodeDepState<()> for Style {
         let mut radius = 0.0;
         let mut image_data = None;
         let mut svg_data = None;
+        let mut display = DisplayMode::Normal;
 
         for attr in node.attributes() {
             match attr.name {
+                "display" => display = parse_display(&attr.value.to_string()),
                 "background" => {
                     let new_back = parse_color(&attr.value.to_string());
                     if let Some(new_back) = new_back {
@@ -433,8 +444,16 @@ impl NodeDepState<()> for Style {
             radius,
             image_data,
             svg_data,
+            display,
         };
         changed
+    }
+}
+
+fn parse_display(value: &str) -> DisplayMode {
+    match value {
+        "center" => DisplayMode::Center,
+        _ => DisplayMode::Normal,
     }
 }
 


### PR DESCRIPTION
This adds a new `display` attribute, with two modes `normal` and `center`.

The center mode will first calculate it's inner children layout as usually, then with this information, it will calculate the according centered position and size, and finally recalculate it's inner children layout with the new position and size.

I added an example `center.rs` to showcase this:

![image](https://user-images.githubusercontent.com/38158676/194937892-1aa325f0-b8a2-4395-89a7-e5a1abd2ba1a.png)
