### PR TITLE
fix: Update tween

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,9 +2755,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tween"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e9aab86b1958c0ff7f3d18d04abd6d8e583d237f92e88191ce5c7bf481c5ec"
+checksum = "f114398da254e78168e12edec0ece6b4ca15a97262ecd8e5efd5025e3fc30204"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,8 @@ name = "freya-hooks"
 version = "0.1.0"
 dependencies = [
  "dioxus",
+ "dioxus-core",
+ "dioxus-hooks",
  "freya-common",
  "freya-elements",
  "freya-node-state",

--- a/hooks/Cargo.toml
+++ b/hooks/Cargo.toml
@@ -12,6 +12,8 @@ keywords = ["gui", "ui", "cross-platform", "dioxus", "skia", "graphics"]
 categories = ["GUI"]
 
 [dependencies]
+dioxus-hooks = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove-node-listeners"}
+dioxus-core = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove-node-listeners"}
 dioxus = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove-node-listeners", features = ["macro", "hooks"]}
 tween = "2.0.0"
 tokio = { version = "1.17.0" }

--- a/hooks/Cargo.toml
+++ b/hooks/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["GUI"]
 
 [dependencies]
 dioxus = { git = "https://github.com/marc2332/dioxus", branch = "fix/remove-node-listeners", features = ["macro", "hooks"]}
-tween = "1.0.1"
+tween = "2.0.0"
 tokio = { version = "1.17.0" }
 freya-elements = { path = "../elements", version = "0.1.0" }
 uuid = { version =  "1.2.1", features = ["v4"]}

--- a/hooks/src/use_animation.rs
+++ b/hooks/src/use_animation.rs
@@ -1,34 +1,35 @@
-use dioxus::prelude::{use_effect, use_state, ScopeState};
+use dioxus_core::ScopeState;
+use dioxus_hooks::{use_effect, use_state};
 use std::{cell::RefCell, ops::RangeInclusive, time::Duration};
 use tokio::time::interval;
-use tween::{BounceIn, SineIn, SineInOut, Tween};
+use tween::{BounceIn, SineIn, SineInOut, Tweener};
 
 /// Type of animation to use.
 #[derive(Clone)]
 pub enum AnimationMode {
-    BounceIn(RefCell<BounceIn<f64, i32>>),
-    SineIn(RefCell<SineIn<f64, i32>>),
-    SineInOut(RefCell<SineInOut<f64, i32>>),
+    BounceIn(RefCell<Tweener<f64, i32, BounceIn>>),
+    SineIn(RefCell<Tweener<f64, i32, SineIn>>),
+    SineInOut(RefCell<Tweener<f64, i32, SineInOut>>),
 }
 
 impl AnimationMode {
     pub fn new_bounce_in(range: RangeInclusive<f64>, time: i32) -> Self {
-        Self::BounceIn(RefCell::new(BounceIn::new(range, time)))
+        Self::BounceIn(RefCell::new(Tweener::bounce_in(*range.start(), *range.end(), time)))
     }
     pub fn new_sine_in(range: RangeInclusive<f64>, time: i32) -> Self {
-        Self::SineIn(RefCell::new(SineIn::new(range, time)))
+        Self::SineIn(RefCell::new(Tweener::sine_in(*range.start(), *range.end(), time)))
     }
     pub fn new_sine_in_out(range: RangeInclusive<f64>, time: i32) -> Self {
-        Self::SineInOut(RefCell::new(SineInOut::new(range, time)))
+        Self::SineInOut(RefCell::new(Tweener::sine_in_out(*range.start(), *range.end(), time)))
     }
 }
 
 impl AnimationMode {
     fn duration(&self) -> i32 {
         match self {
-            AnimationMode::BounceIn(tween) => tween.borrow().duration(),
-            AnimationMode::SineIn(tween) => tween.borrow().duration(),
-            AnimationMode::SineInOut(tween) => tween.borrow().duration(),
+            AnimationMode::BounceIn(tween) => tween.borrow().duration,
+            AnimationMode::SineIn(tween) => tween.borrow().duration,
+            AnimationMode::SineInOut(tween) => tween.borrow().duration,
         }
     }
 }
@@ -57,17 +58,17 @@ pub fn use_animation(
             let mut run_with = move |index: i32| match tween {
                 AnimationMode::BounceIn(ref mut tween) => {
                     let tween = tween.get_mut();
-                    let v = tween.run(index);
+                    let v = tween.move_to(index);
                     value_setter(v);
                 }
                 AnimationMode::SineIn(ref mut tween) => {
                     let tween = tween.get_mut();
-                    let v = tween.run(index);
+                    let v = tween.move_to(index);
                     value_setter(v);
                 }
                 AnimationMode::SineInOut(ref mut tween) => {
                     let tween = tween.get_mut();
-                    let v = tween.run(index);
+                    let v = tween.move_to(index);
                     value_setter(v);
                 }
             };


### PR DESCRIPTION
[Tween](https://crates.io/crates/tween/versions) v1.0.0 has been magically removed from crates.io, this PR updates Tween to v2
