### PR TITLE
feat: Update Skia to 0.58.0 and remove "x11" feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         export RUSTFLAGS="-Cinstrument-coverage"
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
-        cargo test --workspace --features x11
+        cargo test --workspace --features linux
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
       run: cargo test --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         export RUSTFLAGS="-Cinstrument-coverage"
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
-        cargo test --workspace --features linux
+        cargo test --workspace 
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
       run: cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.61.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a022e58a142a46fea340d68012b9201c094e93ec3d033a944a24f8fd4a4f09a"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -3003,9 +3003,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "skia-bindings"
-version = "0.56.1"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942439446d2468deca69a86eef5274141a51a285ac2c0307bca3ea9345331abd"
+checksum = "06eade095c427b059cebaf220a2bd78d8136129183e6ca92603ed2d689300709"
 dependencies = [
  "bindgen",
  "cc",
@@ -3021,9 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.56.1"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214e59000fac981279e3c4157f8b6c385160f26ae234491c36f5e79701ff0eff"
+checksum = "aa22a9ab62ccffa803562426cc41574a95ffb3652a37c095d64fa9033fde6234"
 dependencies = [
  "base64",
  "bitflags",
@@ -3412,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tween"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
 name = "base64-simd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.61.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
 dependencies = [
@@ -3031,7 +3037,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3356,11 +3362,11 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "skia-bindings"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06eade095c427b059cebaf220a2bd78d8136129183e6ca92603ed2d689300709"
+checksum = "404d98ffda633acd7a3ea68e0e5f160814ee7ae8942c89d60c53f7e0fae99373"
 dependencies = [
- "bindgen 0.61.0",
+ "bindgen 0.63.0",
  "cc",
  "flate2",
  "heck",
@@ -3374,11 +3380,11 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa22a9ab62ccffa803562426cc41574a95ffb3652a37c095d64fa9033fde6234"
+checksum = "53fb6ba679574182f565bd7b38e40d1ba658d33d8287d28905af5fb3e9b98b49"
 dependencies = [
- "base64",
+ "base64 0.20.0",
  "bitflags",
  "lazy_static",
  "skia-bindings",
@@ -3850,7 +3856,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733b5ad78377302af52c0dbcb2623d78fe50e4b3bf215948ff29e9ee031d8566"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "flate2",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["layers", "layout", "renderer", "state", "freya", "elements", "compon
 
 [features]
 devtools = ["freya/devtools"]
-x11 = ["freya/x11"]
+linux = ["freya/linux"]
 wireframe = ["freya/wireframe"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ members = ["layers", "layout", "renderer", "state", "freya", "elements", "compon
 
 [features]
 devtools = ["freya/devtools"]
-linux = ["freya/linux"]
 wireframe = ["freya/wireframe"]
 
 [dev-dependencies]

--- a/examples.sh
+++ b/examples.sh
@@ -1,4 +1,4 @@
 for example in examples/*.rs
 do
-    cargo run --example "$(basename "${example%.rs}")" --features "linux" &
+    cargo run --example "$(basename "${example%.rs}")" &
 done

--- a/examples.sh
+++ b/examples.sh
@@ -1,4 +1,4 @@
 for example in examples/*.rs
 do
-    cargo run --example "$(basename "${example%.rs}")" --features "x11" &
+    cargo run --example "$(basename "${example%.rs}")" --features "linux" &
 done

--- a/freya/Cargo.toml
+++ b/freya/Cargo.toml
@@ -35,6 +35,6 @@ dioxus-router = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1
 tokio = { version = "1.23.0", features = ["sync", "rt-multi-thread", "time", "macros"] }
 anymap = "0.12.1"
 fxhash = "0.2.1"
-skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.58.0", features = ["gl", "textlayout", "svg"] }
 tracing = "0.1"
 futures = "0.3.25"

--- a/freya/Cargo.toml
+++ b/freya/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["GUI"]
 
 [features]
 devtools = []
-x11 = ["freya-renderer/x11"]
+linux = ["freya-renderer/linux"]
 wireframe = ["freya-renderer/wireframe"]
 
 [dependencies]
@@ -35,6 +35,6 @@ dioxus-router = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5
 tokio = { version = "1.23.0", features = ["sync", "rt-multi-thread", "time", "macros"] }
 anymap = "0.12.1"
 fxhash = "0.2.1"
-skia-safe = { version = "0.56.1" }
+skia-safe = { version = "0.57.0" }
 tracing = "0.1"
 futures = "0.3.25"

--- a/freya/Cargo.toml
+++ b/freya/Cargo.toml
@@ -13,8 +13,11 @@ categories = ["GUI"]
 
 [features]
 devtools = []
-linux = ["freya-renderer/linux"]
 wireframe = ["freya-renderer/wireframe"]
+
+[target."cfg(target_os = \"linux\")".dependencies.skia-safe]
+version = "0.58.0"
+features = ["gl", "textlayout", "svg", "x11", "wayland"]
 
 [dependencies]
 freya-node-state = { path = "../state", version = "0.1.0" }

--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -19,7 +19,7 @@ freya-node-state = { path = "../state", version = "0.1.0" }
 freya-layers = { path = "../layers", version = "0.1.0" }
 tokio = { version = "1.23.0", features = ["sync", "rt-multi-thread", "time"] }
 freya-elements = { path = "../elements", version = "0.1.0"}
-skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.58.0", features = ["gl", "textlayout", "svg"] }
 
 [dev-dependencies]
 dioxus-native-core-macro = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51"}

--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -19,7 +19,7 @@ freya-node-state = { path = "../state", version = "0.1.0" }
 freya-layers = { path = "../layers", version = "0.1.0" }
 tokio = { version = "1.23.0", features = ["sync", "rt-multi-thread", "time"] }
 freya-elements = { path = "../elements", version = "0.1.0"}
-skia-safe = { version = "0.56.1", features = ["textlayout"] }
+skia-safe = { version = "0.57.0", features = ["textlayout"] }
 
 [dev-dependencies]
 dioxus-native-core-macro = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a253e1b4bfef24abd46a623fa"}

--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/marc2332/freya"
 keywords = ["gui", "ui", "cross-platform", "dioxus", "skia", "graphics"]
 categories = ["GUI"]
 
+[target."cfg(target_os = \"linux\")".dependencies.skia-safe]
+version = "0.58.0"
+features = ["gl", "textlayout", "svg", "x11", "wayland"]
+
 [dependencies]
 dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51"}
 dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51", features = ["macro", "hooks"]}

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -16,7 +16,7 @@ linux = ["skia-safe/x11", "skia-safe/wayland"]
 
 [dependencies]
 glutin_tao = { version = "0.30.1", features = ["serde"]}
-skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.58.0", features = ["gl", "textlayout", "svg"] }
 dioxus-rsx = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51"}
 dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51"}
 dioxus-core-macro = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51"}

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -11,8 +11,9 @@ repository = "https://github.com/marc2332/freya"
 keywords = ["gui", "ui", "cross-platform", "dioxus", "skia", "graphics"]
 categories = ["GUI"]
 
-[features]
-linux = ["skia-safe/x11", "skia-safe/wayland"]
+[target."cfg(target_os = \"linux\")".dependencies.skia-safe]
+version = "0.58.0"
+features = ["gl", "textlayout", "svg", "x11", "wayland"]
 
 [dependencies]
 glutin_tao = { version = "0.30.1", features = ["serde"]}

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["gui", "ui", "cross-platform", "dioxus", "skia", "graphics"]
 categories = ["GUI"]
 
 [features]
-x11 = ["skia-safe/x11"]
+linux = ["skia-safe/x11", "skia-safe/wayland"]
 
 [dependencies]
 glutin_tao = { version = "0.30.1", features = ["serde"]}
-skia-safe = { version = "0.56.1", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
 dioxus-rsx = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a253e1b4bfef24abd46a623fa"}
 dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a253e1b4bfef24abd46a623fa"}
 dioxus-core-macro = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a253e1b4bfef24abd46a623fa"}

--- a/readme.md
+++ b/readme.md
@@ -57,16 +57,10 @@ fn app(cx: Scope) -> Element {
 
 **⚠️ Note for Windows**: You need the **latest** (this is very important) Visual Studio 2022.
 
-Windows & MacOS:
+Run:
 
 ```shell
 cargo run --example counter
-```
-
-Linux:
-
-```shell
-cargo run --example counter --features linux
 ```
 
 ### Usage 📜
@@ -82,7 +76,7 @@ dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a25
 - Containers
 - Scroll views (nested too)
 - Events: click, wheel, mouse /down/leave/over for now
-- Support for Windows, Linux (needs `linux` feature) and MacOS support
+- Support for Windows, Linux and MacOS
 - Optional Components library (buttons, switch, etc)
 - Animation hook utility
 - SVG Support

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ fn app(cx: Scope) -> Element {
 
 ### Want to try it? 🤔
 
-**Note for Windows**: You need Visual Studio 2022.
+**⚠️ Note for Windows**: You need the **latest** (this is very important) Visual Studio 2022.
 
 Windows & MacOS:
 
@@ -69,6 +69,7 @@ Add Freya as a dependency in your `Cargo.toml`:
 
 ```toml
 freya = { git = "https://github.com/marc2332/freya" }
+dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a253e1b4bfef24abd46a623fa"}
 ```
 
 ### Features ✨

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ cargo run --example counter
 Linux:
 
 ```shell
-cargo run --example counter --features x11
+cargo run --example counter --features linux
 ```
 
 ### Usage 📜
@@ -76,7 +76,7 @@ freya = { git = "https://github.com/marc2332/freya" }
 - Containers
 - Scroll views (nested too)
 - Events: click, wheel, mouse /down/leave/over for now
-- Support for Windows, Linux (needs `x11` feature) and MacOS support
+- Support for Windows, Linux (needs `linux` feature) and MacOS support
 - Optional Components library (buttons, switch, etc)
 - Animation hook utility
 - SVG Support

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -12,8 +12,15 @@ keywords = ["gui", "ui", "cross-platform", "dioxus", "skia", "graphics"]
 categories = ["GUI"]
 
 [features]
-linux = ["skia-safe/x11", "skia-safe/wayland"]
 wireframe = []
+
+[target."cfg(target_os = \"linux\")".dependencies.skia-safe]
+version = "0.58.0"
+features = ["gl", "textlayout", "svg", "x11", "wayland"]
+
+[target."cfg(target_os = \"linux\")".dependencies.glutin_tao]
+version = "0.30.1"
+features = ["serde", "x11"]
 
 [dependencies]
 gl = "*"

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -10,14 +10,15 @@ homepage = "https://github.com/marc2332/freya"
 repository = "https://github.com/marc2332/freya"
 keywords = ["gui", "ui", "cross-platform", "dioxus", "skia", "graphics"]
 categories = ["GUI"]
+
 [features]
-x11 = ["skia-safe/x11"]
+linux = ["skia-safe/x11", "skia-safe/wayland"]
 wireframe = []
 
 [dependencies]
 gl = "*"
 glutin_tao = { version = "0.30.1", features = ["serde"]}
-skia-safe = { version = "0.56.1", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
 dioxus-rsx = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a253e1b4bfef24abd46a623fa"}
 dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a253e1b4bfef24abd46a623fa"}
 dioxus-core-macro = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a253e1b4bfef24abd46a623fa"}

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -18,7 +18,7 @@ wireframe = []
 [dependencies]
 gl = "*"
 glutin_tao = { version = "0.30.1", features = ["serde"]}
-skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.58.0", features = ["gl", "textlayout", "svg"] }
 dioxus-rsx = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51"}
 dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51"}
 dioxus-core-macro = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51"}

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -20,7 +20,7 @@ dioxus-hooks = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5f
 dioxus-core = { git = "https://github.com/DioxusLabs/dioxus", rev="a616a8fa9d5fe46a253e1b4bfef24abd46a623fa"}
 anymap = "0.12.1"
 fxhash = "0.2.1"
-skia-safe = { version = "0.56.1", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
 freya-elements = { path = "../elements", version = "0.1.0"}
 freya-common = { path = "../common", version = "0.1.0" }
 tokio = { version = "1.23.0" }

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -20,7 +20,7 @@ dioxus-hooks = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1c
 dioxus-core = { git = "https://github.com/DioxusLabs/dioxus", rev="fdf72b709a1ccc3924f67bbd7ae236d3fffacc51"}
 anymap = "0.12.1"
 fxhash = "0.2.1"
-skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.58.0", features = ["gl", "textlayout", "svg"] }
 freya-elements = { path = "../elements", version = "0.1.0"}
 freya-common = { path = "../common", version = "0.1.0" }
 tokio = { version = "1.23.0" }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -27,7 +27,7 @@ freya-processor = { path = "../processor", version = "0.1.0" }
 tokio = { version = "1.23.0", features = ["macros", "sync", "rt", "time"]}
 futures = "0.3.25"
 anymap = "0.12.1"
-skia-safe = { version = "0.56.1", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
 
 [dev-dependencies]
 freya-components ={ path = "../components"}

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -27,7 +27,7 @@ freya-processor = { path = "../processor", version = "0.1.0" }
 tokio = { version = "1.23.0", features = ["macros", "sync", "rt", "time"]}
 futures = "0.3.25"
 anymap = "0.12.1"
-skia-safe = { version = "0.57.0", features = ["gl", "textlayout", "svg"] }
+skia-safe = { version = "0.58.0", features = ["gl", "textlayout", "svg"] }
 
 [dev-dependencies]
 freya-components ={ path = "../components"}


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/65

## Changes
- Remove the `x11` feature
- Enable x11 support in `skia-safe` by default