### PR TITLE
feat: Move text editing into a separate trait

### DIFF
--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -146,7 +146,7 @@ fn app(cx: Scope) -> Element {
 
 #[allow(non_snake_case)]
 fn Editor(cx: Scope) -> Element {
-    let (content, cursor, process_keyevent, process_clickevent, cursor_ref) = use_editable(
+    let (text_editor, process_keyevent, process_clickevent, cursor_ref) = use_editable(
         &cx,
         || {
             "Lorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet"
@@ -294,14 +294,14 @@ fn Editor(cx: Scope) -> Element {
                         width: "100%",
                         height: "100%",
                         show_scrollbar: true,
-                        content.lines().map(move |l| {
+                        text_editor.lines().map(move |l| {
                             let process_clickevent = process_clickevent.clone();
 
-                            let is_line_selected = cursor.1 == line_index;
+                            let is_line_selected = text_editor.cursor_row() == line_index;
 
                             // Only show the cursor in the active line
                             let character_index = if is_line_selected {
-                                cursor.0.to_string()
+                                text_editor.cursor_col().to_string()
                             } else {
                                 "none".to_string()
                             };

--- a/examples/editor.rs
+++ b/examples/editor.rs
@@ -23,7 +23,7 @@ fn app(cx: Scope) -> Element {
 fn Body(cx: Scope) -> Element {
     let theme = use_theme(&cx);
     let theme = theme.read();
-    let (content, cursor, process_keyevent, process_clickevent, cursor_ref) = use_editable(
+    let (text_editor, process_keyevent, process_clickevent, cursor_ref) = use_editable(
         &cx,
         || {
             "Lorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet"
@@ -40,7 +40,7 @@ fn Body(cx: Scope) -> Element {
     let line_height = (line_height_percentage / 25.0) + 1.2;
     let mut line_index = 0;
 
-    let cursor_char = content.line_to_char(cursor.1) + cursor.0;
+    let cursor_char = text_editor.cursor_pos();
 
     let font_style = {
         if *is_bold.get() && *is_italic.get() {
@@ -183,14 +183,14 @@ fn Body(cx: Scope) -> Element {
                         width: "100%",
                         height: "100%",
                         show_scrollbar: true,
-                        content.lines().map(move |l| {
+                        text_editor.lines().map(move |l| {
                             let process_clickevent = process_clickevent.clone();
 
-                            let is_line_selected = cursor.1 == line_index;
+                            let is_line_selected = text_editor.cursor_row() == line_index;
 
                             // Only show the cursor in the active line
                             let character_index = if is_line_selected {
-                                cursor.0.to_string()
+                                text_editor.cursor_col().to_string()
                             } else {
                                 "none".to_string()
                             };
@@ -269,7 +269,7 @@ fn Body(cx: Scope) -> Element {
                             text {
                                 color: "white",
                                 font_size: "{font_size}",
-                                "{content}"
+                                "{text_editor}"
                             }
                         }
                     }
@@ -283,7 +283,7 @@ fn Body(cx: Scope) -> Element {
                 padding: "10",
                 label {
                     color: "rgb(200, 200, 200)",
-                    "Ln {cursor.1 + 1}, Col {cursor.0 + 1}"
+                    "Ln {text_editor.cursor_row() + 1}, Col {text_editor.cursor_col() + 1}"
                 }
             }
         }

--- a/examples/virtual_scroll_view.rs
+++ b/examples/virtual_scroll_view.rs
@@ -10,7 +10,7 @@ fn main() {
 }
 
 fn app(cx: Scope) -> Element {
-    let (content, cursor, process_keyevent, process_clickevent, cursor_ref) = use_editable(
+    let (text_editor, process_keyevent, process_clickevent, cursor_ref) = use_editable(
         &cx,
         || {
             "Lorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet\nLorem ipsum dolor sit amet"
@@ -38,18 +38,18 @@ fn app(cx: Scope) -> Element {
                 width: "100%",
                 height: "100%",
                 show_scrollbar: true,
-                length: content.len_lines() as i32,
+                length: text_editor.len_lines() as i32,
                 item_size: real_line_height,
-                builder_values: (cursor, process_clickevent, content),
+                builder_values: (process_clickevent, text_editor),
                 builder: Box::new(move |(k, line_index, vals)| {
-                    let (cursor, process_clickevent, content) = vals.as_ref().unwrap();
-                    let line_content = content.lines().nth(line_index  as usize).unwrap();
+                    let (process_clickevent, text_editor) = vals.as_ref().unwrap();
+                    let line_content = text_editor.line(line_index as usize).unwrap();
 
-                    let is_line_selected = cursor.1 == line_index as usize;
+                    let is_line_selected = text_editor.cursor_row() == line_index as usize;
 
                     // Only show the cursor in the active line
                     let character_index = if is_line_selected {
-                        cursor.0.to_string()
+                        text_editor.cursor_col().to_string()
                     } else {
                         "none".to_string()
                     };

--- a/hooks/src/lib.rs
+++ b/hooks/src/lib.rs
@@ -1,6 +1,7 @@
 //! # Freya Hooks
 //! A collection of hooks to be used in Freya.
 
+mod text_editor;
 mod use_animation;
 mod use_camera;
 mod use_editable;
@@ -8,6 +9,7 @@ mod use_focus;
 mod use_node;
 mod use_theme;
 
+pub use text_editor::*;
 pub use use_animation::*;
 pub use use_camera::*;
 pub use use_editable::*;

--- a/hooks/src/text_editor.rs
+++ b/hooks/src/text_editor.rs
@@ -71,9 +71,13 @@ impl Display for Line<'_> {
     }
 }
 
+/// Events for [TextEditor]
 pub enum TextEvent {
+    /// Cursor position has been moved
     CursorChanged,
+    /// Text has changed
     TextChanged,
+    /// Nothing happened
     None,
 }
 
@@ -152,7 +156,7 @@ pub trait TextEditor: Sized + Clone + Display {
         self.cursor_col() + self.cursor_row()
     }
 
-    // Process a Key press
+    // Process a Key event
     fn process_key(&mut self, key: &Key, code: &Code, _modifers: &Modifiers) -> TextEvent {
         let mut event = TextEvent::None;
         match key {

--- a/hooks/src/text_editor.rs
+++ b/hooks/src/text_editor.rs
@@ -1,7 +1,6 @@
 use std::{fmt::Display, ops::Range};
 
 use freya_elements::{Code, Key, Modifiers};
-use ropey::iter::Lines;
 pub use ropey::Rope;
 
 /// Holds the position of a cursor in a text
@@ -47,7 +46,7 @@ impl TextCursor {
 /// A text line from a [TextEditor]
 #[derive(Clone)]
 pub struct Line<'a> {
-    text: &'a str,
+    pub text: &'a str,
 }
 
 impl Line<'_> {
@@ -298,92 +297,5 @@ pub trait TextEditor: Sized + Clone + Display {
         }
 
         event
-    }
-}
-
-#[derive(Clone)]
-pub struct UseEditableText {
-    rope: Rope,
-    cursor: TextCursor,
-}
-
-impl Display for UseEditableText {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.rope.to_string())
-    }
-}
-
-impl TextEditor for UseEditableText {
-    type LinesIterator<'a> = LinesIterator<'a>;
-
-    fn lines(&self) -> Self::LinesIterator<'_> {
-        let lines = self.rope.lines();
-        LinesIterator { lines }
-    }
-
-    fn insert_char(&mut self, char: char, char_idx: usize) {
-        self.rope.insert_char(char_idx, char);
-    }
-
-    fn insert(&mut self, text: &str, char_idx: usize) {
-        self.rope.insert(char_idx, text);
-    }
-
-    fn remove(&mut self, range: Range<usize>) {
-        self.rope.remove(range)
-    }
-
-    fn char_to_line(&self, char_idx: usize) -> usize {
-        self.rope.char_to_line(char_idx)
-    }
-
-    fn line_to_char(&self, line_idx: usize) -> usize {
-        self.rope.line_to_char(line_idx)
-    }
-
-    fn line(&self, line_idx: usize) -> Option<Line<'_>> {
-        let line = self.rope.get_line(line_idx);
-
-        line.map(|line| Line {
-            text: line.as_str().unwrap_or(""),
-        })
-    }
-
-    fn len_lines<'a>(&self) -> usize {
-        self.rope.len_lines()
-    }
-
-    fn cursor(&self) -> &TextCursor {
-        &self.cursor
-    }
-
-    fn cursor_mut(&mut self) -> &mut TextCursor {
-        &mut self.cursor
-    }
-}
-
-/// Iterator over text lines.
-pub struct LinesIterator<'a> {
-    lines: Lines<'a>,
-}
-
-impl<'a> Iterator for LinesIterator<'a> {
-    type Item = Line<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let line = self.lines.next();
-
-        line.map(|line| Line {
-            text: line.as_str().unwrap_or(""),
-        })
-    }
-}
-
-impl From<&str> for UseEditableText {
-    fn from(value: &str) -> Self {
-        Self {
-            rope: Rope::from_str(value),
-            cursor: TextCursor::new(0, 0),
-        }
     }
 }

--- a/hooks/src/text_editor.rs
+++ b/hooks/src/text_editor.rs
@@ -153,7 +153,8 @@ pub trait TextEditor: Sized + Clone + Display {
 
     /// Get the cursor position
     fn cursor_pos(&self) -> usize {
-        self.cursor_col() + self.cursor_row()
+        let line_begining = self.line_to_char(self.cursor_row());
+        line_begining + self.cursor_col()
     }
 
     // Process a Key event

--- a/hooks/src/text_editor.rs
+++ b/hooks/src/text_editor.rs
@@ -1,0 +1,389 @@
+use std::{fmt::Display, ops::Range};
+
+use freya_elements::{Code, Key, Modifiers};
+use ropey::iter::Lines;
+pub use ropey::Rope;
+
+/// Holds the position of a cursor in a text
+#[derive(Clone)]
+pub struct TextCursor {
+    col: usize,
+    row: usize,
+}
+
+impl TextCursor {
+    /// Construct a new [TextCursor] given a column and a row
+    pub fn new(col: usize, row: usize) -> Self {
+        Self { col, row }
+    }
+
+    /// Move the cursor to a new column and row
+    pub fn move_to(&mut self, col: usize, row: usize) {
+        self.col = col;
+        self.row = row;
+    }
+
+    /// Get the current column
+    pub fn col(&self) -> usize {
+        self.col
+    }
+
+    /// Get the current row
+    pub fn row(&self) -> usize {
+        self.row
+    }
+
+    /// Set a new column
+    pub fn set_col(&mut self, col: usize) {
+        self.col = col;
+    }
+
+    /// Set a new row
+    pub fn set_row(&mut self, row: usize) {
+        self.row = row;
+    }
+}
+
+/// A text line from a [TextEditor]
+#[derive(Clone)]
+pub struct Line<'a> {
+    text: &'a str,
+}
+
+impl Line<'_> {
+    /// Get the length of the line
+    pub fn len_chars(&self) -> usize {
+        self.text.len()
+    }
+
+    /// Get the text of the line
+    fn as_str(&self) -> &str {
+        self.text
+    }
+}
+
+impl Display for Line<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.text)
+    }
+}
+
+pub enum TextEvent {
+    CursorChanged,
+    TextChanged,
+    None,
+}
+
+/// Editable text manager
+pub trait TextEditor: Sized + Clone + Display {
+    type LinesIterator<'a>: Iterator<Item = Line<'a>>
+    where
+        Self: 'a;
+
+    /// Iterator over all the lines in the text.
+    fn lines(&self) -> Self::LinesIterator<'_>;
+
+    /// Insert a character in the text in the given position.
+    fn insert_char(&mut self, char: char, char_idx: usize);
+
+    /// Insert a string in the text in the given position.
+    fn insert(&mut self, text: &str, char_idx: usize);
+
+    /// Remove a part of the text.
+    fn remove(&mut self, range: Range<usize>);
+
+    /// Get line from the given char
+    fn char_to_line(&self, char_idx: usize) -> usize;
+
+    /// Get the first char from the given line
+    fn line_to_char(&self, line_idx: usize) -> usize;
+
+    /// Get a line from the text
+    fn line(&self, line_idx: usize) -> Option<Line<'_>>;
+
+    /// Total of lines
+    fn len_lines(&self) -> usize;
+
+    /// Get a readable cursor
+    fn cursor(&self) -> &TextCursor;
+
+    /// Get a mutable cursor
+    fn cursor_mut(&mut self) -> &mut TextCursor;
+
+    /// Get the cursor row
+    fn cursor_row(&self) -> usize {
+        self.cursor().row()
+    }
+
+    /// Get the cursor column
+    fn cursor_col(&self) -> usize {
+        self.cursor().col()
+    }
+
+    /// Move the cursor 1 line down
+    fn cursor_down(&mut self) {
+        let new_row = self.cursor_row() + 1;
+        self.cursor_mut().set_row(new_row);
+    }
+
+    /// Move the cursor 1 line up
+    fn cursor_up(&mut self) {
+        let new_row = self.cursor_row() - 1;
+        self.cursor_mut().set_row(new_row);
+    }
+
+    /// Move the cursor 1 char to the right
+    fn cursor_right(&mut self) {
+        let new_col = self.cursor_col() + 1;
+        self.cursor_mut().set_col(new_col);
+    }
+
+    /// Move the cursor 1 char to the left
+    fn cursor_left(&mut self) {
+        let new_col = self.cursor_col() - 1;
+        self.cursor_mut().set_col(new_col);
+    }
+
+    /// Get the cursor position
+    fn cursor_pos(&self) -> usize {
+        self.cursor_col() + self.cursor_row()
+    }
+
+    // Process a Key press
+    fn process_key(&mut self, key: &Key, code: &Code, _modifers: &Modifiers) -> TextEvent {
+        let mut event = TextEvent::None;
+        match key {
+            Key::ArrowDown => {
+                let total_lines = self.len_lines() - 1;
+                // Go one line down
+                if self.cursor_row() < total_lines {
+                    let next_line = self.line(self.cursor_row() + 1).unwrap();
+
+                    // Try to use the current cursor column, otherwise use the new line length
+                    let cursor_index = if self.cursor_col() <= next_line.len_chars() {
+                        self.cursor_col()
+                    } else {
+                        next_line.len_chars()
+                    };
+
+                    self.cursor_mut().set_col(cursor_index);
+                    self.cursor_down();
+
+                    event = TextEvent::CursorChanged
+                }
+            }
+            Key::ArrowLeft => {
+                // Go one character to the left
+                if self.cursor_col() > 0 {
+                    self.cursor_left();
+
+                    event = TextEvent::CursorChanged
+                } else if self.cursor_row() > 0 {
+                    // Go one line up if there is no more characters on the left
+                    let prev_line = self.line(self.cursor_row() - 1);
+                    if let Some(prev_line) = prev_line {
+                        // Use the new line length as new cursor column, otherwise just set it to 0
+                        let len = if prev_line.len_chars() > 0 {
+                            prev_line.len_chars()
+                        } else {
+                            0
+                        };
+
+                        self.cursor_up();
+                        self.cursor_mut().set_col(len - 1);
+
+                        event = TextEvent::CursorChanged
+                    }
+                }
+            }
+            Key::ArrowRight => {
+                let total_lines = self.len_lines() - 1;
+                let current_line = self.line(self.cursor_row()).unwrap();
+
+                // Go one line down if there isn't more characters on the right
+                if self.cursor_row() < total_lines
+                    && self.cursor_col() == current_line.len_chars() - 1
+                {
+                    self.cursor_down();
+                    self.cursor_mut().set_col(0);
+
+                    event = TextEvent::CursorChanged
+                } else if self.cursor_col() < current_line.len_chars() {
+                    // Go one character to the right if possible
+                    self.cursor_right();
+
+                    event = TextEvent::CursorChanged
+                }
+            }
+            Key::ArrowUp => {
+                // Go one line up if there is any
+                if self.cursor_row() > 0 {
+                    let prev_line = self.line(self.cursor_row() - 1).unwrap();
+
+                    // Try to use the current cursor column, otherwise use the new line length
+                    let cursor_column = if self.cursor_col() <= prev_line.len_chars() {
+                        self.cursor_col()
+                    } else {
+                        prev_line.len_chars()
+                    };
+
+                    self.cursor_up();
+                    self.cursor_mut().set_col(cursor_column);
+
+                    event = TextEvent::CursorChanged
+                }
+            }
+            Key::Backspace => {
+                if self.cursor_col() > 0 {
+                    // Remove the character to the left if there is any
+                    let char_idx = self.line_to_char(self.cursor_row()) + self.cursor_col();
+                    self.remove(char_idx - 1..char_idx);
+
+                    self.cursor_left();
+
+                    event = TextEvent::TextChanged
+                } else if self.cursor_row() > 0 {
+                    // Moves the whole current line to the end of the line above.
+                    let prev_line_len = self.line(self.cursor_row() - 1).unwrap().len_chars();
+                    let current_line = self.line(self.cursor_row()).clone();
+
+                    if let Some(current_line) = current_line {
+                        let current_line_len = current_line.len_chars();
+                        let prev_char_idx =
+                            self.line_to_char(self.cursor_row() - 1) + prev_line_len - 1;
+                        let char_idx = self.line_to_char(self.cursor_row()) + current_line_len - 1;
+
+                        let line = current_line.as_str().to_string();
+                        self.insert(&line, prev_char_idx);
+                        self.remove(char_idx..(char_idx + current_line_len) + 1);
+                    }
+
+                    self.cursor_up();
+                    self.cursor_mut().set_col(prev_line_len - 1);
+
+                    event = TextEvent::TextChanged
+                }
+            }
+            Key::Enter => {
+                // Breaks the line
+                let char_idx = self.line_to_char(self.cursor_row()) + self.cursor_col();
+                self.insert_char('\n', char_idx);
+                self.cursor_down();
+                self.cursor_mut().set_col(0);
+
+                event = TextEvent::TextChanged
+            }
+            Key::Character(character) => {
+                match code {
+                    Code::Delete => {}
+                    Code::Space => {
+                        // Simply adds an space
+                        let char_idx = self.line_to_char(self.cursor_row()) + self.cursor_col();
+                        self.insert_char(' ', char_idx);
+                        self.cursor_right();
+
+                        event = TextEvent::TextChanged
+                    }
+                    _ => {
+                        // Adds a new character
+                        let char_idx = self.line_to_char(self.cursor_row()) + self.cursor_col();
+                        self.insert(character, char_idx);
+                        self.cursor_right();
+
+                        event = TextEvent::TextChanged
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        event
+    }
+}
+
+#[derive(Clone)]
+pub struct UseEditableText {
+    rope: Rope,
+    cursor: TextCursor,
+}
+
+impl Display for UseEditableText {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.rope.to_string())
+    }
+}
+
+impl TextEditor for UseEditableText {
+    type LinesIterator<'a> = LinesIterator<'a>;
+
+    fn lines(&self) -> Self::LinesIterator<'_> {
+        let lines = self.rope.lines();
+        LinesIterator { lines }
+    }
+
+    fn insert_char(&mut self, char: char, char_idx: usize) {
+        self.rope.insert_char(char_idx, char);
+    }
+
+    fn insert(&mut self, text: &str, char_idx: usize) {
+        self.rope.insert(char_idx, text);
+    }
+
+    fn remove(&mut self, range: Range<usize>) {
+        self.rope.remove(range)
+    }
+
+    fn char_to_line(&self, char_idx: usize) -> usize {
+        self.rope.char_to_line(char_idx)
+    }
+
+    fn line_to_char(&self, line_idx: usize) -> usize {
+        self.rope.line_to_char(line_idx)
+    }
+
+    fn line(&self, line_idx: usize) -> Option<Line<'_>> {
+        let line = self.rope.get_line(line_idx);
+
+        line.map(|line| Line {
+            text: line.as_str().unwrap_or(""),
+        })
+    }
+
+    fn len_lines<'a>(&self) -> usize {
+        self.rope.len_lines()
+    }
+
+    fn cursor(&self) -> &TextCursor {
+        &self.cursor
+    }
+
+    fn cursor_mut(&mut self) -> &mut TextCursor {
+        &mut self.cursor
+    }
+}
+
+/// Iterator over text lines.
+pub struct LinesIterator<'a> {
+    lines: Lines<'a>,
+}
+
+impl<'a> Iterator for LinesIterator<'a> {
+    type Item = Line<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let line = self.lines.next();
+
+        line.map(|line| Line {
+            text: line.as_str().unwrap_or(""),
+        })
+    }
+}
+
+impl From<&str> for UseEditableText {
+    fn from(value: &str) -> Self {
+        Self {
+            rope: Rope::from_str(value),
+            cursor: TextCursor::new(0, 0),
+        }
+    }
+}

--- a/hooks/src/text_editor.rs
+++ b/hooks/src/text_editor.rs
@@ -41,6 +41,10 @@ impl TextCursor {
     pub fn set_row(&mut self, row: usize) {
         self.row = row;
     }
+
+    pub fn as_tuple(&self) -> (usize, usize) {
+        (self.row, self.col)
+    }
 }
 
 /// A text line from a [TextEditor]

--- a/hooks/src/use_editable.rs
+++ b/hooks/src/use_editable.rs
@@ -5,13 +5,12 @@ use std::{
 
 use dioxus_core::{AttributeValue, Event, ScopeState};
 use dioxus_hooks::{use_effect, use_ref, use_state, UseRef, UseState};
-use freya_elements::{
-    events_data::{KeyboardData, MouseData},
-    Code, Key,
-};
+use freya_elements::events_data::{KeyboardData, MouseData};
 use freya_node_state::{CursorReference, CustomAttributeValues};
 pub use ropey::Rope;
 use tokio::sync::{mpsc::unbounded_channel, mpsc::UnboundedSender};
+
+use crate::text_editor::*;
 
 /// How the editable content must behave.
 pub enum EditableMode {
@@ -27,8 +26,7 @@ pub enum EditableMode {
 
 pub type KeypressNotifier = UnboundedSender<Rc<KeyboardData>>;
 pub type ClickNotifier = UnboundedSender<(Rc<MouseData>, usize)>;
-pub type EditableText = UseState<Rope>;
-pub type CursorPosition = UseState<(usize, usize)>;
+pub type EditableText = UseState<UseEditableText>;
 pub type KeyboardEvent = Event<KeyboardData>;
 pub type CursorRef = UseRef<CursorReference>;
 
@@ -39,16 +37,12 @@ pub fn use_editable<'a>(
     mode: EditableMode,
 ) -> (
     &EditableText,
-    &CursorPosition,
     KeypressNotifier,
     ClickNotifier,
     AttributeValue,
 ) {
     // Hold the actual editable content
-    let content = use_state(cx, || Rope::from(initializer()));
-
-    // Holds the column and line where the cursor is
-    let cursor = use_state(cx, || (0, 0));
+    let content = use_state(cx, || UseEditableText::from(initializer()));
 
     let cursor_channels = cx.use_hook(|| {
         let (tx, rx) = unbounded_channel::<(usize, usize)>();
@@ -110,12 +104,10 @@ pub fn use_editable<'a>(
         let cursor_ref = cursor_ref.clone();
         let cursor_receiver = cursor_channels.1.take();
         let content = content.clone();
-        let cursor_getter = cursor.current();
-        let cursor_setter = cursor.setter();
+        let rope = content.clone();
 
         async move {
             let mut cursor_receiver = cursor_receiver.unwrap();
-            let mut prev_cursor = *cursor_getter;
             let cursor_ref = cursor_ref.clone();
 
             while let Some((new_index, editor_num)) = cursor_receiver.recv().await {
@@ -133,7 +125,7 @@ pub fn use_editable<'a>(
                     EditableMode::SingleLineMultipleEditors => new_index,
                 };
 
-                let new_current_line = content.line(new_cursor_row);
+                let new_current_line = content.line(new_cursor_row).unwrap();
 
                 // Use the line lenght as new column if the clicked column surpases the length
                 let new_cursor = if new_cursor_col >= new_current_line.len_chars() {
@@ -143,9 +135,11 @@ pub fn use_editable<'a>(
                 };
 
                 // Only update if it's actually different
-                if prev_cursor != new_cursor {
-                    cursor_setter(new_cursor);
-                    prev_cursor = new_cursor;
+                if rope.cursor().col() != new_cursor.0 || rope.cursor().row() != new_cursor.1 {
+                    rope.with_mut(|rope| {
+                        rope.cursor_mut().set_col(new_cursor.0);
+                        rope.cursor_mut().set_row(new_cursor.1);
+                    })
                 }
 
                 // Remove the current calcutions so the layout engine doesn't try to calculate again
@@ -156,363 +150,23 @@ pub fn use_editable<'a>(
 
     // Listen for keypresses
     use_effect(cx, (), move |_| {
-        let cursor_getter = cursor.to_owned();
         let rx = keypress_channel.1.take();
-        let content = content.clone();
-        let cursor_setter = cursor.setter();
+        let rope = content.clone();
         async move {
             let mut rx = rx.unwrap();
 
             while let Some(pressed_key) = rx.recv().await {
-                let rope = content.current();
-                let cursor = cursor_getter.current();
-                match &pressed_key.key {
-                    Key::ArrowDown => {
-                        let total_lines = rope.len_lines() - 1;
-                        // Go one line down
-                        if cursor.1 < total_lines {
-                            let next_line = rope.line(cursor.1 + 1);
-
-                            // Try to use the current cursor column, otherwise use the new line length
-                            let cursor_index = if cursor.0 <= next_line.len_chars() {
-                                cursor.0
-                            } else {
-                                next_line.len_chars()
-                            };
-
-                            cursor_setter((cursor_index, cursor.1 + 1));
-                        }
-                    }
-                    Key::ArrowLeft => {
-                        // Go one character to the left
-                        if cursor.0 > 0 {
-                            cursor_setter((cursor.0 - 1, cursor.1));
-                        } else if cursor.1 > 0 {
-                            // Go one line up if there is no more characters on the left
-                            let prev_line = rope.get_line(cursor.1 - 1);
-                            if let Some(prev_line) = prev_line {
-                                // Use the new line length as new cursor column, otherwise just set it to 0
-                                let len = if prev_line.len_chars() > 0 {
-                                    prev_line.len_chars()
-                                } else {
-                                    0
-                                };
-                                cursor_setter((len - 1, cursor.1 - 1));
-                            }
-                        }
-                    }
-                    Key::ArrowRight => {
-                        let total_lines = rope.len_lines() - 1;
-                        let current_line = rope.line(cursor.1);
-
-                        // Go one line down if there isn't more characters on the right
-                        if cursor.1 < total_lines && cursor.0 == current_line.len_chars() - 1 {
-                            cursor_setter((0, cursor.1 + 1));
-                        } else if cursor.0 < current_line.len_chars() {
-                            // Go one character to the right if possible
-                            cursor_setter((cursor.0 + 1, cursor.1));
-                        }
-                    }
-                    Key::ArrowUp => {
-                        // Go one line up if there is any
-                        if cursor.1 > 0 {
-                            let prev_line = rope.line(cursor.1 - 1);
-
-                            // Try to use the current cursor column, otherwise use the new line length
-                            let cursor_column = if cursor.0 <= prev_line.len_chars() {
-                                cursor.0
-                            } else {
-                                prev_line.len_chars()
-                            };
-
-                            cursor_setter((cursor_column, cursor.1 - 1));
-                        }
-                    }
-                    Key::Backspace => {
-                        if cursor.0 > 0 {
-                            // Remove the character to the left if there is any
-                            let char_idx = rope.line_to_char(cursor.1) + cursor.0;
-                            content.with_mut(|code| {
-                                code.remove(char_idx - 1..char_idx);
-                            });
-
-                            cursor_setter((cursor.0 - 1, cursor.1));
-                        } else if cursor.1 > 0 {
-                            // Moves the whole current line to the end of the line above.
-                            let prev_line = rope.line(cursor.1 - 1);
-                            let current_line = rope.get_line(cursor.1);
-
-                            if let Some(current_line) = current_line {
-                                let prev_char_idx =
-                                    rope.line_to_char(cursor.1 - 1) + prev_line.len_chars() - 1;
-                                let char_idx =
-                                    rope.line_to_char(cursor.1) + current_line.len_chars() - 1;
-
-                                content.with_mut(|code| {
-                                    if let Some(current_line) = current_line.as_str() {
-                                        code.insert(prev_char_idx, current_line);
-                                        code.remove(char_idx..(char_idx + current_line.len()) + 1);
-                                    }
-                                });
-                            }
-
-                            cursor_setter((prev_line.len_chars() - 1, cursor.1 - 1));
-                        }
-                    }
-                    Key::Enter => {
-                        // Breaks the line
-                        let char_idx = rope.line_to_char(cursor.1) + cursor.0;
-                        content.with_mut(|code| {
-                            code.insert(char_idx, "\n");
-                        });
-                        cursor_setter((0, cursor.1 + 1));
-                    }
-                    Key::Character(character) => {
-                        match pressed_key.code {
-                            Code::Delete => {}
-                            Code::Space => {
-                                // Simply adds an space
-                                let char_idx = rope.line_to_char(cursor.1) + cursor.0;
-                                content.with_mut(|code| {
-                                    code.insert(char_idx, " ");
-                                });
-                                cursor_setter((cursor.0 + 1, cursor.1));
-                            }
-                            _ => {
-                                // Adds a new character to the right
-                                let char_idx = rope.line_to_char(cursor.1) + cursor.0;
-                                content.with_mut(|code| {
-                                    code.insert(char_idx, character.as_str());
-                                });
-
-                                cursor_setter((cursor.0 + 1, cursor.1));
-                            }
-                        }
-                    }
-                    _ => {}
-                }
+                rope.with_mut(|rope| {
+                    rope.process_key(&pressed_key.key, &pressed_key.code, &pressed_key.modifiers);
+                });
             }
         }
     });
 
     (
         content,
-        cursor,
         keypress_channel_sender,
         click_channel_sender,
         cursor_ref_attr,
     )
-}
-
-#[cfg(test)]
-mod test {
-    use crate::{use_editable, EditableMode};
-    use freya::prelude::*;
-    use freya_elements::{Code, Key, Modifiers};
-    use freya_testing::{launch_test, FreyaEvent, MouseButton};
-
-    #[tokio::test]
-    pub async fn multiple_lines_single_editor() {
-        fn use_editable_app(cx: Scope) -> Element {
-            let (content, cursor, process_keyevent, process_clickevent, cursor_reference) =
-                use_editable(
-                    &cx,
-                    || "Hello Rustaceans",
-                    EditableMode::MultipleLinesSingleEditor,
-                );
-            let cursor_char = content.line_to_char(cursor.1) + cursor.0;
-            render!(
-                rect {
-                    width: "100%",
-                    height: "100%",
-                    background: "white",
-                    cursor_reference: cursor_reference,
-                    onclick:  move |e: MouseEvent| {
-                        process_clickevent.send((e.data, 0)).ok();
-                    },
-                    paragraph {
-                        height: "50%",
-                        width: "100%",
-                        cursor_id: "0",
-                        cursor_index: "{cursor_char}",
-                        cursor_color: "black",
-                        cursor_mode: "editable",
-                        onkeydown: move |e| {
-                            process_keyevent.send(e.data).unwrap();
-                        },
-                        text {
-                            color: "black",
-                            "{content}"
-                        }
-                    }
-                    label {
-                        color: "black",
-                        height: "50%",
-                        "{cursor.0}:{cursor.1}"
-                    }
-                }
-            )
-        }
-
-        let mut utils = launch_test(use_editable_app);
-
-        // Initial state
-        let root = utils.root().child(0).unwrap();
-        let cursor = root.child(1).unwrap().child(0).unwrap();
-        let content = root.child(0).unwrap().child(0).unwrap().child(0).unwrap();
-        assert_eq!(cursor.text(), Some("0:0"));
-        assert_eq!(content.text(), Some("Hello Rustaceans"));
-
-        // Move cursor
-        utils.send_event(FreyaEvent::Mouse {
-            name: "click",
-            cursor: (35.0, 3.0),
-            button: Some(MouseButton::Left),
-        });
-
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_update((500.0, 500.0)).await;
-
-        // Cursor has been moved
-        let root = utils.root().child(0).unwrap();
-        let cursor = root.child(1).unwrap().child(0).unwrap();
-        #[cfg(not(target_os = "linux"))]
-        assert_eq!(cursor.text(), Some("5:0"));
-
-        #[cfg(target_os = "linux")]
-        assert_eq!(cursor.text(), Some("4:0"));
-
-        // Insert text
-        utils.send_event(FreyaEvent::Keyboard {
-            name: "keydown",
-            key: Key::Character("!".to_string()),
-            code: Code::Unidentified,
-            modifiers: Modifiers::empty(),
-        });
-
-        utils.wait_for_update((500.0, 500.0)).await;
-
-        // Text and cursor have changed
-        let cursor = root.child(1).unwrap().child(0).unwrap();
-        let content = root.child(0).unwrap().child(0).unwrap().child(0).unwrap();
-        #[cfg(not(target_os = "linux"))]
-        {
-            assert_eq!(content.text(), Some("Hello! Rustaceans"));
-            assert_eq!(cursor.text(), Some("6:0"));
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            assert_eq!(content.text(), Some("Hell!o Rustaceans"));
-            assert_eq!(cursor.text(), Some("5:0"));
-        }
-    }
-
-    #[tokio::test]
-    pub async fn single_line_mulitple_editors() {
-        fn use_editable_app(cx: Scope) -> Element {
-            let (content, cursor, process_keyevent, process_clickevent, cursor_reference) =
-                use_editable(
-                    &cx,
-                    || "Hello Rustaceans\nHello World",
-                    EditableMode::SingleLineMultipleEditors,
-                );
-            render!(
-                rect {
-                    width: "100%",
-                    height: "100%",
-                    background: "white",
-                    cursor_reference: cursor_reference,
-
-                    onkeydown: move |e| {
-                        process_keyevent.send(e.data).unwrap();
-                    },
-                    content.lines().enumerate().map(move |(i, line)| {
-                        let process_clickevent = process_clickevent.clone();
-                        rsx!(
-                            paragraph {
-                                width: "100%",
-                                height: "30",
-                                max_lines: "1",
-                                cursor_id: "0",
-                                cursor_index: "{i}",
-                                cursor_color: "black",
-                                cursor_mode: "editable",
-                                onclick:  move |e: MouseEvent| {
-                                    process_clickevent.send((e.data, i)).ok();
-                                },
-                                text {
-                                    color: "black",
-                                    "{line}"
-                                }
-                            }
-                        )
-                    })
-                    label {
-                        color: "black",
-                        height: "50%",
-                        "{cursor.0}:{cursor.1}"
-                    }
-                }
-            )
-        }
-
-        let mut utils = launch_test(use_editable_app);
-
-        // Initial state
-        let root = utils.root().child(0).unwrap();
-        let cursor = root.child(2).unwrap().child(0).unwrap();
-        let content = root.child(0).unwrap().child(0).unwrap().child(0).unwrap();
-        assert_eq!(cursor.text(), Some("0:0"));
-        assert_eq!(content.text(), Some("Hello Rustaceans\n"));
-
-        // Move cursor
-        utils.send_event(FreyaEvent::Mouse {
-            name: "click",
-            cursor: (35.0, 3.0),
-            button: Some(MouseButton::Left),
-        });
-
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_update((500.0, 500.0)).await;
-
-        // Cursor has been moved
-        let root = utils.root().child(0).unwrap();
-        let cursor = root.child(2).unwrap().child(0).unwrap();
-        #[cfg(not(target_os = "linux"))]
-        assert_eq!(cursor.text(), Some("5:0"));
-
-        #[cfg(target_os = "linux")]
-        assert_eq!(cursor.text(), Some("4:0"));
-
-        // Insert text
-        utils.send_event(FreyaEvent::Keyboard {
-            name: "keydown",
-            key: Key::Character("!".to_string()),
-            code: Code::Unidentified,
-            modifiers: Modifiers::empty(),
-        });
-
-        utils.wait_for_update((500.0, 500.0)).await;
-
-        // Text and cursor have changed
-        let cursor = root.child(2).unwrap().child(0).unwrap();
-        let content = root.child(0).unwrap().child(0).unwrap().child(0).unwrap();
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            assert_eq!(content.text(), Some("Hello! Rustaceans\n"));
-            assert_eq!(cursor.text(), Some("6:0"));
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            assert_eq!(content.text(), Some("Hell!o Rustaceans\n"));
-            assert_eq!(cursor.text(), Some("5:0"));
-        }
-
-        // Second line
-        let content = root.child(1).unwrap().child(0).unwrap().child(0).unwrap();
-        assert_eq!(content.text(), Some("Hello World"));
-    }
 }

--- a/hooks/tests/use_editable.rs
+++ b/hooks/tests/use_editable.rs
@@ -1,0 +1,207 @@
+use crate::{use_editable, EditableMode, TextEditor};
+use freya::prelude::*;
+use freya_elements::{Code, Key, Modifiers};
+use freya_testing::{launch_test, FreyaEvent, MouseButton};
+
+#[tokio::test]
+pub async fn multiple_lines_single_editor() {
+    fn use_editable_app(cx: Scope) -> Element {
+        let (text_editor, process_keyevent, process_clickevent, cursor_reference) = use_editable(
+            &cx,
+            || "Hello Rustaceans",
+            EditableMode::MultipleLinesSingleEditor,
+        );
+        let cursor_char = text_editor.cursor_pos();
+        render!(
+            rect {
+                width: "100%",
+                height: "100%",
+                background: "white",
+                cursor_reference: cursor_reference,
+                onclick:  move |e: MouseEvent| {
+                    process_clickevent.send((e.data, 0)).ok();
+                },
+                paragraph {
+                    height: "50%",
+                    width: "100%",
+                    cursor_id: "0",
+                    cursor_index: "{cursor_char}",
+                    cursor_color: "black",
+                    cursor_mode: "editable",
+                    onkeydown: move |e| {
+                        process_keyevent.send(e.data).unwrap();
+                    },
+                    text {
+                        color: "black",
+                        "{text_editor}"
+                    }
+                }
+                label {
+                    color: "black",
+                    height: "50%",
+                    "{text_editor.cursor_col()}:{text_editor.cursor_row()}"
+                }
+            }
+        )
+    }
+
+    let mut utils = launch_test(use_editable_app);
+
+    // Initial state
+    let root = utils.root().child(0).unwrap();
+    let cursor = root.child(1).unwrap().child(0).unwrap();
+    let content = root.child(0).unwrap().child(0).unwrap().child(0).unwrap();
+    assert_eq!(cursor.text(), Some("0:0"));
+    assert_eq!(content.text(), Some("Hello Rustaceans"));
+
+    // Move cursor
+    utils.send_event(FreyaEvent::Mouse {
+        name: "click",
+        cursor: (35.0, 3.0),
+        button: Some(MouseButton::Left),
+    });
+
+    utils.wait_for_update((500.0, 500.0)).await;
+    utils.wait_for_update((500.0, 500.0)).await;
+
+    // Cursor has been moved
+    let root = utils.root().child(0).unwrap();
+    let cursor = root.child(1).unwrap().child(0).unwrap();
+    #[cfg(not(target_os = "linux"))]
+    assert_eq!(cursor.text(), Some("5:0"));
+
+    #[cfg(target_os = "linux")]
+    assert_eq!(cursor.text(), Some("4:0"));
+
+    // Insert text
+    utils.send_event(FreyaEvent::Keyboard {
+        name: "keydown",
+        key: Key::Character("!".to_string()),
+        code: Code::Unidentified,
+        modifiers: Modifiers::empty(),
+    });
+
+    utils.wait_for_update((500.0, 500.0)).await;
+
+    // Text and cursor have changed
+    let cursor = root.child(1).unwrap().child(0).unwrap();
+    let content = root.child(0).unwrap().child(0).unwrap().child(0).unwrap();
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert_eq!(content.text(), Some("Hello! Rustaceans"));
+        assert_eq!(cursor.text(), Some("6:0"));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        assert_eq!(content.text(), Some("Hell!o Rustaceans"));
+        assert_eq!(cursor.text(), Some("5:0"));
+    }
+}
+
+#[tokio::test]
+pub async fn single_line_mulitple_editors() {
+    fn use_editable_app(cx: Scope) -> Element {
+        let (text_editor, process_keyevent, process_clickevent, cursor_reference) = use_editable(
+            &cx,
+            || "Hello Rustaceans\nHello World",
+            EditableMode::SingleLineMultipleEditors,
+        );
+        render!(
+            rect {
+                width: "100%",
+                height: "100%",
+                background: "white",
+                cursor_reference: cursor_reference,
+
+                onkeydown: move |e| {
+                    process_keyevent.send(e.data).unwrap();
+                },
+                text_editor.lines().enumerate().map(move |(i, line)| {
+                    let process_clickevent = process_clickevent.clone();
+                    rsx!(
+                        paragraph {
+                            width: "100%",
+                            height: "30",
+                            max_lines: "1",
+                            cursor_id: "0",
+                            cursor_index: "{i}",
+                            cursor_color: "black",
+                            cursor_mode: "editable",
+                            onclick:  move |e: MouseEvent| {
+                                process_clickevent.send((e.data, i)).ok();
+                            },
+                            text {
+                                color: "black",
+                                "{line}"
+                            }
+                        }
+                    )
+                })
+                label {
+                    color: "black",
+                    height: "50%",
+                    "{text_editor.cursor_col()}:{text_editor.cursor_row()}"
+                }
+            }
+        )
+    }
+
+    let mut utils = launch_test(use_editable_app);
+
+    // Initial state
+    let root = utils.root().child(0).unwrap();
+    let cursor = root.child(2).unwrap().child(0).unwrap();
+    let content = root.child(0).unwrap().child(0).unwrap().child(0).unwrap();
+    assert_eq!(cursor.text(), Some("0:0"));
+    assert_eq!(content.text(), Some("Hello Rustaceans\n"));
+
+    // Move cursor
+    utils.send_event(FreyaEvent::Mouse {
+        name: "click",
+        cursor: (35.0, 3.0),
+        button: Some(MouseButton::Left),
+    });
+
+    utils.wait_for_update((500.0, 500.0)).await;
+    utils.wait_for_update((500.0, 500.0)).await;
+
+    // Cursor has been moved
+    let root = utils.root().child(0).unwrap();
+    let cursor = root.child(2).unwrap().child(0).unwrap();
+    #[cfg(not(target_os = "linux"))]
+    assert_eq!(cursor.text(), Some("5:0"));
+
+    #[cfg(target_os = "linux")]
+    assert_eq!(cursor.text(), Some("4:0"));
+
+    // Insert text
+    utils.send_event(FreyaEvent::Keyboard {
+        name: "keydown",
+        key: Key::Character("!".to_string()),
+        code: Code::Unidentified,
+        modifiers: Modifiers::empty(),
+    });
+
+    utils.wait_for_update((500.0, 500.0)).await;
+
+    // Text and cursor have changed
+    let cursor = root.child(2).unwrap().child(0).unwrap();
+    let content = root.child(0).unwrap().child(0).unwrap().child(0).unwrap();
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert_eq!(content.text(), Some("Hello! Rustaceans\n"));
+        assert_eq!(cursor.text(), Some("6:0"));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        assert_eq!(content.text(), Some("Hell!o Rustaceans\n"));
+        assert_eq!(cursor.text(), Some("5:0"));
+    }
+
+    // Second line
+    let content = root.child(1).unwrap().child(0).unwrap().child(0).unwrap();
+    assert_eq!(content.text(), Some("Hello World"));
+}


### PR DESCRIPTION
## Changes
- new `TextEditor` trait meant to hold a `Rope` and a `TextCursor`.
-  `use_editable` uses the new `UseEditableText` struct which implements `TextEditor`