### PR TITLE
feat: Improved padding syntax

### DIFF
--- a/components/src/button.rs
+++ b/components/src/button.rs
@@ -54,7 +54,7 @@ pub fn Button<'a>(cx: Scope<'a, ButtonProps<'a>>) -> Element {
             width: "auto",
             height: "auto",
             direction: "both",
-            padding: "3",
+            padding: "2",
             container {
                 onclick: move |ev| {
                     if let Some(onclick) = &cx.props.onclick {
@@ -73,7 +73,7 @@ pub fn Button<'a>(cx: Scope<'a, ButtonProps<'a>>) -> Element {
                 color: "{button_theme.font_theme.color}",
                 shadow: "0 5 15 10 black",
                 radius: "5",
-                padding: "17",
+                padding: "8",
                 background: "{background}",
                 &cx.props.children
             }

--- a/components/src/dropdown.rs
+++ b/components/src/dropdown.rs
@@ -44,7 +44,7 @@ where
         width: "100%",
         height: "35",
         background: background,
-        padding: "12",
+        padding: "6",
         radius: "3",
         onclick: move |_| {
             if let Some(onclick) = &cx.props.onclick {
@@ -151,7 +151,7 @@ where
                     height: "auto",
                     background: *background_button.get(),
                     shadow: "0 0 100 6 black",
-                    padding: "15",
+                    padding: "7",
                     &cx.props.children
                 }
             }
@@ -165,7 +165,7 @@ where
                 onclick: move |_| opened.set(true),
                 width: "70",
                 height: "auto",
-                padding: "15",
+                padding: "7",
                 label {
                     align: "center",
                     "{selected.read()}"

--- a/components/src/input.rs
+++ b/components/src/input.rs
@@ -70,7 +70,7 @@ pub fn Input<'a>(cx: Scope<'a, InputProps<'a>>) -> Element {
             width: "auto",
             height: "auto",
             direction: "both",
-            padding: "3",
+            padding: "1.5",
             container {
                 width: "100",
                 height: "35",
@@ -78,7 +78,7 @@ pub fn Input<'a>(cx: Scope<'a, InputProps<'a>>) -> Element {
                 color: "{button_theme.font_theme.color}",
                 shadow: "0 5 15 10 black",
                 radius: "5",
-                padding: "17",
+                padding: "8",
                 background: "{button_theme.background}",
                 label {
                     "{text}"

--- a/components/src/slider.rs
+++ b/components/src/slider.rs
@@ -123,7 +123,7 @@ pub fn Slider<'a>(cx: Scope<'a, SliderProps>) -> Element<'a> {
             onwheel: onwheel,
             display: "center",
             direction: "both",
-            padding: "2",
+            padding: "1",
             rect {
                 background: "{theme.background}",
                 width: "100%",
@@ -146,7 +146,7 @@ pub fn Slider<'a>(cx: Scope<'a, SliderProps>) -> Element<'a> {
                         width: "17",
                         height: "17",
                         radius: "50",
-                        padding: "6",
+                        padding: "3",
                         rect {
                             height: "100%",
                             width: "100%",

--- a/components/src/switch.rs
+++ b/components/src/switch.rs
@@ -98,11 +98,11 @@ pub fn Switch<'a>(cx: Scope<'a, SwitchProps<'a>>) -> Element<'a> {
             width: "auto",
             height: "auto",
             direction: "both",
-            padding: "3",
+            padding: "1.5",
             rect {
                 width: "50",
                 height: "25",
-                padding: "2",
+                padding: "1",
                 radius: "50",
                 background: "{border}",
                 onmousedown: onmousedown,
@@ -113,7 +113,7 @@ pub fn Switch<'a>(cx: Scope<'a, SwitchProps<'a>>) -> Element<'a> {
                     width: "100%",
                     height: "100%",
                     scroll_x: "{scroll_x}",
-                    padding: "5",
+                    padding: "2.5",
                     radius: "50",
                     rect {
                         background: "{circle}",

--- a/components/src/tooltip.rs
+++ b/components/src/tooltip.rs
@@ -15,7 +15,7 @@ pub fn Tooltip<'a>(cx: Scope<'a>, url: &'a str) -> Element {
     render!(
         rect {
             height: "30",
-            padding: "4",
+            padding: "2",
             width: "170",
             direction: "both",
             rect {

--- a/docs/src/basic_app.md
+++ b/docs/src/basic_app.md
@@ -46,7 +46,7 @@ fn app(cx: Scope) -> Element {
             width: "100%",
             background: "rgb(35, 35, 35)",
             color: "white",
-            padding: "25",
+            padding: "12.5",
             onclick: move |_| count += 1,
             label { "Click to increase -> {count}" }
         }

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,7 +22,7 @@ fn app(cx: Scope) -> Element {
             width: "100%",
             background: "rgb(35, 35, 35)",
             color: "white",
-            padding: "25",
+            padding: "12.5",
             onclick: move |_| count += 1,
             label { "Click to increase -> {count}" }
         }

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -34,7 +34,7 @@ fn app(cx: Scope) -> Element {
                 width: "200",
                 background: "blue",
                 rect {
-                    padding: "20",
+                    padding: "10",
                     height: "50",
                     width: "100%",
                     background: "green",
@@ -44,7 +44,7 @@ fn app(cx: Scope) -> Element {
                     }
                 }
                 rect {
-                    padding: "20",
+                    padding: "10",
                     height: "50",
                     width: "100%",
                     background: "red",

--- a/examples/app_dog.rs
+++ b/examples/app_dog.rs
@@ -66,7 +66,7 @@ fn app<'a>(cx: Scope<'a>) -> Element<'a> {
                 })
             }
             container {
-                padding: "20",
+                padding: "10",
                 height: "58",
                 width: "100%",
                 Button {

--- a/examples/calc.rs
+++ b/examples/calc.rs
@@ -12,7 +12,7 @@ fn main() {
 fn app(cx: Scope) -> Element {
     render!(rect {
         background: "rgb(233, 196, 106)",
-        padding: "50",
+        padding: "25",
         direction: "both",
         width: "calc(100% - 50% + 100)",
         height: "100%",

--- a/examples/camera.rs
+++ b/examples/camera.rs
@@ -16,7 +16,7 @@ fn app(cx: Scope) -> Element {
         rect {
             width: "100%",
             height: "100%",
-            padding: "100",
+            padding: "50",
             shadow: "0 10 150 40 black",
             if let Some(err) = camera_error.get() {
                 rsx!(

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -95,7 +95,7 @@ fn app(cx: Scope) -> Element {
                                     width: "600",
                                     height: "400",
                                     radius: "15",
-                                    padding: "20",
+                                    padding: "10",
                                     shadow: "0 0 60 35 white",
                                     onmousedown:  move |e: MouseEvent| {
                                         clicking_drag.set(Some((id, e.get_element_coordinates().to_tuple())));
@@ -120,7 +120,7 @@ fn app(cx: Scope) -> Element {
                 width: "100%",
                 display: "center",
                 direction: "horizontal",
-                padding: "30",
+                padding: "15",
                 rect {
                     layer: "-100",
                     padding: "10",

--- a/examples/center.rs
+++ b/examples/center.rs
@@ -19,7 +19,7 @@ fn app(cx: Scope) -> Element {
             direction: "both",
             rect {
                 background: "rgb(255, 0, 255)",
-                padding: "30",
+                padding: "15",
                 height: "75%",
                 width: "75%",
                 display: "center",

--- a/examples/click.rs
+++ b/examples/click.rs
@@ -15,7 +15,7 @@ fn app(cx: Scope) -> Element {
         container {
             color: "white",
             background: "rgb(15, 15, 15)",
-            padding: "50",
+            padding: "25",
             direction: "both",
             width: "auto",
             height: "auto",
@@ -23,7 +23,7 @@ fn app(cx: Scope) -> Element {
                 count.with_mut(|c| *c = 0);
             },
             container {
-                padding: "50",
+                padding: "25",
                 height: "100%",
                 width: "100%",
                 background: "rgb(45, 45, 45)",
@@ -31,7 +31,7 @@ fn app(cx: Scope) -> Element {
                     count.with_mut(|c| *c = 1)
                 },
                 container {
-                    padding: "50",
+                    padding: "25",
                     height: "100%",
                     width: "100%",
                     background: "rgb(90, 90, 90)",

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -17,10 +17,10 @@ fn app(cx: Scope) -> Element {
             height: "20%",
             width: "100%",
             background: "rgb(233, 196, 106)",
-            padding: "12.5",
+            padding: "12",
             color: "rgb(20, 33, 61)",
-            label {
-                font_size: "20",
+            label { 
+                font_size: "20", 
                 "Number is: {count}"
             }
         }
@@ -29,7 +29,7 @@ fn app(cx: Scope) -> Element {
             width: "100%",
             background: "rgb(168, 218, 220)",
             color: "black",
-            padding: "12.5",
+            padding: "12",
             onclick: move |_| count += 1,
             label { "Click to increase!" }
         }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -19,8 +19,8 @@ fn app(cx: Scope) -> Element {
             background: "rgb(233, 196, 106)",
             padding: "12",
             color: "rgb(20, 33, 61)",
-            label { 
-                font_size: "20", 
+            label {
+                font_size: "20",
                 "Number is: {count}"
             }
         }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -17,7 +17,7 @@ fn app(cx: Scope) -> Element {
             height: "20%",
             width: "100%",
             background: "rgb(233, 196, 106)",
-            padding: "25",
+            padding: "12.5",
             color: "rgb(20, 33, 61)",
             label {
                 font_size: "20",
@@ -29,7 +29,7 @@ fn app(cx: Scope) -> Element {
             width: "100%",
             background: "rgb(168, 218, 220)",
             color: "black",
-            padding: "25",
+            padding: "12.5",
             onclick: move |_| count += 1,
             label { "Click to increase!" }
         }

--- a/examples/divider.rs
+++ b/examples/divider.rs
@@ -17,7 +17,7 @@ fn app(cx: Scope) -> Element {
             height: "stretch",
             width: "stretch",
             direction: "horizontal",
-            padding: "30",
+            padding: "15",
             color: "white",
             rect {
                 width: "{sizes.0}%",
@@ -26,7 +26,7 @@ fn app(cx: Scope) -> Element {
                     background: "red",
                     height: "{sizes.2}%",
                     width: "stretch",
-                    padding: "30",
+                    padding: "15",
                     onclick: |_| sizes.with_mut(|v| {
                         v.0 += 5;
                         v.1 -= 5;
@@ -41,7 +41,7 @@ fn app(cx: Scope) -> Element {
                     background: "green",
                     height: "{sizes.3}%",
                     width: "stretch",
-                    padding: "30",
+                    padding: "15",
                     onclick: |_| sizes.with_mut(|v| {
                         v.0 += 5;
                         v.1 -= 5;
@@ -60,7 +60,7 @@ fn app(cx: Scope) -> Element {
                     background: "blue",
                     height: "{sizes.2}%",
                     width: "stretch",
-                    padding: "30",
+                    padding: "15",
                     onclick: |_| sizes.with_mut(|v| {
                         v.0 -= 5;
                         v.1 += 5;
@@ -75,7 +75,7 @@ fn app(cx: Scope) -> Element {
                     background: "black",
                     height: "{sizes.3}%",
                     width: "stretch",
-                    padding: "30",
+                    padding: "15",
                     onclick: |_| sizes.with_mut(|v| {
                         v.0 -= 5;
                         v.1 += 5;

--- a/examples/drawer.rs
+++ b/examples/drawer.rs
@@ -109,7 +109,7 @@ fn app(cx: Scope) -> Element {
                 width: "100%",
                 onclick: move |_| { opened.set(false) },
                 rect {
-                    padding: "5",
+                    padding: "2.5",
                     height: "30",
                     width: "100",
                     background: "black",
@@ -129,12 +129,12 @@ fn Button<'a>(cx: Scope<'a, ButtonProps<'a>>) -> Element {
         rect {
             width: "100%",
             height: "60",
-            padding: "10",
+            padding: "5",
             onclick: move |evt| cx.props.onclick.call(evt),
             rect {
                 width: "100%",
                 height: "100%",
-                padding: "2",
+                padding: "1",
                 radius: "7",
                 background: "green",
                 rect {
@@ -147,7 +147,7 @@ fn Button<'a>(cx: Scope<'a, ButtonProps<'a>>) -> Element {
                     width: "100%",
                     height: "100%",
                     background: "{background}",
-                    padding: "25",
+                    padding: "12.5",
                     radius: "6",
                     &cx.props.body
                 }

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -47,7 +47,7 @@ fn Body(cx: Scope) -> Element {
     render!(
         rect {
             background: "{body_theme.background}",
-            padding: "15",
+            padding: "7.5",
             width: "100%",
             height: "100%",
             Dropdown {

--- a/examples/editor.rs
+++ b/examples/editor.rs
@@ -62,14 +62,14 @@ fn Body(cx: Scope) -> Element {
             rect {
                 width: "100%",
                 height: "60",
-                padding: "20",
+                padding: "10",
                 direction: "horizontal",
                 background: "rgb(20, 20, 20)",
                 rect {
                     height: "100%",
                     width: "100%",
                     direction: "horizontal",
-                    padding: "10",
+                    padding: "5",
                     label {
                         font_size: "30",
                         "Editor"
@@ -168,7 +168,7 @@ fn Body(cx: Scope) -> Element {
             rect {
                 width: "100%",
                 height: "calc(100% - 90)",
-                padding: "20",
+                padding: "10",
                 onkeydown: move |e| {
                    process_keyevent.send(e.data).unwrap();
                 },
@@ -178,7 +178,7 @@ fn Body(cx: Scope) -> Element {
                 rect {
                     width: "50%",
                     height: "100%",
-                    padding: "30",
+                    padding: "15",
                     ScrollView {
                         width: "100%",
                         height: "100%",
@@ -255,7 +255,7 @@ fn Body(cx: Scope) -> Element {
                     radius: "15",
                     width: "50%",
                     height: "100%",
-                    padding: "30",
+                    padding: "15",
                     shadow: "0 10 30 7 white",
                     ScrollView {
                         width: "100%",
@@ -280,7 +280,7 @@ fn Body(cx: Scope) -> Element {
                 height: "30",
                 background: "rgb(20, 20, 20)",
                 direction: "horizontal",
-                padding: "10",
+                padding: "5",
                 label {
                     color: "rgb(200, 200, 200)",
                     "Ln {text_editor.cursor_row() + 1}, Col {text_editor.cursor_col() + 1}"

--- a/examples/floating_window.rs
+++ b/examples/floating_window.rs
@@ -22,7 +22,7 @@ fn app(cx: Scope) -> Element {
     render!(
         rect {
             background: "white",
-            padding: "20",
+            padding: "10",
             display: "center",
             direction: "both",
             width: "100",

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -27,7 +27,7 @@ fn app(cx: Scope) -> Element {
         rect {
             width: "100%",
             height: "100%",
-            padding: "100",
+            padding: "50",
             onwheel: onwheel,
             image {
                 image_data: image_data,

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -16,7 +16,7 @@ fn app(cx: Scope) -> Element {
 
     render!(
         container {
-            padding: "15",
+            padding: "7",
             width: "100%",
             height: "100%",
             label {

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -25,7 +25,7 @@ fn app(cx: Scope) -> Element {
         rect {
             width: "100%",
             height: "100%",
-            padding: "50",
+            padding: "25",
             label {
                 color: "black",
                 "Is enabled? {is_enabled}"

--- a/examples/massive.rs
+++ b/examples/massive.rs
@@ -21,7 +21,7 @@ fn app(cx: Scope) -> Element {
         container {
             width: "100%",
             height: "100%",
-            padding: "5",
+            padding: "2.5",
             label {
                 height: "35",
                 color: "black",

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -50,7 +50,7 @@ fn Area<'a>(cx: Scope<'a>) -> Element {
             height: "50%",
             width: "100%",
             background: "blue",
-            padding: "10",
+            padding: "5",
             onmouseover: cursor_moved,
             onclick: cursor_clicked,
             label {

--- a/examples/paddings.rs
+++ b/examples/paddings.rs
@@ -1,0 +1,48 @@
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
+
+use freya::prelude::*;
+
+fn main() {
+    launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    render!(
+        rect {
+            height: "33%",
+            width: "100%",
+            padding: "15",
+            background: "black",
+            rect {
+                height: "100%",
+                width: "100%",
+                background: "yellow"
+            }
+        }
+        rect {
+            height: "33%",
+            width: "100%",
+            padding: "10 30 50 70",
+            background: "gray",
+            rect {
+                height: "100%",
+                width: "100%",
+                background: "yellow"
+            }
+        }
+        rect {
+            height: "33%",
+            width: "100%",
+            padding: "25 125",
+            background: "white",
+            rect {
+                height: "100%",
+                width: "100%",
+                background: "yellow"
+            }
+        }
+    )
+}

--- a/examples/progress_bars.rs
+++ b/examples/progress_bars.rs
@@ -73,7 +73,7 @@ fn LoadingBar<'a>(cx: Scope<'a, LoadingBarProps>) -> Element {
         rect {
             width: "auto",
             height: "30",
-            padding: "15",
+            padding: "7",
             background: "white",
             rect {
                 width: "{&cx.props.progress}%",

--- a/examples/radius.rs
+++ b/examples/radius.rs
@@ -21,7 +21,7 @@ fn app(cx: Scope) -> Element {
         container {
             height: "100%",
             width: "100%",
-            padding: "125",
+            padding: "60",
             onwheel: onwheel,
             rect {
                 shadow: "0 0 150 30.0 black",

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -14,33 +14,34 @@ fn app(cx: Scope) -> Element {
         rect {
             height: "100%",
             width: "100%",
-            padding: "100",
+            padding: "50",
             background: "white",
+            color: "white",
             ScrollView {
                 show_scrollbar: true,
                 rect {
                     height: "200",
                     width: "400",
                     background: "rgb(214, 40, 40)",
-                    padding: "30",
+                    padding: "15",
                     rect {
                         height: "100%",
                         width: "100%",
                         background: "rgb(27, 38, 59)",
-                        padding: "25",
-                        label {             color: "white","Scrollbar support!!!" }
+                        padding: "15",
+                        label {  "Scrollbar support!!!" }
                     }
                 }
                 rect {
                     height: "200",
                     width: "400",
                     background: "rgb(214, 40, 40)",
-                    padding: "30",
+                    padding: "15",
                     rect {
                         height: "100%",
                         width: "100%",
                         background: "rgb(27, 38, 59)",
-                        padding: "25",
+                        padding: "15",
                         label { "Scrollbar support!!!" }
                     }
                 }
@@ -48,12 +49,12 @@ fn app(cx: Scope) -> Element {
                     height: "200",
                     width: "400",
                     background: "rgb(214, 40, 40)",
-                    padding: "30",
+                    padding: "15",
                     rect {
                         height: "100%",
                         width: "100%",
                         background: "rgb(27, 38, 59)",
-                        padding: "25",
+                        padding: "15",
                         label { "Scrollbar support!!!" }
                     }
                 }

--- a/examples/shadow.rs
+++ b/examples/shadow.rs
@@ -21,14 +21,14 @@ fn app(cx: Scope) -> Element {
         container {
             height: "100%",
             width: "100%",
-            padding: "125",
+            padding: "60",
             onwheel: onwheel,
             rect {
                 shadow: "0 10 210 {shadow_size} red",
                 height: "100%",
                 width: "100%",
                 background: "black",
-                padding: "50",
+                padding: "25",
                 label {
                     "Scroll!"
                 }

--- a/examples/showcase.rs
+++ b/examples/showcase.rs
@@ -23,7 +23,7 @@ fn main() {
 
 #[allow(non_snake_case)]
 fn Space(cx: Scope) -> Element {
-    render!(rect { padding: "10" })
+    render!(rect { padding: "5" })
 }
 
 #[allow(non_snake_case)]
@@ -43,7 +43,7 @@ fn Body(cx: Scope) -> Element {
 
     render!(
         rect {
-            padding: "35",
+            padding: "20",
             background: "{body_theme.background}",
             color: "{body_theme.color}",
             width: "100%",

--- a/examples/stateful_window.rs
+++ b/examples/stateful_window.rs
@@ -20,7 +20,7 @@ fn app(cx: Scope) -> Element {
 
     render!(rect {
         background: "white",
-        padding: "20",
+        padding: "10",
         width: "100%",
         height: "100%",
         radius: "50",

--- a/examples/switch.rs
+++ b/examples/switch.rs
@@ -18,7 +18,7 @@ fn app(cx: Scope) -> Element {
         rect {
             width: "100%",
             height: "100%",
-            padding: "50",
+            padding: "25",
             label {
                 color: "black",
                 "Is enabled? {is_enabled}"

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -40,7 +40,7 @@ fn app(cx: Scope) -> Element {
             background: "{big}",
             height: "stretch",
             width: "stretch",
-            padding: "50",
+            padding: "25",
             label {
                 "hello",
             }
@@ -56,9 +56,9 @@ fn app(cx: Scope) -> Element {
                     background: "{small}",
                     height: "auto",
                     width: "stretch",
-                    padding: "20",
+                    padding: "10",
                     label {
-                        "ddddddd",
+                        "Wooow",
                     }
                 }
             },

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -18,6 +18,7 @@ fn app(cx: Scope) -> Element {
             width: "100%",
             height: "100%",
             background: "black",
+            color: "white",
             container {
                 width: "100%",
                 height: "60",

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -28,7 +28,7 @@ fn app(cx: Scope) -> Element {
                     }
                     ScrollView {
                         height: "200",
-                        padding: "40",
+                        padding: "20",
                         Card {
                             title: "Lalala",
                             content: "Wooow",
@@ -39,7 +39,7 @@ fn app(cx: Scope) -> Element {
                         }
                         ScrollView {
                             height: "200",
-                            padding: "40",
+                            padding: "20",
                             Card {
                                 title: "Lalala",
                                 content: "Wooow",
@@ -50,7 +50,7 @@ fn app(cx: Scope) -> Element {
                             }
                             ScrollView {
                                 height: "200",
-                                padding: "40",
+                                padding: "20",
                                 Card {
                                     title: "Lalala",
                                     content: "Wooow",
@@ -103,7 +103,7 @@ fn Navbar<'a>(cx: Scope<'a, NavbarProps<'a>>) -> Element {
             height: "75",
             width: "stretch",
             background: "rgb(20, 20, 20)",
-            padding: "30",
+            padding: "15",
             label {
                 "{&cx.props.title}"
             }
@@ -148,12 +148,12 @@ fn Card<'a>(cx: Scope<'a, CardProps<'a>>) -> Element {
         rect {
             width: "stretch",
             height: "200",
-            padding: "20",
+            padding: "10",
             background: "rgb(45, 45, 45)",
             rect {
                 width: "stretch",
                 height: "50%",
-                padding: "10",
+                padding: "5",
                 radius: "10",
                 label {
                     height: "auto",
@@ -197,7 +197,7 @@ fn Area<'a>(cx: Scope<'a>) -> Element {
             height: "50%",
             width: "100%",
             background: "blue",
-            padding: "20",
+            padding: "10",
             radius: "10",
             onmouseover: cursor_moved,
             onclick: cursor_clicked,

--- a/examples/virtual_scroll_view.rs
+++ b/examples/virtual_scroll_view.rs
@@ -26,7 +26,7 @@ fn app(cx: Scope) -> Element {
     render!(
         container {
             background: "rgb(15, 15, 15)",
-            padding: "50",
+            padding: "25",
             direction: "both",
             width: "auto",
             height: "50%",
@@ -106,7 +106,7 @@ fn app(cx: Scope) -> Element {
         }
         container {
             background: "rgb(15, 15, 15)",
-            padding: "50",
+            padding: "25",
             direction: "both",
             width: "auto",
             height: "50%",

--- a/freya/src/devtools.rs
+++ b/freya/src/devtools.rs
@@ -233,7 +233,7 @@ fn NodesTree<'a>(
     render!(VirtualScrollView {
         width: "100%",
         height: "{height}",
-        padding: "30",
+        padding: "15",
         show_scrollbar: true,
         length: nodes.len() as i32,
         item_size: 27.0,
@@ -314,7 +314,7 @@ fn TabButton<'a>(cx: Scope<'a, TabButtonProps<'a>>) -> Element<'a> {
                 container {
                     width: "100%",
                     height: "100%",
-                    padding: "15",
+                    padding: "7.5",
                     label {
                         align: "center",
                         height: "100%",
@@ -440,7 +440,7 @@ fn Property<'a>(cx: Scope<'a>, name: &'a str, value: String) -> Element<'a> {
             height: "30",
             width: "100%",
             direction: "horizontal",
-            padding: "20",
+            padding: "10",
             paragraph {
                 width: "100%",
                 text {
@@ -472,7 +472,7 @@ fn ColorfulProperty<'a>(cx: Scope<'a>, name: &'a str, color: &'a Color) -> Eleme
             height: "30",
             width: "100%",
             direction: "horizontal",
-            padding: "20",
+            padding: "10",
             label {
                 font_size: "15",
                 color: "rgb(71, 180, 240)",
@@ -491,7 +491,7 @@ fn ColorfulProperty<'a>(cx: Scope<'a>, name: &'a str, color: &'a Color) -> Eleme
                 height: "17",
                 radius: "5",
                 background: "white",
-                padding: "5",
+                padding: "2.5",
                 rect {
                     radius: "3",
                     width: "100%",
@@ -524,7 +524,7 @@ fn ShadowProperty<'a>(
             height: "30",
             width: "100%",
             direction: "horizontal",
-            padding: "20",
+            padding: "10",
             paragraph {
                 text {
                     font_size: "15",
@@ -550,7 +550,7 @@ fn ShadowProperty<'a>(
                 height: "17",
                 radius: "5",
                 background: "white",
-                padding: "5",
+                padding: "2.5",
                 rect {
                     radius: "3",
                     width: "100%",
@@ -592,7 +592,7 @@ fn NodeElement<'a>(
     render!(
         rect {
             radius: "7",
-            padding: "10",
+            padding: "5",
             background: background,
             width: "100%",
             height: "27",

--- a/freya/src/lib.rs
+++ b/freya/src/lib.rs
@@ -18,7 +18,7 @@
 //!            width: "100%",
 //!            background: "rgb(35, 35, 35)",
 //!            color: "white",
-//!            padding: "25",
+//!            padding: "12",
 //!            onclick: move |_| count += 1,
 //!            label { "Click to increase -> {count}" }
 //!        }

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ fn app(cx: Scope) -> Element {
             height: "20%",
             width: "100%",
             background: "rgb(233, 196, 106)",
-            padding: "25",
+            padding: "12",
             color: "rgb(20, 33, 61)",
             label { 
                 font_size: "20", 
@@ -38,7 +38,7 @@ fn app(cx: Scope) -> Element {
             width: "100%",
             background: "rgb(168, 218, 220)",
             color: "black",
-            padding: "25",
+            padding: "12",
             onclick: move |_| count += 1,
             label { "Click to increase!" }
         }

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -23,5 +23,5 @@ fxhash = "0.2.1"
 skia-safe = { version = "0.58.0", features = ["gl", "textlayout", "svg"] }
 freya-elements = { path = "../elements", version = "0.1.0"}
 freya-common = { path = "../common", version = "0.1.0" }
-tokio = { version = "1.23.0" }
+tokio = { version = "1.23.0", features = ["sync"] }
 bytes = "1.3.0"

--- a/state/src/size.rs
+++ b/state/src/size.rs
@@ -115,12 +115,9 @@ impl ParentDepState<CustomAttributeValues> for Size {
                     "padding" => {
                         let attr = attr.value.as_text();
                         if let Some(attr) = attr {
-                            let total_padding: f32 = attr.parse().unwrap();
-                            let padding_for_side = total_padding / 2.0;
-                            padding.0 = padding_for_side;
-                            padding.1 = padding_for_side;
-                            padding.2 = padding_for_side;
-                            padding.3 = padding_for_side;
+                            if let Some(paddings) = parse_padding(attr) {
+                                padding = paddings;
+                            }
                         }
                     }
                     "direction" => {
@@ -163,6 +160,41 @@ impl ParentDepState<CustomAttributeValues> for Size {
         };
         changed
     }
+}
+
+pub fn parse_padding(padding: &str) -> Option<(f32, f32, f32, f32)> {
+    let mut padding_config = (0.0, 0.0, 0.0, 0.0);
+    let mut paddings = padding.split_ascii_whitespace();
+
+    match paddings.clone().count() {
+        // Same in each directions
+        1 => {
+            padding_config.0 = paddings.next()?.parse::<f32>().ok()?;
+            padding_config.1 = padding_config.0;
+            padding_config.2 = padding_config.0;
+            padding_config.3 = padding_config.0;
+        }
+        // By vertical and horizontal
+        2 => {
+            // Vertical
+            padding_config.0 = paddings.next()?.parse::<f32>().ok()?;
+            padding_config.2 = padding_config.0;
+
+            // Horizontal
+            padding_config.1 = paddings.next()?.parse::<f32>().ok()?;
+            padding_config.3 = padding_config.1;
+        }
+        // Each directions
+        4 => {
+            padding_config.0 = paddings.next()?.parse::<f32>().ok()?;
+            padding_config.1 = paddings.next()?.parse::<f32>().ok()?;
+            padding_config.2 = paddings.next()?.parse::<f32>().ok()?;
+            padding_config.3 = paddings.next()?.parse::<f32>().ok()?;
+        }
+        _ => {}
+    }
+
+    Some(padding_config)
 }
 
 pub fn parse_size(size: &str) -> Option<SizeMode> {

--- a/state/tests/parse_paddings.rs
+++ b/state/tests/parse_paddings.rs
@@ -1,0 +1,19 @@
+use freya_node_state::parse_padding;
+
+#[test]
+fn parse_all_paddings() {
+    let paddings = parse_padding("10");
+    assert_eq!(paddings, Some((10.0, 10.0, 10.0, 10.0)));
+}
+
+#[test]
+fn parse_axis_paddings() {
+    let paddings = parse_padding("50 10");
+    assert_eq!(paddings, Some((50.0, 10.0, 50.0, 10.0)));
+}
+
+#[test]
+fn parse_sides_paddings() {
+    let paddings = parse_padding("1 2 3 4");
+    assert_eq!(paddings, Some((1.0, 2.0, 3.0, 4.0)));
+}


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/94

- [x] Remove the `/ 2.0` (This will break a lot of examples) from https://github.com/marc2332/freya/blob/main/state/src/size.rs#L119 as it doesn't really make sense
- [x] Allow vertical and horizontal for separate, e.g `padding: "20 10"`
- [x] Allow every direction for separate, e.g `padding: "5 10 20 7"`