### PR TITLE
feat: Multiple font families support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ dependencies = [
  "freya-elements",
  "fxhash",
  "skia-safe",
+ "smallvec",
  "tokio",
 ]
 

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -255,7 +255,7 @@ impl<'a> NodeLayoutMeasurer<'a> {
             TextStyle::new()
                 .set_font_style(font_style)
                 .set_font_size(font_size)
-                .set_font_families(&[font_family]),
+                .set_font_families(font_family),
         );
 
         let texts = get_inner_texts(self.dom, &self.node_id);
@@ -268,7 +268,7 @@ impl<'a> NodeLayoutMeasurer<'a> {
                     .set_height(font_style.line_height)
                     .set_color(font_style.color)
                     .set_font_size(font_style.font_size)
-                    .set_font_families(&[font_style.font_family.clone()]),
+                    .set_font_families(&font_style.font_family),
             );
             paragraph_builder.add_text(text);
         }
@@ -404,7 +404,7 @@ impl<'a> NodeLayoutMeasurer<'a> {
                     TextStyle::new()
                         .set_font_style(font_style)
                         .set_font_size(font_size)
-                        .set_font_families(&[font_family]),
+                        .set_font_families(font_family),
                 );
 
                 paragraph_builder.add_text(text);

--- a/renderer/src/elements/label.rs
+++ b/renderer/src/elements/label.rs
@@ -55,7 +55,7 @@ pub fn render_label(
                 .set_font_style(font_style)
                 .set_color(font_color)
                 .set_font_size(font_size)
-                .set_font_families(&[font_family]),
+                .set_font_families(font_family),
         );
         let mut paragraph_builder =
             ParagraphBuilder::new(&paragraph_style, font_collection.clone());

--- a/renderer/src/elements/paragraph.rs
+++ b/renderer/src/elements/paragraph.rs
@@ -42,7 +42,7 @@ pub fn render_paragraph(
                 .set_height(node_text.0.font_style.line_height)
                 .set_color(node_text.0.font_style.color)
                 .set_font_size(node_text.0.font_style.font_size)
-                .set_font_families(&[node_text.0.font_style.font_family.clone()]),
+                .set_font_families(&node_text.0.font_style.font_family),
         );
         paragraph_builder.add_text(node_text.1.clone());
     }

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -25,3 +25,4 @@ freya-elements = { path = "../elements", version = "0.1.0"}
 freya-common = { path = "../common", version = "0.1.0" }
 tokio = { version = "1.23.0", features = ["sync"] }
 bytes = "1.3.0"
+smallvec = "1.10.0"

--- a/state/src/font_style.rs
+++ b/state/src/font_style.rs
@@ -3,13 +3,14 @@ use dioxus_native_core::state::ParentDepState;
 use dioxus_native_core_macro::sorted_str_slice;
 use skia_safe::textlayout::TextAlign;
 use skia_safe::Color;
+use smallvec::{smallvec, SmallVec};
 
 use crate::{parse_color, CustomAttributeValues};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FontStyle {
     pub color: Color,
-    pub font_family: String,
+    pub font_family: SmallVec<[String; 2]>,
     pub font_size: f32,
     pub line_height: f32, // https://developer.mozilla.org/en-US/docs/Web/CSS/line-height,
     pub align: TextAlign,
@@ -21,7 +22,7 @@ impl Default for FontStyle {
     fn default() -> Self {
         Self {
             color: Color::BLACK,
-            font_family: "Fira Sans".to_string(),
+            font_family: smallvec!["Fira Sans".to_string()],
             font_size: 16.0,
             line_height: 1.2,
             align: TextAlign::default(),
@@ -70,7 +71,13 @@ impl ParentDepState<CustomAttributeValues> for FontStyle {
                     "font_family" => {
                         let attr = attr.value.as_text();
                         if let Some(attr) = attr {
-                            font_style.font_family = attr.to_string();
+                            let families = attr.split(',');
+                            font_style.font_family = SmallVec::from(
+                                families
+                                    .into_iter()
+                                    .map(|f| f.trim().to_string())
+                                    .collect::<Vec<String>>(),
+                            );
                         }
                     }
                     "font_size" => {

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -75,7 +75,7 @@ pub enum AttributeType<'a> {
     Direction(&'a DirectionMode),
     Display(&'a DisplayMode),
     Shadow(&'a ShadowSettings),
-    Text(&'a str),
+    Text(String),
 }
 
 pub struct NodeStateIterator<'a> {
@@ -115,7 +115,7 @@ impl<'a> Iterator for NodeStateIterator<'a> {
             12 => Some(("color", AttributeType::Color(&self.state.font_style.color))),
             13 => Some((
                 "font_family",
-                AttributeType::Text(&self.state.font_style.font_family),
+                AttributeType::Text(self.state.font_style.font_family.join(",")),
             )),
             14 => Some((
                 "font_size",


### PR DESCRIPTION
`font_family` attribute now supports multiple fonts as fallback.

```rust
fn app(cx: Scope) -> Element {
    render!(
        label {
            font_family: "Font A, Font B if A doesn't exist",
            "Hello World!"
        }
    )
}

```