### PR TITLE
feat: Improvements in `freya-testing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,7 @@ dependencies = [
  "dioxus-native-core",
  "dioxus-native-core-macro",
  "dioxus-rsx",
+ "euclid",
  "freya-common",
  "freya-components",
  "freya-core",

--- a/components/src/gesture_area.rs
+++ b/components/src/gesture_area.rs
@@ -199,7 +199,7 @@ mod test {
         let mut utils = launch_test(dobule_tap_app);
 
         // Initial state
-        utils.wait_for_work((500.0, 500.0));
+        utils.wait_for_update().await;
 
         assert_eq!(
             utils.root().child(0).unwrap().child(0).unwrap().text(),
@@ -222,8 +222,8 @@ mod test {
             force: None,
         });
 
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_update((500.0, 500.0)).await;
+        utils.wait_for_update().await;
+        utils.wait_for_update().await;
 
         sleep(Duration::from_millis(DOUBLE_TAP_MIN as u64)).await;
 
@@ -235,8 +235,8 @@ mod test {
             force: None,
         });
 
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_update((500.0, 500.0)).await;
+        utils.wait_for_update().await;
+        utils.wait_for_update().await;
 
         assert_eq!(
             utils.root().child(0).unwrap().child(0).unwrap().text(),
@@ -265,7 +265,7 @@ mod test {
         let mut utils = launch_test(tap_up_down_app);
 
         // Initial state
-        utils.wait_for_work((500.0, 500.0));
+        utils.wait_for_update().await;
 
         assert_eq!(
             utils.root().child(0).unwrap().child(0).unwrap().text(),
@@ -280,8 +280,8 @@ mod test {
             force: None,
         });
 
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_update((500.0, 500.0)).await;
+        utils.wait_for_update().await;
+        utils.wait_for_update().await;
 
         assert_eq!(
             utils.root().child(0).unwrap().child(0).unwrap().text(),
@@ -296,8 +296,8 @@ mod test {
             force: None,
         });
 
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_update((500.0, 500.0)).await;
+        utils.wait_for_update().await;
+        utils.wait_for_update().await;
 
         assert_eq!(
             utils.root().child(0).unwrap().child(0).unwrap().text(),

--- a/freya/src/lib.rs
+++ b/freya/src/lib.rs
@@ -1,4 +1,7 @@
-#![doc(html_logo_url = "https://freyaui.dev/logo.svg", html_favicon_url = "https://freyaui.dev/logo.svg")]
+#![doc(
+    html_logo_url = "https://freyaui.dev/logo.svg",
+    html_favicon_url = "https://freyaui.dev/logo.svg"
+)]
 //! # Freya
 //! Build native & cross-platform GUI applications using 🦀 Rust.
 //!

--- a/hooks/src/use_animation.rs
+++ b/hooks/src/use_animation.rs
@@ -241,14 +241,14 @@ mod test {
         let mut utils = launch_test(use_animation_app);
 
         // Initial state
-        utils.wait_for_update((500.0, 500.0)).await;
+        utils.wait_for_update().await;
 
         assert_eq!(utils.root().child(0).unwrap().layout().unwrap().width, 0.0);
 
         // State somewhere in the middle
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_work((500.0, 500.0));
+        utils.wait_for_update().await;
+        utils.wait_for_update().await;
+
         let width = utils.root().child(0).unwrap().layout().unwrap().width;
         assert!(width > 0.0);
         assert!(width < 100.0);
@@ -256,8 +256,8 @@ mod test {
         sleep(Duration::from_millis(50)).await;
 
         // State in the end
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_work((500.0, 500.0));
+        utils.wait_for_update().await;
+
         let width = utils.root().child(0).unwrap().layout().unwrap().width;
         assert_eq!(width, 100.0);
     }
@@ -292,14 +292,14 @@ mod test {
         let mut utils = launch_test(use_animation_app);
 
         // Initial state
-        utils.wait_for_update((500.0, 500.0)).await;
+        utils.wait_for_update().await;
 
         assert_eq!(utils.root().child(0).unwrap().layout().unwrap().width, 10.0);
 
         // State somewhere in the middle
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_work((500.0, 500.0));
+        utils.wait_for_update().await;
+        utils.wait_for_update().await;
+
         let width = utils.root().child(0).unwrap().layout().unwrap().width;
         assert!(width > 10.0);
 
@@ -310,8 +310,8 @@ mod test {
         });
 
         // State has been restarted
-        utils.wait_for_update((500.0, 500.0)).await;
-        utils.wait_for_work((500.0, 500.0));
+        utils.wait_for_update().await;
+
         let width = utils.root().child(0).unwrap().layout().unwrap().width;
         assert_eq!(width, 10.0);
     }

--- a/hooks/src/use_focus.rs
+++ b/hooks/src/use_focus.rs
@@ -35,7 +35,7 @@ pub fn use_init_focus(cx: &ScopeState) {
 mod test {
     use crate::{use_focus, use_init_focus};
     use freya::prelude::*;
-    use freya_testing::{launch_test, FreyaEvent, MouseButton};
+    use freya_testing::{launch_test_with_config, FreyaEvent, MouseButton, TestingConfig};
 
     #[tokio::test]
     pub async fn track_focus() {
@@ -66,10 +66,13 @@ mod test {
             )
         }
 
-        let mut utils = launch_test(use_focus_app);
+        let mut utils = launch_test_with_config(
+            use_focus_app,
+            TestingConfig::default().with_size((100.0, 100.0).into()),
+        );
 
         // Initial state
-        utils.wait_for_work((100.0, 100.0));
+        utils.wait_for_update().await;
         let root = utils.root().child(0).unwrap();
         assert_eq!(
             root.child(0).unwrap().child(0).unwrap().text(),
@@ -88,7 +91,7 @@ mod test {
         });
 
         // First rect is now focused
-        utils.wait_for_update((100.0, 100.0)).await;
+        utils.wait_for_update().await;
         assert_eq!(
             root.child(0).unwrap().child(0).unwrap().text(),
             Some("true")
@@ -106,7 +109,7 @@ mod test {
         });
 
         // Second rect is now focused
-        utils.wait_for_update((100.0, 100.0)).await;
+        utils.wait_for_update().await;
         assert_eq!(
             root.child(0).unwrap().child(0).unwrap().text(),
             Some("false")

--- a/hooks/src/use_node.rs
+++ b/hooks/src/use_node.rs
@@ -39,7 +39,7 @@ pub fn use_node(cx: &ScopeState) -> (AttributeValue, NodeReferenceLayout) {
 mod test {
     use crate::use_node;
     use freya::prelude::*;
-    use freya_testing::launch_test;
+    use freya_testing::{launch_test_with_config, TestingConfig};
 
     #[tokio::test]
     pub async fn track_size() {
@@ -56,16 +56,20 @@ mod test {
             )
         }
 
-        let mut utils = launch_test(use_node_app);
+        let mut utils = launch_test_with_config(
+            use_node_app,
+            TestingConfig::default().with_size((500.0, 800.0).into()),
+        );
 
-        utils.wait_for_update((500.0, 800.0)).await;
+        utils.wait_for_update().await;
         let root = utils.root().child(0).unwrap();
         assert_eq!(
             root.child(0).unwrap().text().unwrap().parse::<f32>(),
             Ok(500.0 * 0.5)
         );
 
-        utils.wait_for_update((300.0, 800.0)).await;
+        utils.set_config(TestingConfig::default().with_size((300.0, 800.0).into()));
+        utils.wait_for_update().await;
 
         let root = utils.root().child(0).unwrap();
         assert_eq!(

--- a/hooks/tests/use_editable.rs
+++ b/hooks/tests/use_editable.rs
@@ -61,8 +61,8 @@ pub async fn multiple_lines_single_editor() {
         button: Some(MouseButton::Left),
     });
 
-    utils.wait_for_update((500.0, 500.0)).await;
-    utils.wait_for_update((500.0, 500.0)).await;
+    utils.wait_for_update().await;
+    utils.wait_for_update().await;
 
     // Cursor has been moved
     let root = utils.root().child(0).unwrap();
@@ -81,7 +81,7 @@ pub async fn multiple_lines_single_editor() {
         modifiers: Modifiers::empty(),
     });
 
-    utils.wait_for_update((500.0, 500.0)).await;
+    utils.wait_for_update().await;
 
     // Text and cursor have changed
     let cursor = root.child(1).unwrap().child(0).unwrap();
@@ -163,8 +163,8 @@ pub async fn single_line_mulitple_editors() {
         button: Some(MouseButton::Left),
     });
 
-    utils.wait_for_update((500.0, 500.0)).await;
-    utils.wait_for_update((500.0, 500.0)).await;
+    utils.wait_for_update().await;
+    utils.wait_for_update().await;
 
     // Cursor has been moved
     let root = utils.root().child(0).unwrap();
@@ -183,7 +183,7 @@ pub async fn single_line_mulitple_editors() {
         modifiers: Modifiers::empty(),
     });
 
-    utils.wait_for_update((500.0, 500.0)).await;
+    utils.wait_for_update().await;
 
     // Text and cursor have changed
     let cursor = root.child(2).unwrap().child(0).unwrap();

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -33,6 +33,7 @@ futures = "0.3.25"
 rustc-hash = "1.1.0"
 anymap = "0.12.1"
 skia-safe = { version = "0.60.0", features = ["gl", "textlayout", "svg"] }
+euclid = "0.22.7"
 
 [dev-dependencies]
 freya-components ={ path = "../components"}

--- a/testing/src/config.rs
+++ b/testing/src/config.rs
@@ -1,0 +1,46 @@
+use std::time::Duration;
+
+use euclid::Size2D;
+
+/// Configuration for a [`TestingHandler`].
+pub struct TestingConfig {
+    vdom_timeout: Duration,
+    size: Size2D<f32, f32>,
+}
+
+impl Default for TestingConfig {
+    fn default() -> Self {
+        Self {
+            vdom_timeout: Duration::from_millis(16),
+            size: Size2D::from((500.0, 500.0)),
+        }
+    }
+}
+
+impl TestingConfig {
+    pub fn new() -> Self {
+        TestingConfig::default()
+    }
+
+    /// Specify a custom canvas size.
+    pub fn with_size(mut self, size: Size2D<f32, f32>) -> Self {
+        self.size = size;
+        self
+    }
+
+    /// Specify a custom duration for the VirtualDOM polling timeout, default is 16ms.
+    pub fn with_vdom_timeout(mut self, vdom_timeout: Duration) -> Self {
+        self.vdom_timeout = vdom_timeout;
+        self
+    }
+
+    /// Get the canvas size.
+    pub fn size(&self) -> Size2D<f32, f32> {
+        self.size
+    }
+
+    /// Get the VirtualDOM polling timeout.
+    pub fn vdom_timeout(&self) -> Duration {
+        self.vdom_timeout
+    }
+}

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -162,7 +162,11 @@ impl TestingHandler {
 
         let mutations = self.vdom.render_immediate();
 
-        let (must_repaint, _) = self.utils.dom.get_mut().apply_mutations(mutations, SCALE_FACTOR as f32);
+        let (must_repaint, _) = self
+            .utils
+            .dom
+            .get_mut()
+            .apply_mutations(mutations, SCALE_FACTOR as f32);
         self.wait_for_work(self.config.size());
         must_repaint
     }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -5,6 +5,7 @@ use dioxus_native_core::node::NodeType;
 use dioxus_native_core::real_dom::RealDom;
 use dioxus_native_core::tree::TreeView;
 use dioxus_native_core::NodeId;
+use euclid::Size2D;
 use freya_common::NodeArea;
 use freya_core::events::EventsProcessor;
 use freya_core::{events::DomEvent, EventEmitter, EventReceiver};
@@ -19,6 +20,11 @@ use tokio::sync::mpsc::unbounded_channel;
 
 pub use freya_core::events::FreyaEvent;
 pub use freya_elements::events::mouse::MouseButton;
+use tokio::time::timeout;
+
+pub use config::*;
+
+mod config;
 
 #[derive(Clone)]
 pub struct TestUtils {
@@ -121,12 +127,19 @@ pub struct TestingHandler {
     events_processor: EventsProcessor,
     font_collection: FontCollection,
     viewports: ViewportsCollection,
+
+    config: TestingConfig,
 }
 
 impl TestingHandler {
+    /// Replace the current [`TestingConfig`].
+    pub fn set_config(&mut self, config: TestingConfig) {
+        self.config = config;
+    }
+
     /// Wait and apply new changes
-    pub async fn wait_for_update(&mut self, sizes: (f32, f32)) -> bool {
-        self.wait_for_work(sizes);
+    pub async fn wait_for_update(&mut self) -> bool {
+        self.wait_for_work(self.config.size());
 
         let vdom = &mut self.vdom;
 
@@ -141,32 +154,24 @@ impl TestingHandler {
             }
         }
 
-        vdom.wait_for_work().await;
+        timeout(self.config.vdom_timeout(), vdom.wait_for_work())
+            .await
+            .ok();
 
         let mutations = self.vdom.render_immediate();
 
         let (must_repaint, _) = self.utils.dom.get_mut().apply_mutations(mutations);
-        self.wait_for_work(sizes);
+        self.wait_for_work(self.config.size());
         must_repaint
     }
 
-    /// Wait until there are no more changes to be applied
-    pub async fn wait_until_cleanup(&mut self, sizes: (f32, f32)) {
-        loop {
-            let must_repaint = self.wait_for_update(sizes).await;
-            if !must_repaint {
-                break;
-            }
-        }
-    }
-
     /// Wait for layout and events to be processed
-    pub fn wait_for_work(&mut self, sizes: (f32, f32)) {
+    pub fn wait_for_work(&mut self, size: Size2D<f32, f32>) {
         let (layers, viewports) = process_layout(
             &self.utils.dom.get(),
             NodeArea {
-                width: sizes.0,
-                height: sizes.1,
+                width: size.width,
+                height: size.height,
                 x: 0.0,
                 y: 0.0,
             },
@@ -211,6 +216,11 @@ impl TestingHandler {
 
 /// Run a Component in a headless testing environment
 pub fn launch_test(root: Component<()>) -> TestingHandler {
+    launch_test_with_config(root, TestingConfig::default())
+}
+
+/// Run a Component in a headless testing environment
+pub fn launch_test_with_config(root: Component<()>, config: TestingConfig) -> TestingHandler {
     let mut vdom = VirtualDom::new(root);
     let mutations = vdom.rebuild();
 
@@ -233,5 +243,6 @@ pub fn launch_test(root: Component<()>) -> TestingHandler {
         event_receiver,
         viewports: FxHashMap::default(),
         utils: TestUtils { dom, layers },
+        config,
     }
 }

--- a/testing/tests/test.rs
+++ b/testing/tests/test.rs
@@ -45,7 +45,7 @@ async fn with_state() {
 
     assert_eq!(label.child(0).unwrap().text(), Some("Is enabled? false"));
 
-    utils.wait_for_update((300.0, 300.0)).await;
+    utils.wait_for_update().await;
 
     assert_eq!(label.child(0).unwrap().text(), Some("Is enabled? true"));
 }
@@ -61,7 +61,7 @@ async fn check_size() {
 
     let mut utils = launch_test(stateful_app);
 
-    utils.wait_for_work((500.0, 500.0));
+    utils.wait_for_update().await;
 
     let rect = utils.root().child(0).unwrap();
 
@@ -95,7 +95,7 @@ async fn simulate_events() {
     let label = rect.child(0).unwrap();
 
     // Render initial layout
-    utils.wait_for_work((500.0, 500.0));
+    utils.wait_for_update().await;
 
     let text = label.child(0).unwrap();
 
@@ -108,7 +108,7 @@ async fn simulate_events() {
     });
 
     // Render new layout after having it clicked
-    utils.wait_for_update((500.0, 500.0)).await;
+    utils.wait_for_update().await;
 
     let text = label.child(0).unwrap();
 


### PR DESCRIPTION
- new `TestingConfig` to simplify the configuration of the `TestingHandler`
- timeout the vdom polling, 16ms by default