### PR TITLE
fix: Space is inserted twice when using the shift modifier

### DIFF
--- a/elements/src/events/keyboard.rs
+++ b/elements/src/events/keyboard.rs
@@ -98,7 +98,7 @@ pub fn get_non_text_keys(key: &VirtualKeyCode) -> Key {
         VirtualKeyCode::Down => Key::ArrowDown,
         VirtualKeyCode::Back => Key::Backspace,
         VirtualKeyCode::Return => Key::Enter,
-        VirtualKeyCode::Space => Key::Character(" ".to_string()),
+        VirtualKeyCode::Space => Key::Unidentified,
         VirtualKeyCode::Compose => Key::Compose,
         VirtualKeyCode::Caret => Key::Unidentified,
         VirtualKeyCode::Numlock => Key::NumLock,


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/181