### PR TITLE
feat: HSL color support

### DIFF
--- a/book/src/guides/style.md
+++ b/book/src/guides/style.md
@@ -99,10 +99,12 @@ The attributes that have colors as values can use the following syntax:
 - `orange`
 - `transparent`
 
-#### rgb() / rgba()
+#### rgb() / hsl()
 
 - With RGB: `rgb(150, 60, 20)`
-- With RGBA: `rgba(30, 50, 200, 70)`
+- With RGB and alpha: `rgb(150, 60, 20, 70)`
+- With HSL: `hsl(28, 0.8, 0.5)`
+- With HSL and alpha: `hsl(28, 0.8, 0.5, 0.25)`
 
 ### Inheritance
 

--- a/state/src/values/color.rs
+++ b/state/src/values/color.rs
@@ -1,5 +1,5 @@
 use crate::Parse;
-use skia_safe::Color;
+use skia_safe::{Color, HSV};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ParseColorError;
@@ -18,7 +18,13 @@ impl Parse for Color {
             "white" => Ok(Color::WHITE),
             "orange" => Ok(Color::from_rgb(255, 165, 0)),
             "transparent" => Ok(Color::TRANSPARENT),
-            _ => parse_rgb(value),
+            _ => {
+                if value.starts_with("hsl") {
+                    parse_hsl(value)
+                } else {
+                    parse_rgb(value)
+                }
+            }
         }
     }
 }
@@ -52,5 +58,57 @@ fn parse_rgb(color: &str) -> Result<Color, ParseColorError> {
         Ok(Color::from_argb(a, r, g, b))
     } else {
         Ok(Color::from_rgb(r, g, b))
+    }
+}
+
+fn parse_hsl(color: &str) -> Result<Color, ParseColorError> {
+    let color = color.replace("hsl(", "").replace(')', "");
+    let mut colors = color.split(',');
+
+    // Get each color component
+    let h = colors.next()
+        .ok_or(ParseColorError)?
+        .trim().replace("deg", "")
+        .parse::<f32>()
+        .map_err(|_| ParseColorError)?;
+    let s_str = colors.next().ok_or(ParseColorError)?.trim();
+    let l_str = colors.next().ok_or(ParseColorError)?.trim();
+    let a_str: Option<&str> = colors.next();
+
+    // S, L and A can end in percentage, otherwise its 0.0 - 1.0
+    let mut s = if s_str.ends_with("%") {
+        s_str.replace("%", "").parse::<f32>().map_err(|_| ParseColorError)? / 100.0
+    } else {
+        s_str.parse::<f32>().map_err(|_| ParseColorError)?
+    };
+
+    let mut l = if l_str.ends_with("%") {
+        l_str.replace("%", "").parse::<f32>().map_err(|_| ParseColorError)? / 100.0
+    } else {
+        l_str.parse::<f32>().map_err(|_| ParseColorError)?
+    };
+
+    // HSL to HSV Conversion
+    l *= 2.0;
+    s *= if l <= 1.0 {
+        l
+    } else {
+        2.0 - l
+    };
+    let v = (l + s) / 2.0;
+    s = (2.0 * s) / (l + s);
+    let hsv = HSV { h, s, v };
+
+    // Handle alpha formatting and convert to ARGB
+    if let Some(a_str) = a_str {
+        let a = if a_str.ends_with("%") {
+            a_str.trim().replace("%", "").parse::<f32>().map_err(|_| ParseColorError)? / 100.0
+        } else {
+            a_str.trim().parse::<f32>().map_err(|_| ParseColorError)?
+        };
+
+        Ok(hsv.to_color((a * 255.0).round() as u8))
+    } else {
+        Ok(hsv.to_color(255))
     }
 }

--- a/state/src/values/color.rs
+++ b/state/src/values/color.rs
@@ -19,10 +19,12 @@ impl Parse for Color {
             "orange" => Ok(Color::from_rgb(255, 165, 0)),
             "transparent" => Ok(Color::TRANSPARENT),
             _ => {
-                if value.starts_with("hsl") {
+                if value.starts_with("hsl(") {
                     parse_hsl(value)
-                } else {
+                } else if value.starts_with("rgb(") {
                     parse_rgb(value)
+                } else {
+                    Err(ParseColorError)
                 }
             }
         }
@@ -30,8 +32,13 @@ impl Parse for Color {
 }
 
 fn parse_rgb(color: &str) -> Result<Color, ParseColorError> {
-    let color = color.replace("rgb(", "").replace(')', "");
+    if !color.ends_with(")") {
+        return Err(ParseColorError)
+    }
+
+    let color = color.replacen("rgb(", "", 1).replacen(")", "", 1);
     let mut colors = color.split(',');
+
 
     let r = colors
         .next()
@@ -62,7 +69,11 @@ fn parse_rgb(color: &str) -> Result<Color, ParseColorError> {
 }
 
 fn parse_hsl(color: &str) -> Result<Color, ParseColorError> {
-    let color = color.replace("hsl(", "").replace(')', "");
+    if !color.ends_with(")") {
+        return Err(ParseColorError)
+    }
+
+    let color = color.replacen("hsl(", "", 1).replacen(")", "", 1);
     let mut colors = color.split(',');
 
     // Get each color component

--- a/state/tests/parse_color.rs
+++ b/state/tests/parse_color.rs
@@ -20,3 +20,26 @@ fn parse_hsl_color() {
 
     assert_eq!(color, color_pct);
 }
+
+#[test]
+fn invalid_colors() {
+    let incorrect_name = Color::parse("wow(0, 0, 0)");
+    let extra_lparen = Color::parse("rgb((0, 0, 0)");
+    let extra_rparen = Color::parse("rgb(0, 0, 0))");
+    let missing_lparen = Color::parse("rgb0, 0, 0)");
+    let missing_rparen = Color::parse("rgb(0, 0, 0");
+    let missing_commas = Color::parse("rgb(0 0 0)");
+    let extra_commas = Color::parse("rgb(0,, 0, 0)");
+    let extra_ending_commas = Color::parse("rgb(0, 0, 0,)");
+    let bad_unit = Color::parse("hsl(28in, 0.4, 0.25, 50%);");
+
+    assert_eq!(incorrect_name.is_err(), true);
+    assert_eq!(extra_lparen.is_err(), true);
+    assert_eq!(extra_rparen.is_err(), true);
+    assert_eq!(missing_lparen.is_err(), true);
+    assert_eq!(missing_rparen.is_err(), true);
+    assert_eq!(missing_commas.is_err(), true);
+    assert_eq!(extra_commas.is_err(), true);
+    assert_eq!(extra_ending_commas.is_err(), true);
+    assert_eq!(bad_unit.is_err(), true);
+}

--- a/state/tests/parse_color.rs
+++ b/state/tests/parse_color.rs
@@ -9,6 +9,14 @@ fn parse_manual_color() {
 
 #[test]
 fn parse_rgb_color() {
-    let color = Color::parse("rgb(91, 123, 57");
+    let color = Color::parse("rgb(91, 123, 57)");
     assert_eq!(color, Ok(Color::from_rgb(91, 123, 57)));
+}
+
+#[test]
+fn parse_hsl_color() {
+    let color = Color::parse("hsl(28, 0.8, 0.5, 0.25)").unwrap();
+    let color_pct = Color::parse("hsl(28deg, 80%, 50%, 25%)").unwrap();
+
+    assert_eq!(color, color_pct);
 }


### PR DESCRIPTION
Adds support for `hsl` colors in addition to the current `rgb` colors. These offer a more human-readable way to interpret sRGB colors, and offers a nice opportunity for making color systems based on hue. Two versions of the syntax are supported (same as CSS):
- Unitless (S/L/A components are 0.0-1.0): `hsl(28, 0.8, 0.5, 0.25)`
- Units (S/L/A components are 0% - 100%): `hsl(28deg, 80%, 50%, 25%)`

In the future, i'd like to also explore raw hex values (e.g. `#fff`) and wider color spaces than just SRGB (far future).