### PR TITLE
refactor(breaking): Consistency for rotation units

### DIFF
--- a/book/src/guides/effects.md
+++ b/book/src/guides/effects.md
@@ -14,7 +14,7 @@ Example:
 fn app(cx: Scope) -> Element {
     render!(
         label {
-            rotate: "180",
+            rotate: "180deg",
             "Hello, World!"
         }
     )

--- a/book/src/guides/style.md
+++ b/book/src/guides/style.md
@@ -140,8 +140,8 @@ The attributes that have colors as values can use the following syntax:
 
 - With RGB: `rgb(150, 60, 20)`
 - With RGB and alpha: `rgb(150, 60, 20, 70)`
-- With HSL: `hsl(28, 0.8, 0.5)`
-- With HSL and alpha: `hsl(28, 0.8, 0.5, 0.25)`
+- With HSL: `hsl(28deg, 80%, 50%)`
+- With HSL and alpha: `hsl(28deg, 80%, 50%, 25%)`
 
 ### Inheritance
 

--- a/components/src/loader.rs
+++ b/components/src/loader.rs
@@ -40,7 +40,7 @@ pub fn Loader(cx: Scope<LoaderProps>) -> Element {
     });
 
     render!(svg {
-        rotate: "{degrees}",
+        rotate: "{degrees}deg",
         width: "31",
         height: "31",
         svg_content: r#"

--- a/examples/i18n.rs
+++ b/examples/i18n.rs
@@ -4,8 +4,8 @@
 )]
 
 use dioxus_std::{
-    i18n::{use_i18, Language, use_init_i18n},
-    translate
+    i18n::{use_i18, use_init_i18n, Language},
+    translate,
 };
 use freya::prelude::*;
 use std::str::FromStr;
@@ -54,11 +54,16 @@ fn Body(cx: Scope) -> Element {
 }
 
 fn app(cx: Scope) -> Element {
-    use_init_i18n(cx, "en-US".parse().unwrap(), "en-US".parse().unwrap(), || {
-        let en_us = Language::from_str(EN_US).unwrap();
-        let es_es = Language::from_str(ES_ES).unwrap();
-        vec![en_us, es_es]
-    });
+    use_init_i18n(
+        cx,
+        "en-US".parse().unwrap(),
+        "en-US".parse().unwrap(),
+        || {
+            let en_us = Language::from_str(EN_US).unwrap();
+            let es_es = Language::from_str(ES_ES).unwrap();
+            vec![en_us, es_es]
+        },
+    );
 
     render!(Body {})
 }

--- a/examples/rotate.rs
+++ b/examples/rotate.rs
@@ -54,21 +54,21 @@ fn app(cx: Scope) -> Element {
             width: "100%",
             height: "100%",
             rect {
-                rotate: "{degrees.0}",
+                rotate: "{degrees.0}deg",
                 background: "rgb(65, 53, 67)",
                 width: "250",
                 height: "250",
                 direction: "both",
                 display: "center",
                 rect {
-                    rotate: "{degrees.1}",
+                    rotate: "{degrees.1}deg",
                     background: "rgb(143, 67, 238)",
                     width: "180",
                     height: "180",
                     direction: "both",
                     display: "center",
                     rect {
-                        rotate: "{degrees.2}",
+                        rotate: "{degrees.2}deg",
                         background: "rgb(240, 235, 141)",
                         width: "100",
                         height: "100"

--- a/state/src/transform.rs
+++ b/state/src/transform.rs
@@ -41,8 +41,10 @@ impl State<CustomAttributeValues> for Transform {
                 match attr.attribute.name.as_str() {
                     "rotate" => {
                         if let Some(value) = attr.value.as_text() {
-                            if let Ok(degs) = value.parse::<f32>() {
-                                rotate_degs = Some(degs)
+                            if value.ends_with("deg") {
+                                if let Ok(degs) = value.replacen("deg", "", 1).parse::<f32>() {
+                                    rotate_degs = Some(degs)
+                                }
                             }
                         }
                     }

--- a/state/src/values/color.rs
+++ b/state/src/values/color.rs
@@ -127,7 +127,11 @@ fn parse_hsl(color: &str) -> Result<Color, ParseColorError> {
     let a_str: Option<&str> = colors.next();
 
     // Ensure correct units and lengths.
-    if colors.next().is_some() || !h_str.ends_with("deg") || !s_str.ends_with('%') || !l_str.ends_with('%') {
+    if colors.next().is_some()
+        || !h_str.ends_with("deg")
+        || !s_str.ends_with('%')
+        || !l_str.ends_with('%')
+    {
         return Err(ParseColorError);
     }
 

--- a/state/src/values/color.rs
+++ b/state/src/values/color.rs
@@ -120,43 +120,32 @@ fn parse_hsl(color: &str) -> Result<Color, ParseColorError> {
     let color = color.replacen("hsl(", "", 1).replacen(')', "", 1);
     let mut colors = color.split(',');
 
-    // Get each color component
-    let h = colors
-        .next()
-        .ok_or(ParseColorError)?
-        .trim()
-        .replace("deg", "")
-        .parse::<f32>()
-        .map_err(|_| ParseColorError)?;
+    // Get each color component as a string
+    let h_str = colors.next().ok_or(ParseColorError)?.trim();
     let s_str = colors.next().ok_or(ParseColorError)?.trim();
     let l_str = colors.next().ok_or(ParseColorError)?.trim();
     let a_str: Option<&str> = colors.next();
 
-    // There should not be more than 4 components.
-    if colors.next().is_some() {
+    // Ensure correct units and lengths.
+    if colors.next().is_some() || !h_str.ends_with("deg") || !s_str.ends_with('%') || !l_str.ends_with('%') {
         return Err(ParseColorError);
     }
 
     // S, L and A can end in percentage, otherwise its 0.0 - 1.0
-    let mut s = if s_str.ends_with('%') {
-        s_str
-            .replace('%', "")
-            .parse::<f32>()
-            .map_err(|_| ParseColorError)?
-            / 100.0
-    } else {
-        s_str.parse::<f32>().map_err(|_| ParseColorError)?
-    };
-
-    let mut l = if l_str.ends_with('%') {
-        l_str
-            .replace('%', "")
-            .parse::<f32>()
-            .map_err(|_| ParseColorError)?
-            / 100.0
-    } else {
-        l_str.parse::<f32>().map_err(|_| ParseColorError)?
-    };
+    let h = h_str
+        .replacen("deg", "", 1)
+        .parse::<f32>()
+        .map_err(|_| ParseColorError)?;
+    let mut s = s_str
+        .replacen('%', "", 1)
+        .parse::<f32>()
+        .map_err(|_| ParseColorError)?
+        / 100.0;
+    let mut l = l_str
+        .replacen('%', "", 1)
+        .parse::<f32>()
+        .map_err(|_| ParseColorError)?
+        / 100.0;
 
     // HSL to HSV Conversion
     l *= 2.0;
@@ -167,16 +156,16 @@ fn parse_hsl(color: &str) -> Result<Color, ParseColorError> {
 
     // Handle alpha formatting and convert to ARGB
     if let Some(a_str) = a_str {
-        let a = if a_str.ends_with('%') {
-            a_str
-                .trim()
-                .replace('%', "")
-                .parse::<f32>()
-                .map_err(|_| ParseColorError)?
-                / 100.0
-        } else {
-            a_str.trim().parse::<f32>().map_err(|_| ParseColorError)?
-        };
+        if !s_str.ends_with('%') {
+            return Err(ParseColorError);
+        }
+
+        let a = a_str
+            .trim()
+            .replace('%', "")
+            .parse::<f32>()
+            .map_err(|_| ParseColorError)?
+            / 100.0;
 
         Ok(hsv.to_color((a * 255.0).round() as u8))
     } else {

--- a/state/tests/parse_color.rs
+++ b/state/tests/parse_color.rs
@@ -15,10 +15,7 @@ fn parse_rgb_color() {
 
 #[test]
 fn parse_hsl_color() {
-    let color = Color::parse("hsl(28, 0.8, 0.5, 0.25)").unwrap();
-    let color_pct = Color::parse("hsl(28deg, 80%, 50%, 25%)").unwrap();
-
-    assert_eq!(color, color_pct);
+    _ = Color::parse("hsl(28deg, 80%, 50%, 25%)").unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This is an initial fix-up of some inconsistencies in freya's styling values.
- Removes the "unitless" form of `hsl` colors (`hsl(45, 0.5, 0.1, 0.2, 0.3)`), instead preferring the more explicit `hsl(45deg, 50%, 10%, 20%, 30%)` syntax.
- Makes `rotate` attribute use `deg` units.

This makes it consistent with the required units in `linear-gradient`. Let me know if any of this needs further discussion or whatnot.