### PR TITLE
Virtual scroll rework

### DIFF
--- a/crates/components/src/scroll_views/mod.rs
+++ b/crates/components/src/scroll_views/mod.rs
@@ -55,10 +55,10 @@ pub fn get_scrollbar_pos_and_size(
         inner_size
     } else {
         let viewable_ratio_height = viewport_size / inner_size;
-        viewport_size * viewable_ratio_height
+        (viewport_size * viewable_ratio_height).max(30.0)
     };
-    let scroll_position = (100.0 / inner_size) * -scroll_position;
-    let scrollbar_position = (scroll_position / 100.0) * viewport_size;
+    let scroll_position = (100.0 / (inner_size-viewport_size)) * -scroll_position;
+    let scrollbar_position = (scroll_position / 100.0) * (viewport_size - scrollbar_height);
     (scrollbar_position, scrollbar_height)
 }
 

--- a/crates/components/src/scroll_views/virtual_scroll_view.rs
+++ b/crates/components/src/scroll_views/virtual_scroll_view.rs
@@ -22,10 +22,9 @@ type BuilderFunction<'a, T> = dyn Fn(
     ),
 ) -> LazyNodes<'a, 'a>;
 
-#[derive(Clone)]
 pub enum ItemSize {
     Fixed(f32),
-    PerItem(Arc<dyn Fn(usize) -> f32>),
+    PerItem(Box<dyn Fn(usize) -> f32>),
     Dynamic,
 }
 

--- a/crates/components/src/scroll_views/virtual_scroll_view.rs
+++ b/crates/components/src/scroll_views/virtual_scroll_view.rs
@@ -1,13 +1,17 @@
+use std::ops::Range;
+use std::sync::Arc;
+
 use dioxus::prelude::*;
+use freya_common::NodeReferenceLayout;
+
 use freya_elements::elements as dioxus_elements;
 use freya_elements::events::{keyboard::Key, KeyboardEvent, MouseEvent, WheelEvent};
 use freya_hooks::{use_focus, use_node};
-use std::ops::Range;
 
 use crate::{
-    get_container_size, get_corrected_scroll_position, get_scroll_position_from_cursor,
-    get_scroll_position_from_wheel, get_scrollbar_pos_and_size, is_scrollbar_visible,
-    manage_key_event, Axis, ScrollBar, ScrollThumb, SCROLLBAR_SIZE, SCROLL_SPEED_MULTIPLIER,
+    Axis, get_container_size, get_corrected_scroll_position,
+    get_scroll_position_from_cursor, get_scroll_position_from_wheel, get_scrollbar_pos_and_size,
+    is_scrollbar_visible, manage_key_event, SCROLL_SPEED_MULTIPLIER, ScrollBar, SCROLLBAR_SIZE, ScrollThumb,
 };
 
 type BuilderFunction<'a, T> = dyn Fn(
@@ -19,13 +23,332 @@ type BuilderFunction<'a, T> = dyn Fn(
     ),
 ) -> LazyNodes<'a, 'a>;
 
+#[derive(Clone)]
+pub enum ItemSize {
+    Fixed(f32),
+    PerItem(Arc<dyn Fn(usize) -> f32>),
+    Dynamic,
+}
+
+#[derive(Debug)]
+enum Node {
+    LeafRange(LeafRangeNode),
+    Leaf(LeafNode),
+    Inner(InnerNode),
+}
+
+#[derive(Debug)]
+struct LeafNode {
+    index: usize,
+    size: f32,
+}
+
+#[derive(Debug)]
+struct LeafRangeNode {
+    range: Range<usize>,
+}
+
+#[derive(Debug)]
+struct InnerNode {
+    range: Range<usize>,
+    total_real_size: f32,
+    range_node_count: usize,
+    children: Vec<Node>,
+}
+
+#[derive(Debug)]
+struct SizeCache {
+    nodes: Vec<Node>,
+    chunk_size: usize,
+}
+
+impl Node {
+    fn contains_index(&self, index: usize) -> bool {
+        match self {
+            Node::LeafRange(node) => {
+                node.range.contains(&index)
+            }
+            Node::Leaf(node) => {
+                node.index == index
+            }
+            Node::Inner(node) => {
+                node.range.contains(&index)
+            }
+        }
+    }
+
+    fn is_inner(&self) -> bool {
+        match self {
+            Node::Inner(_) => true,
+            _ => false
+        }
+    }
+
+    fn is_leaf(&self) -> bool {
+        match self {
+            Node::Leaf(_) => true,
+            _ => false
+        }
+    }
+
+    fn is_leaf_range(&self) -> bool {
+        match self {
+            Node::LeafRange(_) => true,
+            _ => false
+        }
+    }
+
+    fn as_inner(&self) -> Option<&InnerNode> {
+        match self {
+            Node::Inner(inner) => Some(inner),
+            _ => None
+        }
+    }
+
+    fn as_leaf_range(&self) -> Option<&LeafRangeNode> {
+        match self {
+            Node::LeafRange(leaf_range) => Some(leaf_range),
+            _ => None
+        }
+    }
+
+    fn as_inner_mut(&mut self) -> Option<&mut InnerNode> {
+        match self {
+            Node::Inner(inner) => Some(inner),
+            _ => None
+        }
+    }
+
+    fn as_leaf_mut(&mut self) -> Option<&mut LeafNode> {
+        match self {
+            Node::Leaf(leaf) => Some(leaf),
+            _ => None
+        }
+    }
+
+    fn as_leaf_range_mut(&mut self) -> Option<&mut LeafRangeNode> {
+        match self {
+            Node::LeafRange(leaf_range) => Some(leaf_range),
+            _ => None
+        }
+    }
+}
+
+impl LeafRangeNode {
+    fn insert(&mut self, index: usize, value: f32) -> (LeafNode, Option<LeafRangeNode>) {
+        assert!(self.range.contains(&index));
+        let end = self.range.end;
+        self.range.end = index;
+        (LeafNode {
+            size: value,
+            index,
+        }, if index+1 < end {
+            Some(LeafRangeNode {
+                range: index + 1..end,
+            })
+        } else {
+            None
+        })
+    }
+}
+
+impl InnerNode {
+    fn insert(&mut self, index: usize, value: f32, chunk_size: usize) -> bool {
+        assert!(self.range.contains(&index));
+        let child_index = self.children.iter().enumerate().find(|(_, node)| {
+            node.contains_index(index)
+        }).unwrap().0;
+
+        if self.children[child_index].is_inner() {
+            let node = self.children[child_index].as_inner_mut().unwrap();
+            let old_size = node.total_real_size;
+            let old_range_count = node.range_node_count;
+            let dirty = node.insert(index, value, chunk_size);
+            self.total_real_size += node.total_real_size - old_size;
+            self.range_node_count += node.range_node_count;
+            self.range_node_count -= old_range_count;
+            dirty
+        } else if self.children[child_index].is_leaf() {
+            let node = self.children[child_index].as_leaf_mut().unwrap();
+            let old_size = node.size;
+            let dirty = node.size != value;
+            node.size = value;
+            self.total_real_size += value - old_size;
+            dirty
+        } else if self.children[child_index].is_leaf_range() {
+            let node = self.children[child_index].as_leaf_range_mut().unwrap();
+            let old_start = node.range.start;
+            let old_end = node.range.end;
+            let (leaf, leaf_range) = node.insert(index, value);
+            let has_leaf_range = leaf_range.is_some();
+            self.total_real_size += value;
+            let additional_leaf_range_count = if has_leaf_range { 1 } else { 0 };
+            self.range_node_count -= 1;
+            if self.children.len() + 1 + additional_leaf_range_count <= chunk_size {
+                self.children.insert(child_index + 1, Node::Leaf(leaf));
+                if has_leaf_range {
+                    self.children.insert(child_index + 2, Node::LeafRange(leaf_range.unwrap()));
+                }
+                if self.children[child_index].as_leaf_range_mut().unwrap().range.len() == 0 {
+                    self.children.remove(child_index);
+                }
+            } else {
+                let node = std::mem::replace(&mut self.children[child_index], Node::Inner(InnerNode {
+                    range: old_start..old_end,
+                    total_real_size: value,
+                    range_node_count: old_end-old_start-1,
+                    children: vec![],
+                }));
+                let new_node = self.children[child_index].as_inner_mut().unwrap();
+                if node.as_leaf_range().unwrap().range.len() != 0 {
+                    new_node.children.push(node);
+                }
+                new_node.children.push(Node::Leaf(leaf));
+                if has_leaf_range {
+                    new_node.children.push(Node::LeafRange(leaf_range.unwrap()));
+                }
+            }
+            true
+        } else {
+            unreachable!()
+        }
+    }
+
+    fn get_total_size(&self, range_size: f32) -> f32 {
+        self.total_real_size + self.range_node_count as f32 * range_size
+    }
+
+    fn largest_less_than(&self, value: f32, range_size: f32) -> (usize, f32) {
+        let total_size = self.get_total_size(range_size);
+        assert!(total_size >= value);
+        let mut total = 0.0;
+        let mut index = None;
+        for (i, node) in self.children.iter().enumerate() {
+            let size = match node {
+                Node::LeafRange(v) => {
+                    v.range.len() as f32 * range_size
+                }
+                Node::Leaf(v) => {
+                    v.size
+                }
+                Node::Inner(v) => {
+                    v.get_total_size(range_size)
+                }
+            };
+            if total + size > value {
+                index = Some(i);
+                break;
+            } else {
+                total += size;
+            }
+        }
+        let remaining = value - total;
+        if let Some(index) = index {
+            match &self.children[index] {
+                Node::LeafRange(v) => {
+                    (v.range.start + (remaining / range_size).floor() as usize, remaining)
+                }
+                Node::Leaf(v) => { (v.index, remaining) }
+                Node::Inner(v) => { v.largest_less_than(remaining, range_size) }
+            }
+        } else {
+            (self.range.end, remaining)
+        }
+    }
+}
+
+impl SizeCache {
+    fn new(length: usize, item_size: &ItemSize, chunk_size: Option<usize>) -> Self {
+        let chunk_size = if let Some(size) = chunk_size {
+            size
+        } else {
+            100
+        };
+        let mut tree = SizeCache {
+            chunk_size,
+            nodes: vec![Node::Inner(InnerNode {
+                range: 0..length,
+                total_real_size: 0.0,
+                range_node_count: length,
+                children: vec![Node::LeafRange(LeafRangeNode {
+                    range: 0..length,
+                })],
+            })],
+        };
+        match item_size {
+            ItemSize::PerItem(func) => {
+                for i in 0..length {
+                    tree.insert(i, func(i));
+                }
+            }
+            _ => {}
+        }
+        tree
+    }
+
+    fn insert(&mut self, index: usize, size: f32) -> bool {
+        let root = self.nodes[0].as_inner_mut().unwrap();
+        root.insert(index, size, self.chunk_size)
+    }
+
+    fn get_covering_range(&self, offset: f32, viewport_size: f32, item_size: &ItemSize) -> (Range<usize>, f32) {
+        let root = self.nodes[0].as_inner().unwrap();
+        match item_size {
+            ItemSize::Dynamic => {
+                if root.range_node_count == root.range.len() {
+                    return (0..1.min(root.range.len()), 0.0);
+                }
+            }
+            _ => {}
+        }
+        let range_size = match item_size {
+            ItemSize::Fixed(size) => { *size }
+            ItemSize::PerItem(_) => { 0.0 }
+            ItemSize::Dynamic => {
+                root.total_real_size / (root.range.len() - root.range_node_count) as f32
+            }
+        };
+        let (start, render_offset) = if root.get_total_size(range_size) >= offset {
+            root.largest_less_than(offset, range_size)
+        } else {
+            (root.range.end, 0.0)
+        };
+        let end = if root.get_total_size(range_size) >= offset + viewport_size {
+            (root.largest_less_than(offset + viewport_size, range_size).0 + 1).min(root.range.len())
+        } else {
+            root.range.end
+        };
+        (start..end, render_offset)
+    }
+
+    fn get_total_size(&self, item_size: &ItemSize, viewport_size: f32) -> f32 {
+        let root = self.nodes[0].as_inner().unwrap();
+        match item_size {
+            ItemSize::Dynamic => {
+                if root.range_node_count == root.range.len() {
+                    return viewport_size;
+                }
+            }
+            _ => {}
+        }
+        let range_size = match item_size {
+            ItemSize::Fixed(size) => { *size }
+            ItemSize::PerItem(_) => { 0.0 }
+            ItemSize::Dynamic => {
+                root.total_real_size / (root.range.len() - root.range_node_count) as f32
+            }
+        };
+        root.get_total_size(range_size)
+    }
+}
+
 /// [`VirtualScrollView`] component properties.
 #[derive(Props)]
 pub struct VirtualScrollViewProps<'a, T: 'a> {
     /// Quantity of items in the VirtualScrollView.
     length: usize,
     /// Size of the items, height for vertical direction and width for horizontal.
-    item_size: f32,
+    item_size: ItemSize,
     /// The item builder function.
     builder: Box<BuilderFunction<'a, T>>,
     /// Custom values to pass to the builder function.
@@ -51,23 +374,32 @@ pub struct VirtualScrollViewProps<'a, T: 'a> {
     pub scroll_with_arrows: bool,
 }
 
-fn get_render_range(
-    viewport_size: f32,
-    scroll_position: f32,
-    item_size: f32,
-    item_length: f32,
-) -> Range<usize> {
-    let render_index_start = (-scroll_position) / item_size;
-    let potentially_visible_length = viewport_size / item_size;
-    let remaining_length = item_length - render_index_start;
 
-    let render_index_end = if remaining_length <= potentially_visible_length {
-        item_length
-    } else {
-        render_index_start + potentially_visible_length
-    };
+#[derive(Props)]
+struct WrapperProps<'a> {
+    node: VNode<'a>,
+    index: usize,
+    size_cache: &'a UseRef<SizeCache>,
+    direction: &'a String,
+}
 
-    render_index_start as usize..(render_index_end as usize)
+#[allow(non_snake_case)]
+fn Wrapper<'a>(cx: Scope<'a, WrapperProps<'a>>) -> Element {
+    let index = cx.props.index;
+    let (node, size) = use_node(cx);
+    if size != NodeReferenceLayout::default() {
+        if cx.props.size_cache.write_silent().insert(cx.props.index, if cx.props.direction == "horizontal" { size.inner.width } else { size.inner.height }) {
+            cx.props.size_cache.needs_update();
+        }
+    }
+
+    render!(
+        rect {
+            key: "{index+1}",
+            reference: node,
+            &cx.props.node
+        }
+    )
 }
 
 /// `VirtualScrollView` component.
@@ -109,6 +441,7 @@ pub fn VirtualScrollView<'a, T>(cx: Scope<'a, VirtualScrollViewProps<'a, T>>) ->
     let clicking_alt = use_ref(cx, || false);
     let scrolled_y = use_ref(cx, || 0);
     let scrolled_x = use_ref(cx, || 0);
+    let sizeCache = use_ref(cx, || SizeCache::new(cx.props.length, &cx.props.item_size, None));
     let (node_ref, size) = use_node(cx);
     let focus = use_focus(cx);
 
@@ -117,11 +450,13 @@ pub fn VirtualScrollView<'a, T>(cx: Scope<'a, VirtualScrollViewProps<'a, T>>) ->
     let user_container_height = &cx.props.height;
     let user_direction = &cx.props.direction;
     let show_scrollbar = cx.props.show_scrollbar;
-    let items_length = cx.props.length;
-    let items_size = cx.props.item_size;
     let scroll_with_arrows = cx.props.scroll_with_arrows;
 
-    let inner_size = items_size + (items_size * items_length as f32);
+    let inner_size = sizeCache.read().get_total_size(&cx.props.item_size, if user_direction == "vertical" {
+        size.area.height()
+    } else {
+        size.area.width()
+    });
 
     let vertical_scrollbar_is_visible = user_direction != "horizontal"
         && is_scrollbar_visible(show_scrollbar, inner_size, size.area.height());
@@ -222,9 +557,9 @@ pub fn VirtualScrollView<'a, T>(cx: Scope<'a, VirtualScrollViewProps<'a, T>>) ->
             k => {
                 if !scroll_with_arrows
                     && (k == &Key::ArrowUp
-                        || k == &Key::ArrowRight
-                        || k == &Key::ArrowDown
-                        || k == &Key::ArrowLeft)
+                    || k == &Key::ArrowRight
+                    || k == &Key::ArrowDown
+                    || k == &Key::ArrowLeft)
                 {
                     return;
                 }
@@ -294,16 +629,20 @@ pub fn VirtualScrollView<'a, T>(cx: Scope<'a, VirtualScrollViewProps<'a, T>>) ->
         (size.area.width(), corrected_scrolled_x)
     };
 
-    // Calculate from what to what items must be rendered
-    let render_range = get_render_range(
-        viewport_size,
-        scroll_position,
-        items_size,
-        items_length as f32,
-    );
+    let (render_range, render_offset) = sizeCache.read().get_covering_range(-scroll_position, viewport_size, &cx.props.item_size);
 
-    let children =
-        render_range.map(|i| (cx.props.builder)((i + 1, i, cx, &cx.props.builder_values)));
+    let children = render_range.map(|i| {
+        let child = (cx.props.builder)((i + 1, i, cx, &cx.props.builder_values)).call(cx.scope);
+        rsx!(
+            Wrapper {
+                key: "{i+1}",
+                node: child,
+                index: i,
+                size_cache: sizeCache,
+                direction: user_direction,
+            }
+        )
+    });
 
     render!(
         rect {

--- a/crates/components/src/scroll_views/virtual_scroll_view.rs
+++ b/crates/components/src/scroll_views/virtual_scroll_view.rs
@@ -667,7 +667,10 @@ pub fn VirtualScrollView<'a, T>(cx: Scope<'a, VirtualScrollViewProps<'a, T>>) ->
                     direction: "{user_direction}",
                     reference: node_ref,
                     onwheel: onwheel,
-                    children
+                    rect {
+                        margin: "{-render_offset} 0 0 0",
+                        children
+                    }
                 }
                 ScrollBar {
                     width: "100%",

--- a/crates/devtools/src/tabs/tree.rs
+++ b/crates/devtools/src/tabs/tree.rs
@@ -22,7 +22,7 @@ pub fn NodesTree<'a>(
         padding: "15",
         show_scrollbar: true,
         length: nodes.read().len(),
-        item_size: 27.0,
+        item_size: ItemSize::Fixed(27.0),
         builder_values: (nodes, selected_node_id, onselected, router),
         builder: Box::new(move |(_k, i, _, values)| {
             let (nodes, selected_node_id, onselected, router) = values.unwrap();

--- a/examples/cloned_editor.rs
+++ b/examples/cloned_editor.rs
@@ -62,7 +62,7 @@ fn Body(cx: Scope) -> Element {
                 width: "50%",
                 height: "100%",
                 length: editor.len_lines(),
-                item_size: 35.0,
+                item_size: ItemSize::Fixed(35.0),
                 builder_values: editable.clone(),
                 scroll_with_arrows: false,
                 builder: Box::new(move |(key, line_index, cx, values)| {
@@ -145,7 +145,7 @@ fn Body(cx: Scope) -> Element {
                 width: "50%",
                 height: "100%",
                 length: editor.len_lines(),
-                item_size: 35.0,
+                item_size: ItemSize::Fixed(35.0),
                 builder_values: editable.clone(),
                 scroll_with_arrows: false,
                 builder: Box::new(move |(key, line_index, cx, values)| {

--- a/examples/virtual_scroll_view.rs
+++ b/examples/virtual_scroll_view.rs
@@ -10,13 +10,13 @@ fn main() {
 }
 
 fn app(cx: Scope) -> Element {
-    let values = use_state(cx, || vec!["Hello World"].repeat(400));
+    let values = use_state(cx, || vec!["Hello World"].repeat(500));
 
     render!(VirtualScrollView {
         width: "100%",
         height: "100%",
         length: values.get().len(),
-        item_size: 25.0,
+        item_size: ItemSize::Dynamic,
         builder_values: values.get(),
         direction: "vertical",
         builder: Box::new(move |(key, index, _, values)| {
@@ -32,7 +32,8 @@ fn app(cx: Scope) -> Element {
                     key: "{key}",
                     background: "{background}",
                     label {
-                        height: "25",
+                        // height: "{70}",
+                        height: "{25 + (100.0*(index as f32).sin()) as usize}",
                         width: "100%",
                         "{index} {value}"
                     }


### PR DESCRIPTION
# rework the virtual scroll view

## Main features
- allow for dynamic and multiple item sizes
- allow scrolling elements partially instead of snapping the closed element to the top
- give scroll thumbs a minimal size


## Known Problems
- when the window is resized it sometimes freezes up