### PR TITLE
fix: Manually request redraw after resize on macOS

### DIFF
--- a/crates/renderer/src/window.rs
+++ b/crates/renderer/src/window.rs
@@ -271,6 +271,8 @@ impl<T: Clone> WindowEnv<T> {
             NonZeroU32::new(width.max(1)).unwrap(),
             NonZeroU32::new(height.max(1)).unwrap(),
         );
+
+        self.window.request_redraw();
     }
 
     /// Run the `on_setup` callback that was passed to the launch function


### PR DESCRIPTION
When resizing really slowly it sometimes stops responding to user input.
The `resize` function on `App` clears the layout.
Normally the OS would automatically schedule a redraw, but at least on Mac OS this doesn't always happen.
Without calling another redraw the layout remains empty, making it impossible to process input events. 
Manually requesting a redraw from the `WindowEnv` `resize` function fixes the problem. 