### PR TITLE
fix(docs): Update Torin's link in differences with Dioxus

### DIFF
--- a/book/src/differences_with_dioxus.md
+++ b/book/src/differences_with_dioxus.md
@@ -7,7 +7,7 @@ These are the main differences between Freya and the different Dioxus renderers 
 | Category                             | Freya            | Dioxus                          |
 |--------------------------------------|------------------|---------------------------------|
 | **Elements, attributes and events**  | Custom           | HTML                            |
-| **Layout**                           | Custom ([`torin`](https://github.com/marc2332/freya/tree/main/torin))   | WebView and [`taffy`](https://github.com/DioxusLabs/taffy)               |
+| **Layout**                           | Torin ([latest](https://github.com/marc2332/freya/tree/main/crates/torin) - [permalink](https://github.com/marc2332/freya/tree/0aba793be113ccd8ecec88311536730917901f3e/crates/torin) - This is an archive and doesn't get updated, unless the link itself is updated)   | WebView and [`taffy`](https://github.com/DioxusLabs/taffy)               |
 | **Renderer**                         | Skia             | WebView or WGPU                 |
 | **Components library**               | Custom           | None, but can use CSS libraries |
 | **Devtools**                         | Custom           | Provided in Webview             |

--- a/book/src/differences_with_dioxus.md
+++ b/book/src/differences_with_dioxus.md
@@ -7,7 +7,7 @@ These are the main differences between Freya and the different Dioxus renderers 
 | Category                             | Freya            | Dioxus                          |
 |--------------------------------------|------------------|---------------------------------|
 | **Elements, attributes and events**  | Custom           | HTML                            |
-| **Layout**                           | Torin ([repository](https://github.com/marc2332/freya/tree/main/crates/torin) - [crates.io](https://crates.io/crates/torin))   | WebView and [`taffy`](https://github.com/DioxusLabs/taffy)               |
+| **Layout** | [`Torin`](https://github.com/marc2332/freya/tree/main/crates/torin) | WebView and [`Taffy`](https://github.com/DioxusLabs/taffy) |
 | **Renderer**                         | Skia             | WebView or WGPU                 |
 | **Components library**               | Custom           | None, but can use CSS libraries |
 | **Devtools**                         | Custom           | Provided in Webview             |

--- a/book/src/differences_with_dioxus.md
+++ b/book/src/differences_with_dioxus.md
@@ -7,7 +7,7 @@ These are the main differences between Freya and the different Dioxus renderers 
 | Category                             | Freya            | Dioxus                          |
 |--------------------------------------|------------------|---------------------------------|
 | **Elements, attributes and events**  | Custom           | HTML                            |
-| **Layout**                           | Torin ([latest](https://github.com/marc2332/freya/tree/main/crates/torin) - [permalink](https://github.com/marc2332/freya/tree/0aba793be113ccd8ecec88311536730917901f3e/crates/torin) - This is an archive and doesn't get updated, unless the link itself is updated)   | WebView and [`taffy`](https://github.com/DioxusLabs/taffy)               |
+| **Layout**                           | Torin ([repository](https://github.com/marc2332/freya/tree/main/crates/torin) - [crates.io](https://crates.io/crates/torin))   | WebView and [`taffy`](https://github.com/DioxusLabs/taffy)               |
 | **Renderer**                         | Skia             | WebView or WGPU                 |
 | **Components library**               | Custom           | None, but can use CSS libraries |
 | **Devtools**                         | Custom           | Provided in Webview             |


### PR DESCRIPTION
The torin link was outdated. This updates it and also adds a permalink which will never "expire", unless the repository is deleted, or @marc2332 changes his name.