### PR TITLE
feat: Password mode for `Input` component

### DIFF
--- a/crates/components/src/input.rs
+++ b/crates/components/src/input.rs
@@ -10,11 +10,19 @@ use freya_hooks::{
 };
 use winit::window::CursorIcon;
 /// Enum to declare is [`Input`] hidden.
-pub enum InputIsHidden {
-    /// The input shown
+#[derive(Default)
+pub enum InputMode {
+    /// The input text is shown
+    #[default]
     Shown,
-    /// The input is obfuscated with a character
+    /// The input text is obfuscated with a character
     Hidden(char),
+}
+
+impl InputMode {
+    fn new_password() -> Self {
+        Self::Hidden('*')
+    }
 }
 /// [`Input`] component properties.
 #[derive(Props)]
@@ -23,9 +31,9 @@ pub struct InputProps<'a> {
     pub value: String,
     /// Handler for the `onchange` event.
     pub onchange: EventHandler<'a, String>,
-    /// Is input hidden with a character. By defaultv input is shown
-    #[props(default = InputIsHidden::Shown, into)]
-    hidden: InputIsHidden,
+    /// Is input hidden with a character. By default input text is shown.
+    #[props(default = InputMode::Shown, into)]
+    hidden: InputMode,
     /// Width of the Input. Default 100.
     #[props(default = "150".to_string(), into)]
     width: String,

--- a/crates/components/src/input.rs
+++ b/crates/components/src/input.rs
@@ -10,7 +10,7 @@ use freya_hooks::{
 };
 use winit::window::CursorIcon;
 /// Enum to declare is [`Input`] hidden.
-#[derive(Default)
+#[derive(Default)]
 pub enum InputMode {
     /// The input text is shown
     #[default]
@@ -20,7 +20,7 @@ pub enum InputMode {
 }
 
 impl InputMode {
-    fn new_password() -> Self {
+    pub fn new_password() -> Self {
         Self::Hidden('*')
     }
 }
@@ -85,8 +85,8 @@ pub fn Input<'a>(cx: Scope<'a, InputProps<'a>>) -> Element {
     let focus_manager = use_focus(cx);
 
     let text = match cx.props.hidden {
-        InputIsHidden::Hidden(ch) => ch.to_string().repeat(cx.props.value.len()),
-        InputIsHidden::Shown => cx.props.value.clone(),
+        InputMode::Hidden(ch) => ch.to_string().repeat(cx.props.value.len()),
+        InputMode::Shown => cx.props.value.clone(),
     };
     let cursor_attr = editable.cursor_attr(cx);
     let highlights_attr = editable.highlights_attr(cx, 0);

--- a/crates/components/src/input.rs
+++ b/crates/components/src/input.rs
@@ -10,6 +10,10 @@ use freya_hooks::{
 };
 use winit::window::CursorIcon;
 
+pub enum InputIsHidden {
+    Shown,
+    Hidden(char),
+}
 /// [`Input`] component properties.
 #[derive(Props)]
 pub struct InputProps<'a> {
@@ -17,6 +21,9 @@ pub struct InputProps<'a> {
     pub value: String,
     /// Handler for the `onchange` event.
     pub onchange: EventHandler<'a, String>,
+    /// Is input hidden with a character. By defaultv input is shown
+    #[props(default = InputIsHidden::Shown, into)]
+    hidden: InputIsHidden,
     /// Width of the Input. Default 100.
     #[props(default = "150".to_string(), into)]
     width: String,
@@ -67,7 +74,10 @@ pub fn Input<'a>(cx: Scope<'a, InputProps<'a>>) -> Element {
     let theme = use_get_theme(cx);
     let focus_manager = use_focus(cx);
 
-    let text = &cx.props.value;
+    let text = match cx.props.hidden {
+        InputIsHidden::Hidden(ch) => ch.to_string().repeat(cx.props.value.len()),
+        InputIsHidden::Shown => cx.props.value.clone(),
+    };
     let cursor_attr = editable.cursor_attr(cx);
     let highlights_attr = editable.highlights_attr(cx, 0);
     let width = &cx.props.width;

--- a/crates/components/src/input.rs
+++ b/crates/components/src/input.rs
@@ -9,9 +9,11 @@ use freya_hooks::{
     use_editable, use_focus, use_get_theme, EditableConfig, EditableEvent, EditableMode, TextEditor,
 };
 use winit::window::CursorIcon;
-
+/// Enum to declare is [`Input`] hidden.
 pub enum InputIsHidden {
+    /// The input shown
     Shown,
+    /// The input is obfuscated with a character
     Hidden(char),
 }
 /// [`Input`] component properties.

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -26,9 +26,9 @@ fn app(cx: Scope) -> Element {
                 direction: "horizontal",
                 Input {
                     hidden: if !is_hidden {
-                        InputIsHidden::Shown
+                        InputMode::Shown
                     } else {
-                        InputIsHidden::Hidden('*')
+                        InputMode::new_password()
                     },
                     value: password.get().clone(),
                     onchange: |e| {

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -1,0 +1,51 @@
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
+
+use freya::prelude::*;
+
+fn main() {
+    launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    let password = use_state(cx, || String::new());
+    let is_hidden = use_state(cx, || true);
+    render!(
+        rect {
+            overflow: "clip",
+            padding: "7",
+            width: "100%",
+            height: "100%",
+            label {
+                color: "black",
+                "Password:"
+            }
+            rect {
+                direction: "horizontal",
+                Input {
+                    hidden: if !is_hidden {
+                        InputIsHidden::Shown
+                    } else {
+                        InputIsHidden::Hidden('*')
+                    },
+                    value: password.get().clone(),
+                    onchange: |e| {
+                        password.set(e)
+                    }
+                },
+                Button {
+                    onclick: |_| is_hidden.modify(|v| !v),
+                    label {
+                        if *is_hidden.get() {
+                            "Show password"
+                        } else {
+                            "Hide password"
+                        }
+                    }
+                }
+            }
+        }
+    )
+}


### PR DESCRIPTION
### Adds
- InputIsHidden enum where state Hidden contains a char that is used to hide chars of the input
- If input is hidden we use rust repeat method on the obfuscation char
- Example using hidden input for password input(also includes ability to show and hide the password)
### Potential changes
- Change the enum to string*
### Potential bugs
- Wrong behavior with special chars like `\n` or `\t`**
-----------------------------------------------------------------------------------------------------
*This would make it not typesafe and introduce addtional checks to prevent bugs
**Should we block input of special chars or exclude some of the charecters from hiding