### PR TITLE
fix: Update cursor position after updating text

### DIFF
--- a/crates/components/src/input.rs
+++ b/crates/components/src/input.rs
@@ -84,6 +84,12 @@ pub fn Input<'a>(cx: Scope<'a, InputProps<'a>>) -> Element {
     let theme = use_get_theme(cx);
     let focus_manager = use_focus(cx);
 
+    if &cx.props.value != editable.editor().current().rope() {
+        editable.editor().with_mut(|editor| {
+            editor.set(&cx.props.value);
+        });
+    }
+
     let text = match cx.props.hidden {
         InputMode::Hidden(ch) => ch.to_string().repeat(cx.props.value.len()),
         InputMode::Shown => cx.props.value.clone(),
@@ -93,15 +99,6 @@ pub fn Input<'a>(cx: Scope<'a, InputProps<'a>>) -> Element {
     let width = &cx.props.width;
     let height = &cx.props.height;
     let max_lines = &cx.props.max_lines;
-
-    use_memo(cx, &(cx.props.value.to_string(),), {
-        to_owned![editable];
-        move |(text,)| {
-            editable.editor().with_mut(|editor| {
-                editor.set(&text);
-            });
-        }
-    });
 
     let onkeydown = {
         to_owned![editable, focus_manager];

--- a/crates/hooks/src/rope_editor.rs
+++ b/crates/hooks/src/rope_editor.rs
@@ -32,6 +32,10 @@ impl RopeEditor {
             mode,
         }
     }
+
+    pub fn rope(&self) -> &Rope {
+        &self.rope
+    }
 }
 
 impl TextEditor for RopeEditor {
@@ -155,11 +159,11 @@ impl TextEditor for RopeEditor {
     }
 
     fn set(&mut self, text: &str) {
+        self.rope.remove(0..);
+        self.rope.insert(0, text);
         if self.cursor_pos() > text.len() {
             self.set_cursor_pos(text.len());
         }
-        self.rope.remove(0..);
-        self.rope.insert(0, text);
     }
 
     fn unhighlight(&mut self) {

--- a/crates/hooks/src/rope_editor.rs
+++ b/crates/hooks/src/rope_editor.rs
@@ -155,6 +155,9 @@ impl TextEditor for RopeEditor {
     }
 
     fn set(&mut self, text: &str) {
+        if self.cursor_pos() > text.len() {
+            self.set_cursor_pos(text.len());
+        }
         self.rope.remove(0..);
         self.rope.insert(0, text);
     }


### PR DESCRIPTION
Current cursor position never should not be after actual text string length so we need anyway fix it while updating text.

Quick fix for #348.