### PR TITLE
Revert "fix: `mouseenter` wasn't being emitted when `mouseover` was emitted at the same time"

### DIFF
--- a/crates/core/src/events_processor.rs
+++ b/crates/core/src/events_processor.rs
@@ -79,9 +79,6 @@ impl EventsProcessor {
         // All these events will mark the node as being hovered
         // "mouseover" "mouseenter" "pointerover"  "pointerenter"
 
-         // We clone this here so events emitted in the same batch that mark an element as hovered will not affect the other events
-        let hovered_elements = self.hovered_elements.clone();
-
         // Emit valid events
         for event in &events_to_emit {
             let id = &event.node_id;
@@ -91,7 +88,7 @@ impl EventsProcessor {
                 | name @ "mouseenter"
                 | name @ "pointerover"
                 | name @ "pointerenter" => {
-                    let is_hovered = hovered_elements.contains(id);
+                    let is_hovered = self.hovered_elements.contains(id);
 
                     if !is_hovered {
                         self.hovered_elements.insert(*id);


### PR DESCRIPTION
Reverts marc2332/freya#351