### PR TITLE
feat: Reorder events based on their priority

### DIFF
--- a/crates/core/src/events/dom_events.rs
+++ b/crates/core/src/events/dom_events.rs
@@ -10,12 +10,35 @@ use torin::prelude::*;
 use crate::events::FreyaEvent;
 
 /// Event emitted to the DOM.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DomEvent {
     pub name: String,
     pub node_id: NodeId,
     pub element_id: ElementId,
     pub data: DomEventData,
+}
+
+impl Eq for DomEvent {}
+
+impl PartialOrd for DomEvent {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DomEvent {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.name.as_str() {
+            "mouseleave" | "pointerleave" => {
+                if self.name == other.name {
+                    std::cmp::Ordering::Equal
+                } else {
+                    std::cmp::Ordering::Less
+                }
+            }
+            _ => std::cmp::Ordering::Greater,
+        }
+    }
 }
 
 impl DomEvent {
@@ -123,7 +146,7 @@ impl DomEvent {
 }
 
 /// Data of a DOM event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DomEventData {
     Mouse(MouseData),
     Keyboard(KeyboardData),

--- a/crates/elements/src/events/keyboard.rs
+++ b/crates/elements/src/events/keyboard.rs
@@ -358,7 +358,7 @@ pub fn from_winit_to_code(key: &VirtualKeyCode) -> Code {
 }
 
 /// Data of a Keyboard event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct KeyboardData {
     pub key: Key,
     pub code: Code,

--- a/crates/elements/src/events/mouse.rs
+++ b/crates/elements/src/events/mouse.rs
@@ -2,7 +2,7 @@ use torin::geometry::CursorPoint;
 pub use winit::event::MouseButton;
 
 /// Data of a Mouse event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MouseData {
     pub screen_coordinates: CursorPoint,
     pub element_coordinates: CursorPoint,

--- a/crates/elements/src/events/pointer.rs
+++ b/crates/elements/src/events/pointer.rs
@@ -16,7 +16,7 @@ pub enum PointerType {
 }
 
 /// Data of a Mouse event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PointerData {
     pub screen_coordinates: CursorPoint,
     pub element_coordinates: CursorPoint,

--- a/crates/elements/src/events/touch.rs
+++ b/crates/elements/src/events/touch.rs
@@ -2,7 +2,7 @@ use torin::geometry::CursorPoint;
 pub use winit::event::{Force, TouchPhase};
 
 /// Data of a Touch event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TouchData {
     pub screen_coordinates: CursorPoint,
     pub element_coordinates: CursorPoint,

--- a/crates/elements/src/events/wheel.rs
+++ b/crates/elements/src/events/wheel.rs
@@ -1,5 +1,5 @@
 /// Data of a Wheel event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WheelData {
     #[allow(dead_code)]
     delta_x: f64,


### PR DESCRIPTION
Send `mouseleave` before `mouseover` for example