### PR TITLE
Mention the fact that the book uses some APIs from the git version

### DIFF
--- a/book/src/index.md
+++ b/book/src/index.md
@@ -1,8 +1,10 @@
 > 👋 Note: This Book is being constantly updated, so, there might some features that have been added, removed or changed.
 
+> ⚠️ Warning: This Book might contain APIs from the latest git version that might not be available on the stable versions released on crates.io.
+
 # Welcome
 
-**Freya** is __work in progress__ cross-platform native GUI library for 🦀 Rust, built on top of 🧬 [Dioxus](https://dioxuslabs.com) and 🎨 [Skia](https://skia.org/) as graphics library. 
+**Freya** is a **work in progress** cross-platform native GUI library for 🦀 Rust, built on top of 🧬 [Dioxus](https://dioxuslabs.com) and 🎨 [Skia](https://skia.org/) as graphics library. 
 
 - [What is Freya?](./what_is_freya.html)
 - [Main differences with Dioxus](./differences_with_dioxus.html)

--- a/book/src/index.md
+++ b/book/src/index.md
@@ -1,6 +1,5 @@
-> 👋 Note: This Book is being constantly updated, so, there might some features that have been added, removed or changed.
-
-> ⚠️ Warning: This Book might contain APIs from the latest git version that might not be available on the stable versions released on crates.io.
+> ⚠️ Warning: This Book might contain APIs from the latest [git version](https://github.com/marc2332/freya) that might not be available on the stable versions released on crates.io.
+> As a general rule, don't expect everything to be documented here.
 
 # Welcome
 


### PR DESCRIPTION
I was going through the book and noticed that some APIs in it (e.g., `position`) are not in the crates.io version (currently `0.1.8`). This PR just adds a warning at the beginning of the book. I know there's a note saying that the book is not always accurate, but it's not very helpful and explicit in this particular case.