### PR TITLE
Fix window icons which don't have a 32 bit depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/crates/renderer/src/config.rs
+++ b/crates/renderer/src/config.rs
@@ -66,9 +66,9 @@ impl LaunchConfig<'_, ()> {
         let reader = Reader::new(Cursor::new(icon))
             .with_guessed_format()
             .expect("Cursor io never fails");
-        let image = reader.decode().expect("Failed to open icon path");
+        let image = reader.decode().expect("Failed to open icon path").into_rgba8();
         let (width, height) = image.dimensions();
-        let rgba = image.into_bytes();
+        let rgba = image.into_raw();
         Icon::from_rgba(rgba, width, height).expect("Failed to open icon")
     }
 }

--- a/crates/renderer/src/config.rs
+++ b/crates/renderer/src/config.rs
@@ -2,7 +2,7 @@ use std::{io::Cursor, sync::Arc};
 
 use freya_engine::prelude::Color;
 use freya_node_state::Parse;
-use image::{io::Reader, GenericImageView};
+use image::io::Reader;
 use winit::window::{Icon, Window, WindowBuilder};
 
 pub type WindowBuilderHook = Box<dyn Fn(&mut WindowBuilder)>;
@@ -66,7 +66,10 @@ impl LaunchConfig<'_, ()> {
         let reader = Reader::new(Cursor::new(icon))
             .with_guessed_format()
             .expect("Cursor io never fails");
-        let image = reader.decode().expect("Failed to open icon path").into_rgba8();
+        let image = reader
+            .decode()
+            .expect("Failed to open icon path")
+            .into_rgba8();
         let (width, height) = image.dimensions();
         let rgba = image.into_raw();
         Icon::from_rgba(rgba, width, height).expect("Failed to open icon")


### PR DESCRIPTION
Trying to load icons for images that have a smaller or larger bit depth than 32 fails. This fixes that by converting the `DynamicImage` to a standard format, so the bytes are formatted correctly.