### PR TITLE
book: Add always up-to-date component reference

### DIFF
--- a/book/src/guides/components.md
+++ b/book/src/guides/components.md
@@ -1,22 +1,3 @@
 # Components
 
-Freya comes with a set of ready to use components:
-
-- [`Button`](https://docs.rs/freya/latest/freya/components/fn.Button.html)
-- [`Switch`](https://docs.rs/freya/latest/freya/components/fn.Switch.html)
-- [`ScrollView`](https://docs.rs/freya/latest/freya/components/fn.ScrollView.html)
-- [`VirtualScrollView`](https://docs.rs/freya/latest/freya/components/fn.VirtualScrollView.html)
-- [`Accordion`](https://docs.rs/freya/latest/freya/components/fn.Accordion.html)
-- [`Canvas`](https://docs.rs/freya/latest/freya/components/fn.Canvas.html)
-- [`CursorArea`](https://docs.rs/freya/latest/freya/components/fn.CursorArea.html)
-- [`Drag and Drop`](https://docs.rs/freya/latest/freya/components/fn.DragZone.html)
-- [`Dropdown`](https://docs.rs/freya/latest/freya/components/fn.Dropdown.html)
-- [`ExternalLink`](https://docs.rs/freya/latest/freya/components/fn.ExternalLink.html)
-- [`GestureArea`](https://docs.rs/freya/latest/freya/components/fn.GestureArea.html)
-- [`Graph`](https://docs.rs/freya/latest/freya/components/fn.Graph.html)
-- [`Input`](https://docs.rs/freya/latest/freya/components/fn.Input.html)
-- [`Loader`](https://docs.rs/freya/latest/freya/components/fn.Loader.html)
-- [`NetworkImage`](https://docs.rs/freya/latest/freya/components/fn.NetworkImage.html)
-- [`Slider`](https://docs.rs/freya/latest/freya/components/fn.Slider.html)
-- [`ThemeProvider`](https://docs.rs/freya/latest/freya/components/fn.ThemeProvider.html)
-- [`Tooltip`](https://docs.rs/freya/latest/freya/components/fn.Tooltip.html)
+Freya comes with a set of ready to use components. View the [API docs](https://docs.rs/freya/latest/freya/components/index.html#functions) for a full list.


### PR DESCRIPTION
Previously, the components were listed out manually. However, that means that the list will not be up-to-date, because new components are being added, or perhaps removed/renamed. This PR removes the list of components and instead links to the `components` module API docs, section "Functions". The old list linked there anyway, and it was indeed missing certain components.