### PR TITLE
book: Fix mistake in theming chapter

### DIFF
--- a/book/src/guides/theming.md
+++ b/book/src/guides/theming.md
@@ -31,7 +31,7 @@ fn Component(cx: Scope) -> Element {
 ```
 
 ### Custom default theme 
-By default, the selected theme is `LIGHT_THEME`. You use the alternative, `DARK_THEME`.
+By default, the selected theme is `LIGHT_THEME`. You can use the alternative, `DARK_THEME`.
 
 ```rust, no_run
 fn app(cx: Scope) -> Element {

--- a/book/src/guides/theming.md
+++ b/book/src/guides/theming.md
@@ -31,7 +31,7 @@ fn Component(cx: Scope) -> Element {
 ```
 
 ### Custom default theme 
-By default, the selected theme is `DARK_THEME`. You use the alternative, `LIGHT_THEME` or any you want.
+By default, the selected theme is `LIGHT_THEME`. You use the alternative, `DARK_THEME`.
 
 ```rust, no_run
 fn app(cx: Scope) -> Element {


### PR DESCRIPTION
The book says that the default theme is `DARK_THEME`, but it's actually `LIGHT_THEME`.