### PR TITLE
Versioned docs: better warnings + fix some typos

### DIFF
--- a/crates/freya/src/_docs/animating.rs
+++ b/crates/freya/src/_docs/animating.rs
@@ -4,7 +4,7 @@
 //!
 //! ### `use_animation`
 //!
-//! This a very simple hook that will let you animate a certain value from an `inital` value to a `final` value, in a given `duration` of time. There are a few animations that you can choose from:
+//! This a very simple hook that will let you animate a certain value from an `initial` value to a `final` value, in a given `duration` of time. There are a few animations that you can choose from:
 //!
 //! - Linear
 //! - EaseIn
@@ -35,7 +35,7 @@
 //!
 //! ### `use_animation_transition`
 //!
-//! This hook let's you group a set of animations together with a certain type of `animation` and a given `duration`. You can also specifiy a set of dependencies that will make animations callback re run.
+//! This hook let's you group a set of animations together with a certain type of `animation` and a given `duration`. You can also specify a set of dependencies that will make animations callback re run.
 //!
 //! Just like `use_animation` you have these animations:
 //!

--- a/crates/freya/src/_docs/theming.rs
+++ b/crates/freya/src/_docs/theming.rs
@@ -2,7 +2,7 @@
 //!
 //! Freya has built-in support for Theming.
 //!
-//! > ⚠️ Currently, extending the base theme is not supported.
+//! <div class="warning">⚠️ Currently, extending the base theme is not supported.</div>
 //!
 //! ### Accessing the current theme
 //! You can access the whole current theme via the `use_get_theme` hook.
@@ -134,10 +134,10 @@
 //! }
 //! ```
 //!
-//! >️ ⚠️ The comma after the last field in the `theme_with!` macro is required.
+//! <div class="warning">⚠️ The comma after the last field in the `theme_with!` macro is required.</div>
+//!
 //! As you can see, it removes the need for the "With" suffix, because that's already in the macro name.
 //! More importantly, though, it wraps each field in a `Some`, and adds the spread.
-//!
 //!
 //! ## Custom theme
 //!


### PR DESCRIPTION
Instead of using `> Message`, we should use `<div class="warning">Message</div>`. Comparison:

![doc-warning-comparison](https://github.com/marc2332/freya/assets/76173380/e50bae89-8f8e-4ca0-bfd7-9501e8e44621)
