### PR TITLE
Fix typo in `rect` prop

### DIFF
--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -410,7 +410,7 @@ builder_constructors! {
         #[doc = include_str!("_docs/attributes/decoration_style.md")]
         decoration_style: String,
         #[doc = include_str!("_docs/attributes/decoration_color.md")]
-        decoraton_color: String,
+        decoration_color: String,
     };
     /// `image` element let's you show an image.
     ///


### PR DESCRIPTION
Defined property `decoraton_color` -> `decoration_color`. This was causing an error in one of the examples. Note that this is technically a breaking change.