### PR TITLE
Add example and doc tests to workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,12 +38,14 @@ jobs:
       run: |
         export RUSTFLAGS="-Cinstrument-coverage"
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
-        cargo nextest run --workspace
+        cargo nextest run --workspace --exclude examples
+        cargo check --examples
         cargo test -p freya --doc
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
       run: |
-        cargo nextest run --workspace
+        cargo nextest run --workspace --exclude examples
+        cargo check --examples
         cargo test -p freya --doc
     - name: Run coverage
       if: runner.os == 'Linux'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,10 +38,13 @@ jobs:
       run: |
         export RUSTFLAGS="-Cinstrument-coverage"
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
-        cargo nextest run --workspace --exclude examples
+        cargo nextest run --workspace
+        cargo test -p freya --doc
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
-      run: cargo nextest run --workspace --exclude examples
+      run: |
+        cargo nextest run --workspace
+        cargo test -p freya --doc
     - name: Run coverage
       if: runner.os == 'Linux'
       run: |

--- a/crates/freya/src/_docs/animating.rs
+++ b/crates/freya/src/_docs/animating.rs
@@ -14,6 +14,8 @@
 //! Here is an example that will animate a value from `0.0` to `100.0` in `50` milliseconds, using the `linear` animation.
 //!
 //! ```rust, no_run
+//! # use freya::prelude::*;
+//!
 //! fn main() {
 //!     launch(app);
 //! }
@@ -47,6 +49,8 @@
 //! Here is an example that will animate a `size` and a color in `200` milliseconds, using the `new_sine_in_out` animation.
 //!
 //! ```rust, no_run
+//! # use freya::prelude::*;
+//!
 //! fn main() {
 //!     launch(app);
 //! }
@@ -54,10 +58,10 @@
 //! const TARGET: f64 = 500.0;
 //!
 //! fn app(cx: Scope) -> Element {
-//!     let animation = use_animation_transition(cx, TransitionAnimation::new_sine_in_out(200), (), || {
+//!     let animation = use_animation_transition(cx, TransitionAnimation::new_sine_in_out(200), (), |()| {
 //!         vec![
-//!             Animate::new_size(0.0, TARGET),
-//!             Animate::new_color("rgb(33, 158, 188)", "white"),
+//!             Transition::new_size(0.0, TARGET),
+//!             Transition::new_color("rgb(33, 158, 188)", "white"),
 //!         ]
 //!     });
 //!

--- a/crates/freya/src/_docs/hot_reload.rs
+++ b/crates/freya/src/_docs/hot_reload.rs
@@ -7,14 +7,18 @@
 //! Before launching your app, you need to initialize the hot-reload context:
 //!
 //! ```rust, no_run
-//! use freya::prelude::*;
-//! use freya::hot_reload::FreyaCtx;
+//! # use freya::prelude::*;
+//! use freya::hotreload::FreyaCtx;
 //!
 //! fn main() {
 //!     dioxus_hot_reload::hot_reload_init!(Config::<FreyaCtx>::default());
 //!
 //!     launch(app);
 //! }
+//!
+//! # fn app(cx: Scope) -> Element {
+//! #     None
+//! # }
 //! ```
 //!
 //! That's it!

--- a/crates/freya/src/_docs/hot_reload.rs
+++ b/crates/freya/src/_docs/hot_reload.rs
@@ -7,7 +7,7 @@
 //! Before launching your app, you need to initialize the hot-reload context:
 //!
 //! ```rust, no_run
-//! # use freya::prelude::*;
+//! use freya::prelude::*;
 //! use freya::hotreload::FreyaCtx;
 //!
 //! fn main() {

--- a/crates/freya/src/_docs/theming.rs
+++ b/crates/freya/src/_docs/theming.rs
@@ -8,6 +8,8 @@
 //! You can access the whole current theme via the `use_get_theme` hook.
 //!
 //! ```rust, no_run
+//! # use freya::prelude::*;
+//!
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         ThemeProvider {
@@ -34,6 +36,8 @@
 //! By default, the selected theme is `LIGHT_THEME`. You can use the alternative, `DARK_THEME`.
 //!
 //! ```rust, no_run
+//! # use freya::prelude::*;
+//!
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         ThemeProvider {
@@ -61,6 +65,8 @@
 //! Changing the selected theme at runtime is possible by using the `use_theme` hook.
 //!
 //! ```rust, no_run
+//! # use freya::prelude::*;
+//!
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         ThemeProvider {
@@ -94,15 +100,17 @@
 //! You can specify which values to override like this:
 //!
 //! ```rust,no_run
+//! # use freya::prelude::*;
+//!
 //! fn app(cx: Scope) -> Element {
 //!     render! {
 //!         Button {
 //!             theme: ButtonThemeWith {
-//!                 background: Some("blue").into(),
-//!                 font_theme: FontThemeWith {
-//!                     Some("white").into(),
+//!                 background: Some("blue".into()),
+//!                 font_theme: Some(FontThemeWith {
+//!                     color: Some("white".into()),
 //!                     ..Default::default()
-//!                 },
+//!                 }),
 //!                 ..Default::default()
 //!             },
 //!             label { "I'm blue now" }
@@ -119,13 +127,15 @@
 //! To make this less verbose, you can use the `theme_with!` macro:
 //!
 //! ```rust,no_run
+//! # use freya::prelude::*;
+//!
 //! fn app(cx: Scope) -> Element {
 //!     render! {
 //!         Button {
 //!             theme: theme_with!(ButtonTheme {
 //!                 background: "blue".into(),
 //!                 font_theme: theme_with!(FontTheme {
-//!                     "white".into(),
+//!                     color: "white".into(),
 //!                 }),
 //!             }),
 //!             label { "I'm blue now" }
@@ -144,6 +154,7 @@
 //! Themes can be built from scratch or extended from others, like here with `LIGHT_THEME`:
 //!
 //! ```rust, no_run
+//! # use freya::prelude::*;
 //!
 //! const CUSTOM_THEME: Theme = Theme {
 //!     button: ButtonTheme {

--- a/crates/freya/src/launch.rs
+++ b/crates/freya/src/launch.rs
@@ -2,8 +2,8 @@ use dioxus_core::Component;
 use freya_renderer::run_app;
 use freya_renderer::{LaunchConfig, WindowConfig};
 
-#[cfg(not(doctest))]
-/// Launch a new Window with the default config.
+/// Launch a new window with the default config.
+///
 /// - Width: `600.0`
 /// - Height: `600.0`
 /// - Decorations enabled
@@ -12,10 +12,13 @@ use freya_renderer::{LaunchConfig, WindowConfig};
 /// - Window background: white
 ///
 /// # Example
-/// ```rust
-/// # use dioxus::prelude::*;
-/// # use freya::{dioxus_elements, *};
-/// launch(app);
+///
+/// ```rust,no_run
+/// # use freya::prelude::*;
+///
+/// fn main() {
+///     launch(app);
+/// }
 ///
 /// fn app(cx: Scope) -> Element {
 ///    render!(
@@ -46,8 +49,8 @@ pub fn launch(app: Component<()>) {
     )
 }
 
-#[cfg(not(doctest))]
-/// Launch a new Window with a custom title and the default config.
+/// Launch a new window with a custom title and the default config.
+///
 /// - Width: `400`
 /// - Height: `300`
 /// - Decorations enabled
@@ -55,10 +58,13 @@ pub fn launch(app: Component<()>) {
 /// - Window background: white
 ///
 /// # Example
-/// ```rust
-/// # use dioxus::prelude::*;
-/// # use freya::{dioxus_elements, *};
-/// launch_with_title(app, "Whoah!");
+///
+/// ```rust,no_run
+/// # use freya::prelude::*;
+///
+/// fn main() {
+///     launch_with_title(app, "Whoa!");
+/// }
 ///
 /// fn app(cx: Scope) -> Element {
 ///    render!(
@@ -89,17 +95,20 @@ pub fn launch_with_title(app: Component<()>, title: &'static str) {
     )
 }
 
-#[cfg(not(doctest))]
-/// Launch a new Window with a custom title, width and height and the default config.
+/// Launch a new window with a custom title, width and height and the default config.
+///
 /// - Decorations enabled
 /// - Transparency disabled
 /// - Window background: white
 ///
 /// # Example
-/// ```rust
-/// # use dioxus::prelude::*;
-/// # use freya::{dioxus_elements, *};
-/// launch_with_props(app, "Whoah!", (400, 600));
+///
+/// ```rust,no_run
+/// # use freya::prelude::*;
+///
+/// fn main() {
+///     launch_with_props(app, "Whoa!", (400.0, 600.0));
+/// }
 ///
 /// fn app(cx: Scope) -> Element {
 ///    render!(
@@ -130,8 +139,9 @@ pub fn launch_with_props(app: Component<()>, title: &'static str, (width, height
     )
 }
 
-#[cfg(not(doctest))]
-/// Launch a new Window with custom config.
+/// Launch a new window with a custom config.
+/// You can use a builder if you wish.
+///
 /// - Width
 /// - Height
 /// - Decorations
@@ -140,20 +150,22 @@ pub fn launch_with_props(app: Component<()>, title: &'static str, (width, height
 /// - Window background color
 ///
 /// # Example
-/// ```rust
-/// # use dioxus::prelude::*;
-/// # use freya::{dioxus_elements, *};
-/// launch_cfg(
-///     app,
-///     WindowConfig::<()>::builder()
-///         .with_width(500.0)
-///         .with_height(400.0)
-///         .with_decorations(true)
-///         .with_transparency(false)
-///         .with_title("Freya App")
-///         .with_background("rgb(150, 100, 200")
-///         .build()
-/// );
+/// ```rust,no_run
+/// # use freya::prelude::*;
+///
+/// fn main() {
+///     launch_cfg(
+///         app,
+///         LaunchConfig::<()>::builder()
+///             .with_width(500.0)
+///             .with_height(400.0)
+///             .with_decorations(true)
+///             .with_transparency(false)
+///             .with_title("Freya App")
+///             .with_background("rgb(150, 100, 200")
+///             .build()
+///     );
+/// }
 ///
 /// fn app(cx: Scope) -> Element {
 ///    render!(

--- a/crates/freya/src/lib.rs
+++ b/crates/freya/src/lib.rs
@@ -17,7 +17,7 @@
 //! - [`Animating`](self::_docs::animating)
 //! - [`Devtools`](self::_docs::devtools)
 //!
-//! ```no_run
+//! ```rust,no_run
 //! use freya::prelude::*;
 //!
 //! fn main(){
@@ -39,7 +39,6 @@
 //!        }
 //!    )
 //! }
-//!
 //! ```
 //!
 //! ## Features flags

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -3,7 +3,6 @@
     windows_subsystem = "windows"
 )]
 
-use freya::prelude::events::PointerEvent;
 use freya::prelude::*;
 
 fn main() {


### PR DESCRIPTION
This PR includes examples when testing and adds doctests **only for the `freya` crate** (which tests the book right now). That's because there's 114 failing doctests in other crates which I wasn't feeling like fixing, but I think imports are the source of most errors, so it shouldn't be that hard. I can do it, but I wouldn't mind if someone else did it.

There were some errors which I fixed to make all new tests pass, and not all of them were just about importing stuff. That's why I strongly think this PR should be merged, along with fixing all errors in the other docs and testing those too.