### PR TITLE
chore: `ScrollBar` offset props must be component props not part of a theme

### DIFF
--- a/crates/components/src/scroll_views/scroll_bar.rs
+++ b/crates/components/src/scroll_views/scroll_bar.rs
@@ -12,6 +12,10 @@ pub struct ScrollBarProps<'a> {
     pub width: String,
     #[props(into)]
     pub height: String,
+    #[props(default = "0".to_string(), into)]
+    pub offset_x: String,
+    #[props(default = "0".to_string(), into)]
+    pub offset_y: String,
     pub clicking_scrollbar: bool,
 }
 
@@ -23,18 +27,22 @@ enum ScrollBarStatus {
 #[allow(non_snake_case)]
 pub fn ScrollBar<'a>(cx: Scope<'a, ScrollBarProps<'a>>) -> Element<'a> {
     let status = use_state(cx, || ScrollBarStatus::Idle);
-    let ScrollBarTheme {
-        background,
+    let ScrollBarTheme { background, .. } = use_applied_theme!(cx, &cx.props.theme, scroll_bar);
+
+    let ScrollBarProps {
+        width,
+        height,
+        clicking_scrollbar,
         offset_x,
         offset_y,
         ..
-    } = use_applied_theme!(cx, &cx.props.theme, scroll_bar);
+    } = cx.props;
 
     let onmouseenter = |_| status.set(ScrollBarStatus::Hovering);
     let onmouseleave = |_| status.set(ScrollBarStatus::Idle);
 
     let background = match status.get() {
-        _ if cx.props.clicking_scrollbar => background.as_ref(),
+        _ if *clicking_scrollbar => background.as_ref(),
         ScrollBarStatus::Hovering => background.as_ref(),
         ScrollBarStatus::Idle => "transparent",
     };
@@ -43,8 +51,8 @@ pub fn ScrollBar<'a>(cx: Scope<'a, ScrollBarProps<'a>>) -> Element<'a> {
         rect {
             overflow: "clip",
             role: "scrollBar",
-            width: "{cx.props.width}",
-            height: "{cx.props.height}",
+            width: "{width}",
+            height: "{height}",
             offset_x: "{offset_x}",
             offset_y: "{offset_y}",
             background: "{background}",

--- a/crates/components/src/scroll_views/scroll_view.rs
+++ b/crates/components/src/scroll_views/scroll_view.rs
@@ -1,9 +1,7 @@
 use dioxus::prelude::*;
 use freya_elements::elements as dioxus_elements;
 use freya_elements::events::{keyboard::Key, KeyboardEvent, MouseEvent, WheelEvent};
-use freya_hooks::{
-    theme_with, use_applied_theme, use_focus, use_node, ScrollBarThemeWith, ScrollViewThemeWith,
-};
+use freya_hooks::{use_applied_theme, use_focus, use_node, ScrollViewThemeWith};
 
 use crate::{
     get_container_size, get_corrected_scroll_position, get_scroll_position_from_cursor,
@@ -294,9 +292,7 @@ pub fn ScrollView<'a>(cx: Scope<'a, ScrollViewProps<'a>>) -> Element {
                 ScrollBar {
                     width: "100%",
                     height: "{horizontal_scrollbar_size}",
-                    theme: theme_with!(ScrollBarTheme {
-                        offset_x: scrollbar_x.to_string().into(),
-                    }),
+                    offset_x: "{scrollbar_x}",
                     clicking_scrollbar: is_scrolling_x,
                     ScrollThumb {
                         clicking_scrollbar: is_scrolling_x,
@@ -309,9 +305,7 @@ pub fn ScrollView<'a>(cx: Scope<'a, ScrollViewProps<'a>>) -> Element {
             ScrollBar {
                 width: "{vertical_scrollbar_size}",
                 height: "100%",
-                theme: theme_with!(ScrollBarTheme {
-                    offset_y: scrollbar_y.to_string().into(),
-                }),
+                offset_y: "{scrollbar_y}",
                 clicking_scrollbar: is_scrolling_y,
                 ScrollThumb {
                     clicking_scrollbar: is_scrolling_y,

--- a/crates/components/src/scroll_views/virtual_scroll_view.rs
+++ b/crates/components/src/scroll_views/virtual_scroll_view.rs
@@ -3,9 +3,7 @@
 use dioxus::prelude::*;
 use freya_elements::elements as dioxus_elements;
 use freya_elements::events::{keyboard::Key, KeyboardEvent, MouseEvent, WheelEvent};
-use freya_hooks::{
-    theme_with, use_applied_theme, use_focus, use_node, ScrollBarThemeWith, ScrollViewThemeWith,
-};
+use freya_hooks::{use_applied_theme, use_focus, use_node, ScrollViewThemeWith};
 use std::ops::Range;
 
 use crate::{
@@ -343,9 +341,7 @@ pub fn VirtualScrollView<'a, T>(cx: Scope<'a, VirtualScrollViewProps<'a, T>>) ->
                 ScrollBar {
                     width: "100%",
                     height: "{horizontal_scrollbar_size}",
-                    theme: theme_with!(ScrollBarTheme {
-                        offset_x: scrollbar_x.to_string().into(),
-                    }),
+                    offset_x: "{scrollbar_x}",
                     clicking_scrollbar: is_scrolling_x,
                     ScrollThumb {
                         clicking_scrollbar: is_scrolling_x,
@@ -358,9 +354,7 @@ pub fn VirtualScrollView<'a, T>(cx: Scope<'a, VirtualScrollViewProps<'a, T>>) ->
             ScrollBar {
                 width: "{vertical_scrollbar_size}",
                 height: "100%",
-                theme: theme_with!(ScrollBarTheme {
-                    offset_y: scrollbar_y.to_string().into(),
-                }),
+                offset_y: "{scrollbar_y}",
                 clicking_scrollbar: is_scrolling_y,
                 ScrollThumb {
                     clicking_scrollbar: is_scrolling_y,

--- a/crates/hooks/src/theming/dark.rs
+++ b/crates/hooks/src/theming/dark.rs
@@ -47,8 +47,6 @@ pub const DARK_THEME: Theme = Theme {
         thumb_background: cow_borrowed!("rgb(100, 100, 100)"),
         hover_thumb_background: cow_borrowed!("rgb(120, 120, 120)"),
         active_thumb_background: cow_borrowed!("rgb(140, 140, 140)"),
-        offset_x: LIGHT_THEME.scroll_bar.offset_x,
-        offset_y: LIGHT_THEME.scroll_bar.offset_y,
     },
     scroll_view: ScrollViewTheme {
         height: LIGHT_THEME.scroll_view.height,

--- a/crates/hooks/src/theming/light.rs
+++ b/crates/hooks/src/theming/light.rs
@@ -47,8 +47,6 @@ pub const LIGHT_THEME: Theme = Theme {
         thumb_background: cow_borrowed!("rgb(135, 135, 135)"),
         hover_thumb_background: cow_borrowed!("rgb(115, 115, 115)"),
         active_thumb_background: cow_borrowed!("rgb(95, 95, 95)"),
-        offset_x: cow_borrowed!("0"),
-        offset_y: cow_borrowed!("0"),
     },
     scroll_view: ScrollViewTheme {
         height: cow_borrowed!("100%"),

--- a/crates/hooks/src/theming/mod.rs
+++ b/crates/hooks/src/theming/mod.rs
@@ -299,8 +299,6 @@ define_theme! {
         thumb_background: str,
         hover_thumb_background: str,
         active_thumb_background: str,
-        offset_x: str,
-        offset_y: str,
     }
 }
 


### PR DESCRIPTION
Reverts some changes from https://github.com/marc2332/freya/pull/425