### PR TITLE
docs: Improve docs and fix errors in doctests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,13 +40,13 @@ jobs:
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc
+        cargo test --workspace --doc --no-run --quiet
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
       run: |
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc
+        cargo test --workspace --doc --no-run --quiet
     - name: Run coverage
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,8 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update && sudo apt install build-essential libssl-dev pkg-config libglib2.0-dev libgtk-3-dev
+    - name: Check examples
+      run: cargo check --examples
     - name: Lint
       run: cargo clippy
     - name: Run Linux tests
@@ -38,12 +40,9 @@ jobs:
         export RUSTFLAGS="-Cinstrument-coverage"
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
         cargo nextest run --workspace --exclude examples
-        cargo check --examples
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
-      run: |
-        cargo nextest run --workspace --exclude examples
-        cargo check --examples
+      run: cargo nextest run --workspace --exclude examples
     - name: Run doctests
       run: cargo test --workspace --doc
     - name: Run coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -40,19 +39,19 @@ jobs:
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc --verbose
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
       run: |
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc --verbose
+    - name: Run doctests
+      run: cargo test --workspace --doc
     - name: Run coverage
       if: runner.os == 'Linux'
       run: |
         rustup component add llvm-tools-preview 
         curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
-        ./grcov . --binary-path ./target/debug/deps -s . -t lcov --branch --ignore-not-existing --ignore "../*" --ignore "/*" -o cov.lcov 
+        ./grcov . --binary-path ./target/debug/deps -s . -t lcov --branch --ignore-not-existing --ignore "../*" --ignore "/*" -o cov.lcov
     - uses: codecov/codecov-action@v3
       if: runner.os == 'Linux'
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,13 +40,13 @@ jobs:
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc --quiet
+        cargo test --workspace --doc
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
       run: |
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc --quiet
+        cargo test --workspace --doc
     - name: Run coverage
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,13 +40,13 @@ jobs:
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc --no-run --quiet
+        cargo test --workspace --doc --quiet
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
       run: |
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc --no-run --quiet
+        cargo test --workspace --doc --quiet
     - name: Run coverage
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,13 +40,13 @@ jobs:
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc
+        cargo test --workspace --doc --verbose
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
       run: |
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test --workspace --doc
+        cargo test --workspace --doc --verbose
     - name: Run coverage
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,13 +40,13 @@ jobs:
         export LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test -p freya --doc
+        cargo test --workspace --doc
     - name: Run MacOS and Windows tests
       if: runner.os != 'Linux'
       run: |
         cargo nextest run --workspace --exclude examples
         cargo check --examples
-        cargo test -p freya --doc
+        cargo test --workspace --doc
     - name: Run coverage
       if: runner.os == 'Linux'
       run: |

--- a/crates/components/src/gesture_area.rs
+++ b/crates/components/src/gesture_area.rs
@@ -43,7 +43,7 @@ type EventsQueue = VecDeque<(Instant, TouchEvent)>;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
 /// # use freya::prelude::*;
 /// fn app(cx: Scope) -> Element {
 ///    let gesture = use_state(cx, || "Tap here".to_string());

--- a/crates/components/src/input.rs
+++ b/crates/components/src/input.rs
@@ -61,7 +61,7 @@ pub struct InputProps<'a> {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
 /// # use freya::prelude::*;
 /// fn app(cx: Scope) -> Element {
 ///     use_init_focus(cx);

--- a/crates/components/src/network_image.rs
+++ b/crates/components/src/network_image.rs
@@ -49,7 +49,7 @@ pub enum ImageStatus {
 ///
 /// # Example
 ///  
-/// ```rust
+/// ```rust,no_run
 /// # use freya::prelude::*;
 /// fn app(cx: Scope) -> Element {
 ///     render!(

--- a/crates/elements/Cargo.toml
+++ b/crates/elements/Cargo.toml
@@ -28,4 +28,5 @@ accesskit = { workspace = true }
 keyboard-types = "0.7.0"
 
 [dev-dependencies]
-dioxus = { workspace = true, features = ["macro"] }
+freya = { workspace = true }
+dioxus = { workspace = true }

--- a/crates/elements/Cargo.toml
+++ b/crates/elements/Cargo.toml
@@ -26,3 +26,6 @@ tokio = { workspace = true }
 accesskit = { workspace = true }
 
 keyboard-types = "0.7.0"
+
+[dev-dependencies]
+dioxus = { workspace = true, features = ["macro"] }

--- a/crates/elements/src/_docs/attributes/background.md
+++ b/crates/elements/src/_docs/attributes/background.md
@@ -7,6 +7,8 @@ You can learn about the syntax of this attribute [here](#color-syntax).
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -14,3 +16,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/attributes/background.md
+++ b/crates/elements/src/_docs/attributes/background.md
@@ -1,10 +1,8 @@
-### background
-
 Specify a color as the background of an element.
 
 You can learn about the syntax of this attribute [here](#color-syntax).
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/background.md
+++ b/crates/elements/src/_docs/attributes/background.md
@@ -5,8 +5,7 @@ You can learn about the syntax of this attribute [here](#color-syntax).
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/border.md
+++ b/crates/elements/src/_docs/attributes/border.md
@@ -1,10 +1,10 @@
-### border
+### border & border_align
 
 You can add a border to an element using the `border` and `border_align` attributes.
 - `border` syntax: `[width] <solid | none> [color]`.
 - `border_align` syntax: `<inner | outer | center>`.
 
-Example:
+### Example
 ```rust, no_run
 # use dioxus::prelude::*;
 # use freya_elements::elements as dioxus_elements;

--- a/crates/elements/src/_docs/attributes/border.md
+++ b/crates/elements/src/_docs/attributes/border.md
@@ -6,8 +6,7 @@ You can add a border to an element using the `border` and `border_align` attribu
 
 ### Example
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/border.md
+++ b/crates/elements/src/_docs/attributes/border.md
@@ -6,6 +6,8 @@ You can add a border to an element using the `border` and `border_align` attribu
 
 Example:
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/color.md
+++ b/crates/elements/src/_docs/attributes/color.md
@@ -1,10 +1,8 @@
-### color
+The `color` attribute lets you specify the color of the text.
 
-The `color` attribute let's you specify the color of the text.
+You can learn about the syntax of this attribute in [`Color Syntax`][crate::_docs::color_syntax].
 
-You can learn about the syntax of this attribute in [`Color Syntax`](/guides/style.html#color-syntax).
-
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;
@@ -19,7 +17,7 @@ fn app(cx: Scope) -> Element {
 }
 ```
 
- Another example showing [inheritance](#inheritance):
+Another example showing [inheritance](crate::_docs::inheritance):
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/color.md
+++ b/crates/elements/src/_docs/attributes/color.md
@@ -1,6 +1,6 @@
 The `color` attribute lets you specify the color of the text.
 
-You can learn about the syntax of this attribute in [`Color Syntax`][crate::_docs::color_syntax].
+You can learn about the syntax of this attribute in [`Color Syntax`](crate::_docs::color_syntax).
 
 ### Example
 

--- a/crates/elements/src/_docs/attributes/color.md
+++ b/crates/elements/src/_docs/attributes/color.md
@@ -5,8 +5,7 @@ You can learn about the syntax of this attribute in [`Color Syntax`](crate::_doc
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {
@@ -20,8 +19,7 @@ fn app(cx: Scope) -> Element {
 Another example showing [inheritance](crate::_docs::inheritance):
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/color.md
+++ b/crates/elements/src/_docs/attributes/color.md
@@ -7,6 +7,8 @@ You can learn about the syntax of this attribute in [`Color Syntax`](/guides/sty
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {
@@ -19,16 +21,17 @@ fn app(cx: Scope) -> Element {
 
  Another example showing [inheritance](#inheritance):
 
- ```rust, no_run
- fn app(cx: Scope) -> Element {
-     render!(
-         rect {
-             color: "blue",
-             label {
-                 "Hello, World!"
-             }
-         }
-     )
- }
-
- ```
+```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
+fn app(cx: Scope) -> Element {
+    render!(
+        rect {
+            color: "blue",
+            label {
+                "Hello, World!"
+            }
+        }
+    )
+}
+```

--- a/crates/elements/src/_docs/attributes/corner.md
+++ b/crates/elements/src/_docs/attributes/corner.md
@@ -5,6 +5,8 @@ The `corner_radius` attribute let's you smooth the corners of the element, with 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/corner.md
+++ b/crates/elements/src/_docs/attributes/corner.md
@@ -5,8 +5,7 @@ The `corner_radius` attribute lets you smooth the corners of the element, with `
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/corner.md
+++ b/crates/elements/src/_docs/attributes/corner.md
@@ -1,8 +1,8 @@
 ### corner_radius & corner_smoothing
 
-The `corner_radius` attribute let's you smooth the corners of the element, with `corner_smoothing` you can give a "squircle" effect.
+The `corner_radius` attribute lets you smooth the corners of the element, with `corner_smoothing` you can give a "squircle" effect.
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/decoration.md
+++ b/crates/elements/src/_docs/attributes/decoration.md
@@ -2,7 +2,7 @@
 
 Specify the decoration in a text.
 
-Accpted values:
+Accepted values:
 
 - `underline`
 - `line-through`
@@ -11,6 +11,8 @@ Accpted values:
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/decoration.md
+++ b/crates/elements/src/_docs/attributes/decoration.md
@@ -1,5 +1,3 @@
-### decoration
-
 Specify the decoration in a text.
 
 Accepted values:
@@ -8,7 +6,7 @@ Accepted values:
 - `line-through`
 - `overline`
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/decoration.md
+++ b/crates/elements/src/_docs/attributes/decoration.md
@@ -9,8 +9,7 @@ Accepted values:
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/decoration_color.md
+++ b/crates/elements/src/_docs/attributes/decoration_color.md
@@ -1,10 +1,8 @@
-### decoration_color
-
 Specify the decoration’s color in a text.
 
-You can learn about the syntax of this attribute in [`Color Syntax`](/guides/style.html#color-syntax).
+You can learn about the syntax of this attribute in [`Color Syntax`][crate::_docs::color_syntax].
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/decoration_color.md
+++ b/crates/elements/src/_docs/attributes/decoration_color.md
@@ -1,12 +1,14 @@
 ### decoration_color
 
-Specify the decoration's color in a text.
+Specify the decoration’s color in a text.
 
 You can learn about the syntax of this attribute in [`Color Syntax`](/guides/style.html#color-syntax).
 
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/decoration_color.md
+++ b/crates/elements/src/_docs/attributes/decoration_color.md
@@ -1,6 +1,6 @@
 Specify the decoration’s color in a text.
 
-You can learn about the syntax of this attribute in [`Color Syntax`][crate::_docs::color_syntax].
+You can learn about the syntax of this attribute in [`Color Syntax`](crate::_docs::color_syntax).
 
 ### Example
 

--- a/crates/elements/src/_docs/attributes/decoration_color.md
+++ b/crates/elements/src/_docs/attributes/decoration_color.md
@@ -5,8 +5,7 @@ You can learn about the syntax of this attribute in [`Color Syntax`](crate::_doc
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/decoration_style.md
+++ b/crates/elements/src/_docs/attributes/decoration_style.md
@@ -11,8 +11,7 @@ Accepted values:
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/decoration_style.md
+++ b/crates/elements/src/_docs/attributes/decoration_style.md
@@ -1,5 +1,3 @@
-### decoration_style
-
 Specify the decoration's style in a text.
 
 Accepted values:
@@ -10,7 +8,7 @@ Accepted values:
 - `dashed`
 - `wavy`
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/decoration_style.md
+++ b/crates/elements/src/_docs/attributes/decoration_style.md
@@ -2,7 +2,7 @@
 
 Specify the decoration's style in a text.
 
-Accpted values:
+Accepted values:
 
 - `solid` (default)
 - `double`
@@ -13,6 +13,8 @@ Accpted values:
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/direction.md
+++ b/crates/elements/src/_docs/attributes/direction.md
@@ -1,6 +1,9 @@
-### direction
+Control how the inner elements stack.
 
-Control how the inner elements will be stacked, possible values are `vertical` (default) and `horizontal`.
+Accepted values:
+
+- `vertical` (default)
+- `horizontal`
 
 ##### Usage
 

--- a/crates/elements/src/_docs/attributes/direction.md
+++ b/crates/elements/src/_docs/attributes/direction.md
@@ -5,6 +5,8 @@ Control how the inner elements will be stacked, possible values are `vertical` (
 ##### Usage
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/direction.md
+++ b/crates/elements/src/_docs/attributes/direction.md
@@ -8,8 +8,7 @@ Accepted values:
 ##### Usage
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/font_family.md
+++ b/crates/elements/src/_docs/attributes/font_family.md
@@ -1,10 +1,11 @@
-### font_family
+With the `font_family` you can specify what font you want to use for the inner text.
 
-With the `font_family` you can specify what font do you want to use for the inner text.
+Check out the [custom font example](https://github.com/marc2332/freya/blob/main/examples/custom_font.rs)
+to see how you can load your own fonts.
 
-Limitation: Only fonts installed in the system are supported for now.
+<!-- TODO: Example of checking if a font exists with skia_safe -->
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/font_family.md
+++ b/crates/elements/src/_docs/attributes/font_family.md
@@ -8,8 +8,7 @@ to see how you can load your own fonts.
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/font_family.md
+++ b/crates/elements/src/_docs/attributes/font_family.md
@@ -7,6 +7,8 @@ Limitation: Only fonts installed in the system are supported for now.
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/font_size.md
+++ b/crates/elements/src/_docs/attributes/font_size.md
@@ -1,8 +1,6 @@
-### font_size
-
 You can specify the size of the text using `font_size`.
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/font_size.md
+++ b/crates/elements/src/_docs/attributes/font_size.md
@@ -5,6 +5,8 @@ You can specify the size of the text using `font_size`.
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/font_size.md
+++ b/crates/elements/src/_docs/attributes/font_size.md
@@ -3,8 +3,7 @@ You can specify the size of the text using `font_size`.
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/font_style.md
+++ b/crates/elements/src/_docs/attributes/font_style.md
@@ -1,10 +1,12 @@
-### font_style
-
 You can choose a style for a text using the `font_style` attribute.
 
-Accepted values: `upright` (default), `italic` and `oblique`.
+Accepted values:
 
-Example:
+- `upright` (default)
+- `italic`
+- `oblique`
+
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;
@@ -13,7 +15,7 @@ fn app(cx: Scope) -> Element {
     render!(
         label {
             font_style: "italic",
-            "Hello, World!"
+            "Hello, italic World!"
         }
     )
 }

--- a/crates/elements/src/_docs/attributes/font_style.md
+++ b/crates/elements/src/_docs/attributes/font_style.md
@@ -7,6 +7,8 @@ Accepted values: `upright` (default), `italic` and `oblique`.
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/font_style.md
+++ b/crates/elements/src/_docs/attributes/font_style.md
@@ -9,8 +9,7 @@ Accepted values:
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/font_weight.md
+++ b/crates/elements/src/_docs/attributes/font_weight.md
@@ -1,6 +1,4 @@
-### font_weight
-
-You can choose a weight for a text using the `font_weight` attribute.
+You can choose a weight for text using the `font_weight` attribute.
 
 Accepted values:
 
@@ -27,7 +25,7 @@ Accepted values:
 - `900`
 - `950`
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;
@@ -36,7 +34,7 @@ fn app(cx: Scope) -> Element {
     render!(
         label {
             font_weight: "bold",
-            "Hello, World!"
+            "Hello, bold World!"
         }
     )
 }

--- a/crates/elements/src/_docs/attributes/font_weight.md
+++ b/crates/elements/src/_docs/attributes/font_weight.md
@@ -28,8 +28,7 @@ Accepted values:
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/font_weight.md
+++ b/crates/elements/src/_docs/attributes/font_weight.md
@@ -30,6 +30,8 @@ Accepted values:
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/font_width.md
+++ b/crates/elements/src/_docs/attributes/font_width.md
@@ -1,5 +1,7 @@
 You can choose a width for a text using the `font_width` attribute.
 
+⚠️ Only fonts with variable widths will be affected.
+
 Accepted values:
 
 - `ultra-condensed`

--- a/crates/elements/src/_docs/attributes/font_width.md
+++ b/crates/elements/src/_docs/attributes/font_width.md
@@ -1,5 +1,3 @@
-### font_width
-
 You can choose a width for a text using the `font_width` attribute.
 
 Accepted values:
@@ -13,7 +11,7 @@ Accepted values:
 - `extra-expanded`
 - `ultra-expanded`
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;
@@ -21,8 +19,8 @@ Example:
 fn app(cx: Scope) -> Element {
     render!(
         label {
-            font_weight: "bold",
-            "Hello, World!"
+            font_width: "ultra-expanded",
+            "Hello, wide World!"
         }
     )
 }

--- a/crates/elements/src/_docs/attributes/font_width.md
+++ b/crates/elements/src/_docs/attributes/font_width.md
@@ -16,8 +16,7 @@ Accepted values:
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/font_width.md
+++ b/crates/elements/src/_docs/attributes/font_width.md
@@ -16,6 +16,8 @@ Accepted values:
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/letter_spacing.md
+++ b/crates/elements/src/_docs/attributes/letter_spacing.md
@@ -5,6 +5,8 @@ Specify the spacing between characters of the text.
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/letter_spacing.md
+++ b/crates/elements/src/_docs/attributes/letter_spacing.md
@@ -3,8 +3,7 @@ Specify the spacing between characters of the text.
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/letter_spacing.md
+++ b/crates/elements/src/_docs/attributes/letter_spacing.md
@@ -1,8 +1,6 @@
-### letter_spacing
-
 Specify the spacing between characters of the text.
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/line_height.md
+++ b/crates/elements/src/_docs/attributes/line_height.md
@@ -9,8 +9,8 @@ Example:
 # use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
-        label {
-            lines_height: "3",
+        paragraph {
+            line_height: "3",
             "Hello, World! \n Hello, again!"
         }
     )

--- a/crates/elements/src/_docs/attributes/line_height.md
+++ b/crates/elements/src/_docs/attributes/line_height.md
@@ -5,6 +5,8 @@ Specify the height of the lines of the text.
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/line_height.md
+++ b/crates/elements/src/_docs/attributes/line_height.md
@@ -2,7 +2,7 @@
 
 Specify the height of the lines of the text.
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;
@@ -11,7 +11,9 @@ fn app(cx: Scope) -> Element {
     render!(
         paragraph {
             line_height: "3",
-            "Hello, World! \n Hello, again!"
+            text {
+                "Hello, World! \n Hello, again!"
+            }
         }
     )
 }

--- a/crates/elements/src/_docs/attributes/line_height.md
+++ b/crates/elements/src/_docs/attributes/line_height.md
@@ -5,8 +5,7 @@ Specify the height of the lines of the text.
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/main_align_cross_align.md
+++ b/crates/elements/src/_docs/attributes/main_align_cross_align.md
@@ -14,8 +14,7 @@ When using the `vertical` direction, `main_align` will be the Y axis and `cross_
 Example on how to center the inner elements in both axis:
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/main_align_cross_align.md
+++ b/crates/elements/src/_docs/attributes/main_align_cross_align.md
@@ -14,6 +14,8 @@ When using the `vertical` direction, `main_align` will be the Y axis and `cross_
 Example on how to center the inner elements in both axis:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/main_align_cross_align.md
+++ b/crates/elements/src/_docs/attributes/main_align_cross_align.md
@@ -2,7 +2,7 @@
 
 Control how the inner elements are positioned inside the element. You can combine it with the `direction` attribute to create complex flows.
 
-Possible values for both attributes are:
+Accepted values for both attributes are:
 
 - `start` (default): At the begining of the axis
 - `center`: At the center of the axis

--- a/crates/elements/src/_docs/attributes/margin.md
+++ b/crates/elements/src/_docs/attributes/margin.md
@@ -2,14 +2,16 @@
 
  Specify the margin of an element. You can do so by three different ways, just like in CSS.
 
- ```rust, no_run
- fn app(cx: Scope) -> Element {
-     render!(
-         rect {
-             margin: "25" // 25 in all sides
-             margin: "100 50" // 100 in top and bottom, and 50 in left and right
-             margin: "5 7 3 9" 5 // in top, 7 in right, 3 in bottom and 9 in left
-         }
-     )
- }
- ```
+```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
+fn app(cx: Scope) -> Element {
+    render!(
+        rect {
+            margin: "25", // 25 in all sides
+            margin: "100 50", // 100 in top and bottom, and 50 in left and right
+            margin: "5 7 3 9" // 5 in top, 7 in right, 3 in bottom and 9 in left
+        }
+    )
+}
+```

--- a/crates/elements/src/_docs/attributes/margin.md
+++ b/crates/elements/src/_docs/attributes/margin.md
@@ -1,6 +1,7 @@
- ### margin
+Specify the margin of an element.
+You can do so by three different ways, just like in CSS.
 
- Specify the margin of an element. You can do so by three different ways, just like in CSS.
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/margin.md
+++ b/crates/elements/src/_docs/attributes/margin.md
@@ -4,8 +4,7 @@ You can do so by three different ways, just like in CSS.
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/max_lines.md
+++ b/crates/elements/src/_docs/attributes/max_lines.md
@@ -1,8 +1,6 @@
-### max_lines
-
 Determines the amount of lines that the text can have. It has unlimited lines by default.
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/max_lines.md
+++ b/crates/elements/src/_docs/attributes/max_lines.md
@@ -3,8 +3,7 @@ Determines the amount of lines that the text can have. It has unlimited lines by
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/max_lines.md
+++ b/crates/elements/src/_docs/attributes/max_lines.md
@@ -13,7 +13,7 @@ fn app(cx: Scope) -> Element {
             "Hello, World! \n Hello, World! \n Hello, world!" // Will show all three lines
         }
         label {
-            line_height: "2",
+            max_lines: "2",
             "Hello, World! \n Hello, World! \n Hello, world!" // Will only show two lines
         }
     )

--- a/crates/elements/src/_docs/attributes/max_lines.md
+++ b/crates/elements/src/_docs/attributes/max_lines.md
@@ -5,13 +5,15 @@ Determines the amount of lines that the text can have. It has unlimited lines by
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {
             "Hello, World! \n Hello, World! \n Hello, world!" // Will show all three lines
         }
         label {
-            lines_height: "2",
+            line_height: "2",
             "Hello, World! \n Hello, World! \n Hello, world!" // Will only show two lines
         }
     )

--- a/crates/elements/src/_docs/attributes/max_width_max_height.md
+++ b/crates/elements/src/_docs/attributes/max_width_max_height.md
@@ -7,8 +7,7 @@ See syntax for [`Size Units`](crate::_docs::size_unit).
 ##### Usage
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/max_width_max_height.md
+++ b/crates/elements/src/_docs/attributes/max_width_max_height.md
@@ -7,6 +7,8 @@ See syntax for [`Size Units`](crate::_docs::size_unit).
 ##### Usage
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/min_width_min_height.md
+++ b/crates/elements/src/_docs/attributes/min_width_min_height.md
@@ -7,8 +7,7 @@ See syntax for [`Size Units`](crate::_docs::size_unit).
 ##### Usage
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/min_width_min_height.md
+++ b/crates/elements/src/_docs/attributes/min_width_min_height.md
@@ -7,6 +7,8 @@ See syntax for [`Size Units`](crate::_docs::size_unit).
 ##### Usage
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/opacity.md
+++ b/crates/elements/src/_docs/attributes/opacity.md
@@ -5,6 +5,8 @@ Specify the opacity of an element and all its desdendants.
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/opacity.md
+++ b/crates/elements/src/_docs/attributes/opacity.md
@@ -3,8 +3,7 @@ Specify the opacity of an element and all its descendants.
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/opacity.md
+++ b/crates/elements/src/_docs/attributes/opacity.md
@@ -1,8 +1,6 @@
-### opacity
+Specify the opacity of an element and all its descendants.
 
-Specify the opacity of an element and all its desdendants.
-
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/overflow.md
+++ b/crates/elements/src/_docs/attributes/overflow.md
@@ -8,8 +8,7 @@ Accepted values:
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/overflow.md
+++ b/crates/elements/src/_docs/attributes/overflow.md
@@ -1,10 +1,11 @@
-### overflow
-
 Specify how overflow should be handled.
 
-Accepted values: `clip` or `none`.
+Accepted values:
 
-### Example:
+- `clip`
+- `none`
+
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/overflow.md
+++ b/crates/elements/src/_docs/attributes/overflow.md
@@ -7,6 +7,8 @@ Accepted values: `clip` or `none`.
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/overflow.md
+++ b/crates/elements/src/_docs/attributes/overflow.md
@@ -12,7 +12,7 @@ Accepted values: `clip` or `none`.
 fn app(cx: Scope) -> Element {
     render!(
         rect {
-            overflow: "clip"
+            overflow: "clip",
             width: "100",
             height: "100%",
             rect {

--- a/crates/elements/src/_docs/attributes/padding.md
+++ b/crates/elements/src/_docs/attributes/padding.md
@@ -3,8 +3,7 @@ Specify the inner paddings of an element. You can do so by three different ways,
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/padding.md
+++ b/crates/elements/src/_docs/attributes/padding.md
@@ -1,8 +1,6 @@
-## padding
-
 Specify the inner paddings of an element. You can do so by three different ways, just like in CSS.
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/padding.md
+++ b/crates/elements/src/_docs/attributes/padding.md
@@ -5,6 +5,8 @@ Specify the inner paddings of an element. You can do so by three different ways,
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -14,3 +16,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/attributes/padding.md
+++ b/crates/elements/src/_docs/attributes/padding.md
@@ -10,8 +10,8 @@ Specify the inner paddings of an element. You can do so by three different ways,
 fn app(cx: Scope) -> Element {
     render!(
         rect {
-            padding: "25" // 25 in all sides
-            padding: "100 50" // 100 in top and bottom, and 50 in left and right
+            padding: "25", // 25 in all sides
+            padding: "100 50", // 100 in top and bottom, and 50 in left and right
             padding: "5 7 3 9" // 5 in top, 7 in right, 3 in bottom and 9 in left
         }
     )

--- a/crates/elements/src/_docs/attributes/position.md
+++ b/crates/elements/src/_docs/attributes/position.md
@@ -19,6 +19,8 @@ These only support pixels.
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/position.md
+++ b/crates/elements/src/_docs/attributes/position.md
@@ -17,8 +17,7 @@ These only support pixels.
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/position.md
+++ b/crates/elements/src/_docs/attributes/position.md
@@ -1,8 +1,6 @@
-### position
+Specify how you want the element to be positioned inside it's parent area.
 
-Specify how you want the element to be positioned inside it's parent Area
-
-Possible values for `position`:
+Accepted values:
 
 - `stacked` (default)
 - `absolute`
@@ -16,7 +14,7 @@ When using the `absolute` mode, you can also combine it with the following attri
 
 These only support pixels.
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/rotate.md
+++ b/crates/elements/src/_docs/attributes/rotate.md
@@ -1,10 +1,10 @@
- ### rotate
+The `rotate` attribute let's you rotate an element.
 
- The `rotate` attribute let's you rotate an element.
+Compatible elements: all except [`text`][crate::elements::text].
 
- Example:
+### Example
 
- ```rust, no_run
+```rust, no_run
 # use dioxus::prelude::*;
 # use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
@@ -16,5 +16,3 @@ fn app(cx: Scope) -> Element {
     )
 }
 ```
-
-Compatible elements: all except [`text`](/guides/elements.html#paragraph-and-text).

--- a/crates/elements/src/_docs/attributes/rotate.md
+++ b/crates/elements/src/_docs/attributes/rotate.md
@@ -5,8 +5,7 @@ Compatible elements: all except [`text`](crate::elements::text).
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/rotate.md
+++ b/crates/elements/src/_docs/attributes/rotate.md
@@ -1,6 +1,6 @@
 The `rotate` attribute let's you rotate an element.
 
-Compatible elements: all except [`text`][crate::elements::text].
+Compatible elements: all except [`text`](crate::elements::text).
 
 ### Example
 

--- a/crates/elements/src/_docs/attributes/rotate.md
+++ b/crates/elements/src/_docs/attributes/rotate.md
@@ -5,15 +5,16 @@
  Example:
 
  ```rust, no_run
- fn app(cx: Scope) -> Element {
-     render!(
-         label {
-             rotate: "180deg",
-             "Hello, World!"
-         }
-     )
- }
- ```
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
+fn app(cx: Scope) -> Element {
+    render!(
+        label {
+            rotate: "180deg",
+            "Hello, World!"
+        }
+    )
+}
+```
 
-
- Compatible elements: all except [`text`](/guides/elements.html#paragraph-and-text).
+Compatible elements: all except [`text`](/guides/elements.html#paragraph-and-text).

--- a/crates/elements/src/_docs/attributes/shadow.md
+++ b/crates/elements/src/_docs/attributes/shadow.md
@@ -1,10 +1,8 @@
-### shadow
-
-Draw a shadow outside of the element.
+Draw a shadow of the element.
 
 Syntax: `<x> <y> <intensity> <size> <color>`
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/shadow.md
+++ b/crates/elements/src/_docs/attributes/shadow.md
@@ -7,6 +7,8 @@ Syntax: `<x> <y> <intensity> <size> <color>`
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/shadow.md
+++ b/crates/elements/src/_docs/attributes/shadow.md
@@ -5,8 +5,7 @@ Syntax: `<x> <y> <intensity> <size> <color>`
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/text_align.md
+++ b/crates/elements/src/_docs/attributes/text_align.md
@@ -1,10 +1,15 @@
-### text_align
-
 You can change the alignment of the text using the `text_align` attribute.
 
-Accepted values: `center`, `end`, `justify`, `left`, `right`, `start`
+Accepted values:
 
-Example
+- `center`
+- `end`
+- `justify`
+- `left` (default)
+- `right`
+- `start`
+
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/text_align.md
+++ b/crates/elements/src/_docs/attributes/text_align.md
@@ -12,8 +12,7 @@ Accepted values:
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/text_align.md
+++ b/crates/elements/src/_docs/attributes/text_align.md
@@ -7,6 +7,8 @@ Accepted values: `center`, `end`, `justify`, `left`, `right`, `start`
 Example
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/text_overflow.md
+++ b/crates/elements/src/_docs/attributes/text_overflow.md
@@ -10,6 +10,8 @@ Accepted values:
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/text_overflow.md
+++ b/crates/elements/src/_docs/attributes/text_overflow.md
@@ -1,5 +1,3 @@
-### text_overflow
-
 Determines how text is treated when it exceeds its [`max_lines`](#max_lines) count. By default uses the `clip` mode, which will cut off any overflowing text, with `ellipsis` mode it will show `...` at the end.
 
 Accepted values:
@@ -7,7 +5,7 @@ Accepted values:
 - `clip` (default)
 - `ellipsis`
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/text_overflow.md
+++ b/crates/elements/src/_docs/attributes/text_overflow.md
@@ -8,8 +8,7 @@ Accepted values:
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/text_shadow.md
+++ b/crates/elements/src/_docs/attributes/text_shadow.md
@@ -1,10 +1,8 @@
-### text_shadow
-
 Specify the shadow of a text.
 
 Syntax: `<x> <y> <size> <color>`
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/text_shadow.md
+++ b/crates/elements/src/_docs/attributes/text_shadow.md
@@ -5,8 +5,7 @@ Syntax: `<x> <y> <size> <color>`
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/text_shadow.md
+++ b/crates/elements/src/_docs/attributes/text_shadow.md
@@ -7,6 +7,8 @@ Syntax: `<x> <y> <size> <color>`
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/width_height.md
+++ b/crates/elements/src/_docs/attributes/width_height.md
@@ -1,10 +1,8 @@
-## width and height
-
 Specify the width and height for the given element.
 
 See syntax in [`Size Units`](crate::_docs::size_unit).
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/width_height.md
+++ b/crates/elements/src/_docs/attributes/width_height.md
@@ -7,6 +7,8 @@ See syntax in [`Size Units`](crate::_docs::size_unit).
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/width_height.md
+++ b/crates/elements/src/_docs/attributes/width_height.md
@@ -5,8 +5,7 @@ See syntax in [`Size Units`](crate::_docs::size_unit).
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/attributes/word_spacing.md
+++ b/crates/elements/src/_docs/attributes/word_spacing.md
@@ -5,6 +5,8 @@ Specify the spacing between words of the text.
 Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/attributes/word_spacing.md
+++ b/crates/elements/src/_docs/attributes/word_spacing.md
@@ -1,8 +1,6 @@
-### word_spacing
-
 Specify the spacing between words of the text.
 
-Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/attributes/word_spacing.md
+++ b/crates/elements/src/_docs/attributes/word_spacing.md
@@ -3,8 +3,7 @@ Specify the spacing between words of the text.
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         label {

--- a/crates/elements/src/_docs/events/click.md
+++ b/crates/elements/src/_docs/events/click.md
@@ -1,10 +1,12 @@
-The `click` event will fire when the user clicks an element with the left-click.
+The `click` event fires when the user clicks an element with the left-click.
 
 Event Data: [MouseData][crate::events::MouseData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/click.md
+++ b/crates/elements/src/_docs/events/click.md
@@ -1,8 +1,10 @@
-The `click` event fires when the user clicks an element with the left-click.
+The `click` event fires when the user clicks an element with the mouse.
+Note that this fires for all mouse buttons.
+You can check the specific variant with the [MouseData][crate::events::MouseData]'s `trigger_button` property.
 
 Event Data: [MouseData][crate::events::MouseData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/click.md
+++ b/crates/elements/src/_docs/events/click.md
@@ -1,8 +1,8 @@
 The `click` event fires when the user clicks an element with the mouse.
 Note that this fires for all mouse buttons.
-You can check the specific variant with the [MouseData][crate::events::MouseData]'s `trigger_button` property.
+You can check the specific variant with the [`MouseData`](crate::events::MouseData)'s `trigger_button` property.
 
-Event Data: [MouseData][crate::events::MouseData]
+Event Data: [`MouseData`](crate::events::MouseData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/click.md
+++ b/crates/elements/src/_docs/events/click.md
@@ -7,8 +7,7 @@ Event Data: [`MouseData`](crate::events::MouseData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/globalclick.md
+++ b/crates/elements/src/_docs/events/globalclick.md
@@ -1,8 +1,8 @@
 The `globalclick` event fires when the user clicks anywhere.
 Note that this fires for all mouse buttons.
-You can check the specific variant with the [MouseData][crate::events::MouseData]'s `trigger_button` property.
+You can check the specific variant with the [`MouseData`](crate::events::MouseData)'s `trigger_button` property.
 
-Event Data: [MouseData][crate::events::MouseData]
+Event Data: [`MouseData`](crate::events::MouseData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/globalclick.md
+++ b/crates/elements/src/_docs/events/globalclick.md
@@ -1,10 +1,12 @@
-The `globalclick` event will fire when the user clicks anywhere with the left-click.
+The `globalclick` event fires when the user clicks anywhere with the left-click.
 
 Event Data: [MouseData][crate::events::MouseData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -18,3 +20,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/globalclick.md
+++ b/crates/elements/src/_docs/events/globalclick.md
@@ -1,8 +1,10 @@
-The `globalclick` event fires when the user clicks anywhere with the left-click.
+The `globalclick` event fires when the user clicks anywhere.
+Note that this fires for all mouse buttons.
+You can check the specific variant with the [MouseData][crate::events::MouseData]'s `trigger_button` property.
 
 Event Data: [MouseData][crate::events::MouseData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/globalclick.md
+++ b/crates/elements/src/_docs/events/globalclick.md
@@ -7,8 +7,7 @@ Event Data: [`MouseData`](crate::events::MouseData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/globalmousedown.md
+++ b/crates/elements/src/_docs/events/globalmousedown.md
@@ -1,8 +1,8 @@
 The `globalmousedown` event fires when the user starts clicking anywhere.
 Note that this fires for all mouse buttons.
-You can check the specific variant with the [MouseData][crate::events::MouseData]'s `trigger_button` property.
+You can check the specific variant with the [`MouseData`](crate::events::MouseData)'s `trigger_button` property.
 
-Event Data: [MouseData][crate::events::MouseData]
+Event Data: [`MouseData`](crate::events::MouseData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/globalmousedown.md
+++ b/crates/elements/src/_docs/events/globalmousedown.md
@@ -1,8 +1,10 @@
-The `globalmousedown` event fires when the user starts clicking anywhere with the left-click.
+The `globalmousedown` event fires when the user starts clicking anywhere.
+Note that this fires for all mouse buttons.
+You can check the specific variant with the [MouseData][crate::events::MouseData]'s `trigger_button` property.
 
 Event Data: [MouseData][crate::events::MouseData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/globalmousedown.md
+++ b/crates/elements/src/_docs/events/globalmousedown.md
@@ -7,8 +7,7 @@ Event Data: [`MouseData`](crate::events::MouseData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/globalmousedown.md
+++ b/crates/elements/src/_docs/events/globalmousedown.md
@@ -1,10 +1,12 @@
-The `globalmousedown` event will fire when the user starts clicking anywhere with the left-click.
+The `globalmousedown` event fires when the user starts clicking anywhere with the left-click.
 
 Event Data: [MouseData][crate::events::MouseData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -18,3 +20,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/globalmouseover.md
+++ b/crates/elements/src/_docs/events/globalmouseover.md
@@ -1,6 +1,6 @@
 The `globalmouseover` event fires when the user moves the mouse anywhere in the app.
 
-Event Data: [MouseData][crate::events::MouseData]
+Event Data: [`MouseData`](crate::events::MouseData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/globalmouseover.md
+++ b/crates/elements/src/_docs/events/globalmouseover.md
@@ -5,8 +5,7 @@ Event Data: [`MouseData`](crate::events::MouseData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/globalmouseover.md
+++ b/crates/elements/src/_docs/events/globalmouseover.md
@@ -2,7 +2,7 @@ The `globalmouseover` event fires when the user moves the mouse anywhere in the 
 
 Event Data: [MouseData][crate::events::MouseData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/globalmouseover.md
+++ b/crates/elements/src/_docs/events/globalmouseover.md
@@ -1,10 +1,12 @@
-The `globalmouseover` event will fire when the user moves the mouse anywhere in the app.
+The `globalmouseover` event fires when the user moves the mouse anywhere in the app.
 
 Event Data: [MouseData][crate::events::MouseData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -18,3 +20,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/keydown.md
+++ b/crates/elements/src/_docs/events/keydown.md
@@ -1,6 +1,6 @@
 The `keydown` event fires when the user starts pressing any key.
 
-Event Data: [KeyboardData][crate::events::KeyboardData]
+Event Data: [`KeyboardData`](crate::events::KeyboardData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/keydown.md
+++ b/crates/elements/src/_docs/events/keydown.md
@@ -5,8 +5,7 @@ Event Data: [`KeyboardData`](crate::events::KeyboardData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/keydown.md
+++ b/crates/elements/src/_docs/events/keydown.md
@@ -10,7 +10,7 @@ Event Data: [KeyboardData][crate::events::KeyboardData]
 fn app(cx: Scope) -> Element {
     render!(
         rect {
-            keydown: |e| println!("Event: {e:?}")
+            onkeydown: |e| println!("Event: {e:?}")
         }
     )
 }

--- a/crates/elements/src/_docs/events/keydown.md
+++ b/crates/elements/src/_docs/events/keydown.md
@@ -2,7 +2,7 @@ The `keydown` event fires when the user starts pressing any key.
 
 Event Data: [KeyboardData][crate::events::KeyboardData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/keydown.md
+++ b/crates/elements/src/_docs/events/keydown.md
@@ -1,10 +1,12 @@
-The `keydown` event will fire when the user starts pressing any key.
+The `keydown` event fires when the user starts pressing any key.
 
 Event Data: [KeyboardData][crate::events::KeyboardData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -12,3 +14,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/keyup.md
+++ b/crates/elements/src/_docs/events/keyup.md
@@ -1,6 +1,6 @@
 The `keyup` event fires when the user releases any key being pressed.
 
-Event Data: [KeyboardData][crate::events::KeyboardData]
+Event Data: [`KeyboardData`](crate::events::KeyboardData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/keyup.md
+++ b/crates/elements/src/_docs/events/keyup.md
@@ -2,7 +2,7 @@ The `keyup` event fires when the user releases any key being pressed.
 
 Event Data: [KeyboardData][crate::events::KeyboardData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/keyup.md
+++ b/crates/elements/src/_docs/events/keyup.md
@@ -10,7 +10,7 @@ Event Data: [KeyboardData][crate::events::KeyboardData]
 fn app(cx: Scope) -> Element {
     render!(
         rect {
-            keyup: |e| println!("Event: {e:?}")
+            onkeyup: |e| println!("Event: {e:?}")
         }
     )
 }

--- a/crates/elements/src/_docs/events/keyup.md
+++ b/crates/elements/src/_docs/events/keyup.md
@@ -5,8 +5,7 @@ Event Data: [`KeyboardData`](crate::events::KeyboardData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/keyup.md
+++ b/crates/elements/src/_docs/events/keyup.md
@@ -1,10 +1,12 @@
-The `keyup` event will fire when the user releases any key being pressed.
+The `keyup` event fires when the user releases any key being pressed.
 
 Event Data: [KeyboardData][crate::events::KeyboardData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -12,3 +14,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/mousedown.md
+++ b/crates/elements/src/_docs/events/mousedown.md
@@ -1,8 +1,8 @@
 The `mousedown` event fires when the user starts clicking an element.
 Note that this fires for all mouse buttons.
-You can check the specific variant with the [MouseData][crate::events::MouseData]'s `trigger_button` property.
+You can check the specific variant with the [`MouseData`](crate::events::MouseData)'s `trigger_button` property.
 
-Event Data: [MouseData][crate::events::MouseData]
+Event Data: [`MouseData`](crate::events::MouseData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/mousedown.md
+++ b/crates/elements/src/_docs/events/mousedown.md
@@ -1,10 +1,12 @@
-The `mousedown` event will fire when the user starts clicking an element.
+The `mousedown` event fires when the user starts clicking an element.
 
 Event Data: [MouseData][crate::events::MouseData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/mousedown.md
+++ b/crates/elements/src/_docs/events/mousedown.md
@@ -7,8 +7,7 @@ Event Data: [`MouseData`](crate::events::MouseData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/mousedown.md
+++ b/crates/elements/src/_docs/events/mousedown.md
@@ -1,8 +1,10 @@
 The `mousedown` event fires when the user starts clicking an element.
+Note that this fires for all mouse buttons.
+You can check the specific variant with the [MouseData][crate::events::MouseData]'s `trigger_button` property.
 
 Event Data: [MouseData][crate::events::MouseData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/mouseenter.md
+++ b/crates/elements/src/_docs/events/mouseenter.md
@@ -1,6 +1,6 @@
 The `mouseenter` event fires when the user starts hovering an element.
 
-Event Data: [MouseData][crate::events::MouseData]
+Event Data: [`MouseData`](crate::events::MouseData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/mouseenter.md
+++ b/crates/elements/src/_docs/events/mouseenter.md
@@ -2,7 +2,7 @@ The `mouseenter` event fires when the user starts hovering an element.
 
 Event Data: [MouseData][crate::events::MouseData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/mouseenter.md
+++ b/crates/elements/src/_docs/events/mouseenter.md
@@ -5,8 +5,7 @@ Event Data: [`MouseData`](crate::events::MouseData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/mouseenter.md
+++ b/crates/elements/src/_docs/events/mouseenter.md
@@ -1,10 +1,12 @@
-The `mouseenter` event will fire when the user starts hovering an element.
+The `mouseenter` event fires when the user starts hovering an element.
 
 Event Data: [MouseData][crate::events::MouseData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/mouseleave.md
+++ b/crates/elements/src/_docs/events/mouseleave.md
@@ -2,7 +2,7 @@ The `mouseleave` event fires when the user stops hovering an element.
 
 Event Data: [MouseData][crate::events::MouseData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/mouseleave.md
+++ b/crates/elements/src/_docs/events/mouseleave.md
@@ -5,8 +5,7 @@ Event Data: [`MouseData`](crate::events::MouseData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/mouseleave.md
+++ b/crates/elements/src/_docs/events/mouseleave.md
@@ -1,6 +1,6 @@
 The `mouseleave` event fires when the user stops hovering an element.
 
-Event Data: [MouseData][crate::events::MouseData]
+Event Data: [`MouseData`](crate::events::MouseData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/mouseleave.md
+++ b/crates/elements/src/_docs/events/mouseleave.md
@@ -1,10 +1,12 @@
-The `mouseleave` event will fire when the user stops hovering an element.
+The `mouseleave` event fires when the user stops hovering an element.
 
 Event Data: [MouseData][crate::events::MouseData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/mouseover.md
+++ b/crates/elements/src/_docs/events/mouseover.md
@@ -1,8 +1,10 @@
 The `mouseover` event fires when the user moves the mouse over an element.
+Unlike [`onmouseover`](crate::events::onmouseover), this fires even if the user was already hovering over
+the element. For that reason, it's less efficient.
 
 Event Data: [MouseData][crate::events::MouseData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/mouseover.md
+++ b/crates/elements/src/_docs/events/mouseover.md
@@ -1,10 +1,12 @@
-The `mouseover` event will fire when the user moves the mouse over an element.
+The `mouseover` event fires when the user moves the mouse over an element.
 
 Event Data: [MouseData][crate::events::MouseData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/mouseover.md
+++ b/crates/elements/src/_docs/events/mouseover.md
@@ -1,8 +1,8 @@
 The `mouseover` event fires when the user moves the mouse over an element.
-Unlike [`onmouseover`](crate::events::onmouseover), this fires even if the user was already hovering over
+Unlike [`onmouseover`](crate::elements::onmouseover), this fires even if the user was already hovering over
 the element. For that reason, it's less efficient.
 
-Event Data: [MouseData][crate::events::MouseData]
+Event Data: [`MouseData`](crate::events::MouseData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/mouseover.md
+++ b/crates/elements/src/_docs/events/mouseover.md
@@ -7,8 +7,7 @@ Event Data: [`MouseData`](crate::events::MouseData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/pointerdown.md
+++ b/crates/elements/src/_docs/events/pointerdown.md
@@ -5,8 +5,7 @@ Event Data: [`PointerData`](crate::events::PointerData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/pointerdown.md
+++ b/crates/elements/src/_docs/events/pointerdown.md
@@ -1,10 +1,12 @@
-The `pointerdown` event will fire when the user starts pressing an element.
+The `pointerdown` event fires when the user starts pressing an element.
 
 Event Data: [PointerData][crate::events::PointerData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/pointerdown.md
+++ b/crates/elements/src/_docs/events/pointerdown.md
@@ -1,6 +1,6 @@
 The `pointerdown` event fires when the user clicks/starts touching an element.
 
-Event Data: [PointerData][crate::events::PointerData]
+Event Data: [`PointerData`](crate::events::PointerData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/pointerdown.md
+++ b/crates/elements/src/_docs/events/pointerdown.md
@@ -1,8 +1,8 @@
-The `pointerdown` event fires when the user starts pressing an element.
+The `pointerdown` event fires when the user clicks/starts touching an element.
 
 Event Data: [PointerData][crate::events::PointerData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;
@@ -13,7 +13,7 @@ fn app(cx: Scope) -> Element {
             width: "100",
             height: "100",
             background: "red",
-            onpointerdown: |_| println!("Started pressing!")
+            onpointerdown: |_| println!("Clicked/started pressing!")
         }
     )
 }

--- a/crates/elements/src/_docs/events/pointerenter.md
+++ b/crates/elements/src/_docs/events/pointerenter.md
@@ -5,8 +5,7 @@ Event Data: [`PointerData`](crate::events::PointerData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/pointerenter.md
+++ b/crates/elements/src/_docs/events/pointerenter.md
@@ -1,10 +1,12 @@
-The `pointerenter` event will fire when the user starts hovering/touching an element.
+The `pointerenter` event fires when the user starts hovering/touching an element.
 
 Event Data: [PointerData][crate::events::PointerData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/pointerenter.md
+++ b/crates/elements/src/_docs/events/pointerenter.md
@@ -2,7 +2,7 @@ The `pointerenter` event fires when the user starts hovering/touching an element
 
 Event Data: [PointerData][crate::events::PointerData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/pointerenter.md
+++ b/crates/elements/src/_docs/events/pointerenter.md
@@ -1,6 +1,6 @@
 The `pointerenter` event fires when the user starts hovering/touching an element.
 
-Event Data: [PointerData][crate::events::PointerData]
+Event Data: [`PointerData`](crate::events::PointerData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/pointerleave.md
+++ b/crates/elements/src/_docs/events/pointerleave.md
@@ -1,10 +1,12 @@
-The `pointerleave` event will fire when the user stops hovering/touching an element.
+The `pointerleave` event fires when the user stops hovering/touching an element.
 
 Event Data: [PointerData][crate::events::PointerData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/pointerleave.md
+++ b/crates/elements/src/_docs/events/pointerleave.md
@@ -5,8 +5,7 @@ Event Data: [`PointerData`](crate::events::PointerData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/pointerleave.md
+++ b/crates/elements/src/_docs/events/pointerleave.md
@@ -1,6 +1,6 @@
 The `pointerleave` event fires when the user stops hovering/touching an element.
 
-Event Data: [PointerData][crate::events::PointerData]
+Event Data: [`PointerData`](crate::events::PointerData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/pointerleave.md
+++ b/crates/elements/src/_docs/events/pointerleave.md
@@ -2,7 +2,7 @@ The `pointerleave` event fires when the user stops hovering/touching an element.
 
 Event Data: [PointerData][crate::events::PointerData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/pointerover.md
+++ b/crates/elements/src/_docs/events/pointerover.md
@@ -1,8 +1,8 @@
 The `pointerover` event fires when the user hovers/touches over an element.
-Unlike [`onpointerenter`](crate::events::onpointerenter), this fires even if the user was already hovering over
+Unlike [`onpointerenter`](crate::elements::onpointerenter), this fires even if the user was already hovering over
 the element. For that reason, it's less efficient.
 
-Event Data: [PointerData][crate::events::PointerData]
+Event Data: [`PointerData`](crate::events::PointerData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/pointerover.md
+++ b/crates/elements/src/_docs/events/pointerover.md
@@ -7,8 +7,7 @@ Event Data: [`PointerData`](crate::events::PointerData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/pointerover.md
+++ b/crates/elements/src/_docs/events/pointerover.md
@@ -1,8 +1,10 @@
 The `pointerover` event fires when the user hovers/touches over an element.
+Unlike [`onpointerenter`](crate::events::onpointerenter), this fires even if the user was already hovering over
+the element. For that reason, it's less efficient.
 
 Event Data: [PointerData][crate::events::PointerData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/pointerover.md
+++ b/crates/elements/src/_docs/events/pointerover.md
@@ -1,10 +1,12 @@
-The `pointerover` event will fire when the user hovers/touches over an element.
+The `pointerover` event fires when the user hovers/touches over an element.
 
 Event Data: [PointerData][crate::events::PointerData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/pointerup.md
+++ b/crates/elements/src/_docs/events/pointerup.md
@@ -1,10 +1,12 @@
-The `pointerleave` event will fire when the user stops hovering/touching an element.
+The `pointerleave` event fires when the user stops hovering/touching an element.
 
 Event Data: [PointerData][crate::events::PointerData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/pointerup.md
+++ b/crates/elements/src/_docs/events/pointerup.md
@@ -1,6 +1,6 @@
 The `pointerup` event fires when the user releases their mouse button or stops touching the element.
 
-Event Data: [PointerData][crate::events::PointerData]
+Event Data: [`PointerData`](crate::events::PointerData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/pointerup.md
+++ b/crates/elements/src/_docs/events/pointerup.md
@@ -1,8 +1,8 @@
-The `pointerleave` event fires when the user stops hovering/touching an element.
+The `pointerup` event fires when the user releases their mouse button or stops touching the element.
 
 Event Data: [PointerData][crate::events::PointerData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;
@@ -13,7 +13,7 @@ fn app(cx: Scope) -> Element {
             width: "100",
             height: "100",
             background: "red",
-            onpointerleave: |_| println!("Stopped hovering or touching!")
+            onpointerup: |_| println!("Released mouse button, or no longer touching!")
         }
     )
 }

--- a/crates/elements/src/_docs/events/pointerup.md
+++ b/crates/elements/src/_docs/events/pointerup.md
@@ -5,8 +5,7 @@ Event Data: [`PointerData`](crate::events::PointerData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/touchcancel.md
+++ b/crates/elements/src/_docs/events/touchcancel.md
@@ -1,8 +1,9 @@
 The `touchcancel` event fires when the user cancels the touching, this is usually caused by the hardware or the OS.
+Also see [`ontouchend`](crate::events::ontouchend).
 
 Event Data: [TouchData][crate::events::TouchData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/touchcancel.md
+++ b/crates/elements/src/_docs/events/touchcancel.md
@@ -6,8 +6,7 @@ Event Data: [`TouchData`](crate::events::TouchData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/touchcancel.md
+++ b/crates/elements/src/_docs/events/touchcancel.md
@@ -1,7 +1,7 @@
 The `touchcancel` event fires when the user cancels the touching, this is usually caused by the hardware or the OS.
-Also see [`ontouchend`](crate::events::ontouchend).
+Also see [`ontouchend`](crate::elements::ontouchend).
 
-Event Data: [TouchData][crate::events::TouchData]
+Event Data: [`TouchData`](crate::events::TouchData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/touchcancel.md
+++ b/crates/elements/src/_docs/events/touchcancel.md
@@ -1,10 +1,12 @@
-The `touchcancel` event will fire when the user cancels the touching, this is usually caused by the hardware or the OS.
+The `touchcancel` event fires when the user cancels the touching, this is usually caused by the hardware or the OS.
 
 Event Data: [TouchData][crate::events::TouchData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/touchend.md
+++ b/crates/elements/src/_docs/events/touchend.md
@@ -1,10 +1,12 @@
-The `touchend` event will fire when the user stops touching an element.
+The `touchend` event fires when the user stops touching an element.
 
 Event Data: [TouchData][crate::events::TouchData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/touchend.md
+++ b/crates/elements/src/_docs/events/touchend.md
@@ -2,7 +2,7 @@ The `touchend` event fires when the user stops touching an element.
 
 Event Data: [TouchData][crate::events::TouchData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/touchend.md
+++ b/crates/elements/src/_docs/events/touchend.md
@@ -1,6 +1,6 @@
 The `touchend` event fires when the user stops touching an element.
 
-Event Data: [TouchData][crate::events::TouchData]
+Event Data: [`TouchData`](crate::events::TouchData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/touchend.md
+++ b/crates/elements/src/_docs/events/touchend.md
@@ -5,8 +5,7 @@ Event Data: [`TouchData`](crate::events::TouchData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/touchmove.md
+++ b/crates/elements/src/_docs/events/touchmove.md
@@ -1,10 +1,12 @@
-The `touchmove` event will fire when the user is touching over an element.
+The `touchmove` event fires when the user is touching over an element.
 
 Event Data: [TouchData][crate::events::TouchData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/touchmove.md
+++ b/crates/elements/src/_docs/events/touchmove.md
@@ -1,6 +1,6 @@
 The `touchmove` event fires when the user is touching over an element.
 
-Event Data: [TouchData][crate::events::TouchData]
+Event Data: [`TouchData`](crate::events::TouchData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/touchmove.md
+++ b/crates/elements/src/_docs/events/touchmove.md
@@ -2,7 +2,7 @@ The `touchmove` event fires when the user is touching over an element.
 
 Event Data: [TouchData][crate::events::TouchData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/touchmove.md
+++ b/crates/elements/src/_docs/events/touchmove.md
@@ -5,8 +5,7 @@ Event Data: [`TouchData`](crate::events::TouchData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/touchstart.md
+++ b/crates/elements/src/_docs/events/touchstart.md
@@ -2,7 +2,7 @@ The `touchstart` event fires when the user starts touching an element.
 
 Event Data: [TouchData][crate::events::TouchData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/touchstart.md
+++ b/crates/elements/src/_docs/events/touchstart.md
@@ -1,10 +1,12 @@
-The `touchstart` event will fire when the user starts touching an element.
+The `touchstart` event fires when the user starts touching an element.
 
 Event Data: [TouchData][crate::events::TouchData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/events/touchstart.md
+++ b/crates/elements/src/_docs/events/touchstart.md
@@ -1,6 +1,6 @@
 The `touchstart` event fires when the user starts touching an element.
 
-Event Data: [TouchData][crate::events::TouchData]
+Event Data: [`TouchData`](crate::events::TouchData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/touchstart.md
+++ b/crates/elements/src/_docs/events/touchstart.md
@@ -5,8 +5,7 @@ Event Data: [`TouchData`](crate::events::TouchData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/wheel.md
+++ b/crates/elements/src/_docs/events/wheel.md
@@ -1,6 +1,6 @@
 The `wheel` event fires when the user scrolls the mouse wheel while hovering over the element.
 
-Event Data: [TouchData][crate::events::TouchData]
+Event Data: [`TouchData`](crate::events::TouchData)
 
 ### Example
 

--- a/crates/elements/src/_docs/events/wheel.md
+++ b/crates/elements/src/_docs/events/wheel.md
@@ -1,8 +1,8 @@
-The `wheel` event fires when the user scrolls the mouse wheel.
+The `wheel` event fires when the user scrolls the mouse wheel while hovering over the element.
 
 Event Data: [TouchData][crate::events::TouchData]
 
-### Example:
+### Example
 
 ```rust, no_run
 # use dioxus::prelude::*;

--- a/crates/elements/src/_docs/events/wheel.md
+++ b/crates/elements/src/_docs/events/wheel.md
@@ -5,8 +5,7 @@ Event Data: [`TouchData`](crate::events::TouchData)
 ### Example
 
 ```rust, no_run
-# use dioxus::prelude::*;
-# use freya_elements::elements as dioxus_elements;
+# use freya::prelude::*;
 fn app(cx: Scope) -> Element {
     render!(
         rect {

--- a/crates/elements/src/_docs/events/wheel.md
+++ b/crates/elements/src/_docs/events/wheel.md
@@ -1,10 +1,12 @@
-The `wheel` event will fire when the user scrolls the mouse wheel.
+The `wheel` event fires when the user scrolls the mouse wheel.
 
 Event Data: [TouchData][crate::events::TouchData]
 
 ### Example:
 
 ```rust, no_run
+# use dioxus::prelude::*;
+# use freya_elements::elements as dioxus_elements;
 fn app(cx: Scope) -> Element {
     render!(
         rect {
@@ -15,3 +17,4 @@ fn app(cx: Scope) -> Element {
         }
     )
 }
+```

--- a/crates/elements/src/_docs/size_unit.rs
+++ b/crates/elements/src/_docs/size_unit.rs
@@ -4,9 +4,8 @@
 //! Will use it's inner children as size, so in this case, the `rect` width will be equivalent to the width of `label`:
 //!
 //! ```rust, no_run
-//! # use dioxus_core::prelude::*;
-//! # use dioxus_core_macro::render;
-//! # use freya_elements as dioxus_elements;
+//! # use dioxus::prelude::*;
+//! # use freya_elements::elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -23,9 +22,8 @@
 //! ##### Logical pixels
 //!
 //! ```rust, no_run
-//! # use dioxus_core::prelude::*;
-//! # use dioxus_core_macro::render;
-//! # use freya_elements as dioxus_elements;
+//! # use dioxus::prelude::*;
+//! # use freya_elements::elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -40,9 +38,8 @@
 //! Relative percentage to the parent equivalent value.
 //!
 //! ```rust, no_run
-//! # use dioxus_core::prelude::*;
-//! # use dioxus_core_macro::render;
-//! # use freya_elements as dioxus_elements;
+//! # use dioxus::prelude::*;
+//! # use freya_elements::elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -58,9 +55,8 @@
 //! For more complex logic you can use the `calc()` function.
 //!
 //! ```rust, no_run
-//! # use dioxus_core::prelude::*;
-//! # use dioxus_core_macro::render;
-//! # use freya_elements as dioxus_elements;
+//! # use dioxus::prelude::*;
+//! # use freya_elements::elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -75,9 +71,8 @@
 //! Use the remaining available space from the parent area:
 //!
 //! ```rust, no_run
-//! # use dioxus_core::prelude::*;
-//! # use dioxus_core_macro::render;
-//! # use freya_elements as dioxus_elements;
+//! # use dioxus::prelude::*;
+//! # use freya_elements::elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -88,7 +83,7 @@
 //!                 width: "100%",
 //!             }
 //!             rect {
-//!                 height: "fill", //! This is the same as calc(100% - 200)
+//!                 height: "fill", // This is the same as calc(100% - 200)
 //!                 width: "100%",
 //!             }
 //!         }
@@ -100,9 +95,8 @@
 //! Relative percentage to the viewport (Window) equivalent value.
 //!
 //! ```rust, no_run
-//! # use dioxus_core::prelude::*;
-//! # use dioxus_core_macro::render;
-//! # use freya_elements as dioxus_elements;
+//! # use dioxus::prelude::*;
+//! # use freya_elements::elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {

--- a/crates/elements/src/_docs/size_unit.rs
+++ b/crates/elements/src/_docs/size_unit.rs
@@ -4,8 +4,8 @@
 //! Will use it's inner children as size, so in this case, the `rect` width will be equivalent to the width of `label`:
 //!
 //! ```rust, no_run
-//! # use dioxus::prelude::*;
-//! # use freya_elements::elements as dioxus_elements;
+//! # use freya::prelude::*;
+//! # use freya::dioxus as dioxus;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -22,8 +22,7 @@
 //! ##### Logical pixels
 //!
 //! ```rust, no_run
-//! # use dioxus::prelude::*;
-//! # use freya_elements::elements as dioxus_elements;
+//! # use freya::prelude::*;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -38,8 +37,7 @@
 //! Relative percentage to the parent equivalent value.
 //!
 //! ```rust, no_run
-//! # use dioxus::prelude::*;
-//! # use freya_elements::elements as dioxus_elements;
+//! # use freya::prelude::*;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -55,8 +53,7 @@
 //! For more complex logic you can use the `calc()` function.
 //!
 //! ```rust, no_run
-//! # use dioxus::prelude::*;
-//! # use freya_elements::elements as dioxus_elements;
+//! # use freya::prelude::*;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -71,8 +68,7 @@
 //! Use the remaining available space from the parent area:
 //!
 //! ```rust, no_run
-//! # use dioxus::prelude::*;
-//! # use freya_elements::elements as dioxus_elements;
+//! # use freya::prelude::*;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -95,8 +91,7 @@
 //! Relative percentage to the viewport (Window) equivalent value.
 //!
 //! ```rust, no_run
-//! # use dioxus::prelude::*;
-//! # use freya_elements::elements as dioxus_elements;
+//! # use freya::prelude::*;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {

--- a/crates/elements/src/_docs/size_unit.rs
+++ b/crates/elements/src/_docs/size_unit.rs
@@ -4,6 +4,9 @@
 //! Will use it's inner children as size, so in this case, the `rect` width will be equivalent to the width of `label`:
 //!
 //! ```rust, no_run
+//! # use dioxus_core::prelude::*;
+//! # use dioxus_core_macro::render;
+//! # use freya_elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -20,6 +23,9 @@
 //! ##### Logical pixels
 //!
 //! ```rust, no_run
+//! # use dioxus_core::prelude::*;
+//! # use dioxus_core_macro::render;
+//! # use freya_elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -34,6 +40,9 @@
 //! Relative percentage to the parent equivalent value.
 //!
 //! ```rust, no_run
+//! # use dioxus_core::prelude::*;
+//! # use dioxus_core_macro::render;
+//! # use freya_elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -49,6 +58,9 @@
 //! For more complex logic you can use the `calc()` function.
 //!
 //! ```rust, no_run
+//! # use dioxus_core::prelude::*;
+//! # use dioxus_core_macro::render;
+//! # use freya_elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -63,6 +75,9 @@
 //! Use the remaining available space from the parent area:
 //!
 //! ```rust, no_run
+//! # use dioxus_core::prelude::*;
+//! # use dioxus_core_macro::render;
+//! # use freya_elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {
@@ -85,6 +100,9 @@
 //! Relative percentage to the viewport (Window) equivalent value.
 //!
 //! ```rust, no_run
+//! # use dioxus_core::prelude::*;
+//! # use dioxus_core_macro::render;
+//! # use freya_elements as dioxus_elements;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {

--- a/crates/elements/src/_docs/size_unit.rs
+++ b/crates/elements/src/_docs/size_unit.rs
@@ -5,7 +5,6 @@
 //!
 //! ```rust, no_run
 //! # use freya::prelude::*;
-//! # use freya::dioxus as dioxus;
 //! fn app(cx: Scope) -> Element {
 //!     render!(
 //!         rect {

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -156,23 +156,26 @@ macro_rules! impl_element {
 }
 
 builder_constructors! {
-    ///    `rect` is a generic element that acts as a container for other elements.
+    /// `rect` is a generic element that acts as a container for other elements.
     ///
-    ///    You can specify things like [`width`](#width-and-height), [`padding`](#padding) or even in what [`direction`](#direction) the inner elements are stacked.
+    /// You can specify things like [`width`](#width-and-height), [`padding`](#padding) or even in what [`direction`](#direction) the inner elements are stacked.
     ///
-    ///    ### Example:
+    /// ### Example:
     ///
-    ///    ```rust, no_run
-    ///    fn app(cx: Scope) -> Element {
-    ///        render!(
-    ///            rect {
-    ///                direction: "vertical",
-    ///                label { "Hi!" }
-    ///                label { "Hi again!"}
-    ///            }
-    ///        )
-    ///    }
-    ///    ```
+    /// ```rust,no_run
+    /// # use dioxus_core::prelude::*;
+    /// # use dioxus_core_macro::render;
+    /// # use freya_elements as dioxus_elements;
+    /// fn app(cx: Scope) -> Element {
+    ///     render!(
+    ///         rect {
+    ///             direction: "vertical",
+    ///             label { "Hi!" }
+    ///             label { "Hi again!"}
+    ///         }
+    ///     )
+    /// }
+    /// ```
     rect {
         #[doc = include_str!("_docs/attributes/padding.md")]
         padding: String,
@@ -244,8 +247,13 @@ builder_constructors! {
     /// `label` simply let's you display some text.
     ///
     /// ### Example:
-    ///
-    /// ```rust, no_run
+    /// # use dioxus_core::prelude::*;
+    /// # use dioxus_core_macro::render;
+    /// # use freya_elements as dioxus_elements;
+    /// ```rust,no_run
+    /// # use dioxus_core::prelude::*;
+    /// # use dioxus_core_macro::render;
+    /// # use freya_elements as dioxus_elements;
     /// fn app(cx: Scope) -> Element {
     ///     render!(
     ///         label {
@@ -306,7 +314,10 @@ builder_constructors! {
     ///
     /// This used used with the `text` element.
     ///
-    /// ``` rust
+    /// ```rust,no_run
+    /// # use dioxus_core::prelude::*;
+    /// # use dioxus_core_macro::render;
+    /// # use freya_elements as dioxus_elements;
     /// fn app(cx: Scope) -> Element {
     ///     render!(
     ///         paragraph {
@@ -417,6 +428,9 @@ builder_constructors! {
     /// ### Example:
     ///
     /// ```rust, no_run
+    /// # use dioxus_core::prelude::*;
+    /// # use dioxus_core_macro::render;
+    /// # use freya_elements as dioxus_elements;
     /// static RUST_LOGO: &[u8] = include_bytes!("./rust_logo.png");
     ///
     /// fn app(cx: Scope) -> Element {
@@ -449,11 +463,15 @@ builder_constructors! {
     };
     /// `svg` element let's you display SVG code.
     ///
-    /// You will need to use the `bytes_to_data` to transform the bytes into data the element can recognize.
+    /// You will need to use the [`bytes_to_data`](https://docs.freyaui.dev/freya/prelude/fn.bytes_to_data.html)
+    /// to transform the bytes into data the element can recognize.
     ///
     /// ### Example:
     ///
-    /// ```rust, no_run
+    /// ```rust,ignore
+    /// # use dioxus_core::prelude::*;
+    /// # use dioxus_core_macro::render;
+    /// # use freya_elements as dioxus_elements;
     /// static FERRIS: &[u8] = include_bytes!("./ferris.svg");
     ///
     /// fn app(cx: Scope) -> Element {

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -163,8 +163,8 @@ builder_constructors! {
     /// ### Example
     ///
     /// ```rust,no_run
-    /// # use dioxus::prelude::*;
-    /// # use freya_elements::elements as dioxus_elements;
+    /// # use freya::prelude::*;
+    /// # use freya::dioxus as dioxus;
     /// fn app(cx: Scope) -> Element {
     ///     render!(
     ///         rect {
@@ -248,8 +248,7 @@ builder_constructors! {
     /// ### Example
     ///
     /// ```rust,no_run
-    /// # use dioxus::prelude::*;
-    /// # use freya_elements::elements as dioxus_elements;
+    /// # use freya::prelude::*;
     /// fn app(cx: Scope) -> Element {
     ///     render!(
     ///         label {
@@ -313,8 +312,7 @@ builder_constructors! {
     /// This used used with the `text` element.
     ///
     /// ```rust,no_run
-    /// # use dioxus::prelude::*;
-    /// # use freya_elements::elements as dioxus_elements;
+    /// # use freya::prelude::*;
     /// fn app(cx: Scope) -> Element {
     ///     render!(
     ///         paragraph {
@@ -425,8 +423,7 @@ builder_constructors! {
     /// ### Example
     ///
     /// ```rust, ignore, no_run
-    /// # use dioxus::prelude::*;
-    /// # use freya_elements::elements as dioxus_elements;
+    /// # use freya::prelude::*;
     /// static RUST_LOGO: &[u8] = include_bytes!("./rust_logo.png");
     ///
     /// fn app(cx: Scope) -> Element {
@@ -465,8 +462,7 @@ builder_constructors! {
     /// ### Example
     ///
     /// ```rust,ignore
-    /// # use dioxus::prelude::*;
-    /// # use freya_elements::elements as dioxus_elements;
+    /// # use freya::prelude::*;
     /// static FERRIS: &[u8] = include_bytes!("./ferris.svg");
     ///
     /// fn app(cx: Scope) -> Element {

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -163,9 +163,8 @@ builder_constructors! {
     /// ### Example:
     ///
     /// ```rust,no_run
-    /// # use dioxus_core::prelude::*;
-    /// # use dioxus_core_macro::render;
-    /// # use freya_elements as dioxus_elements;
+    /// # use dioxus::prelude::*;
+    /// # use freya_elements::elements as dioxus_elements;
     /// fn app(cx: Scope) -> Element {
     ///     render!(
     ///         rect {
@@ -247,13 +246,10 @@ builder_constructors! {
     /// `label` simply let's you display some text.
     ///
     /// ### Example:
-    /// # use dioxus_core::prelude::*;
-    /// # use dioxus_core_macro::render;
-    /// # use freya_elements as dioxus_elements;
+    ///
     /// ```rust,no_run
-    /// # use dioxus_core::prelude::*;
-    /// # use dioxus_core_macro::render;
-    /// # use freya_elements as dioxus_elements;
+    /// # use dioxus::prelude::*;
+    /// # use freya_elements::elements as dioxus_elements;
     /// fn app(cx: Scope) -> Element {
     ///     render!(
     ///         label {
@@ -315,9 +311,8 @@ builder_constructors! {
     /// This used used with the `text` element.
     ///
     /// ```rust,no_run
-    /// # use dioxus_core::prelude::*;
-    /// # use dioxus_core_macro::render;
-    /// # use freya_elements as dioxus_elements;
+    /// # use dioxus::prelude::*;
+    /// # use freya_elements::elements as dioxus_elements;
     /// fn app(cx: Scope) -> Element {
     ///     render!(
     ///         paragraph {
@@ -427,10 +422,9 @@ builder_constructors! {
     ///
     /// ### Example:
     ///
-    /// ```rust, no_run
-    /// # use dioxus_core::prelude::*;
-    /// # use dioxus_core_macro::render;
-    /// # use freya_elements as dioxus_elements;
+    /// ```rust, ignore, no_run
+    /// # use dioxus::prelude::*;
+    /// # use freya_elements::elements as dioxus_elements;
     /// static RUST_LOGO: &[u8] = include_bytes!("./rust_logo.png");
     ///
     /// fn app(cx: Scope) -> Element {
@@ -469,9 +463,8 @@ builder_constructors! {
     /// ### Example:
     ///
     /// ```rust,ignore
-    /// # use dioxus_core::prelude::*;
-    /// # use dioxus_core_macro::render;
-    /// # use freya_elements as dioxus_elements;
+    /// # use dioxus::prelude::*;
+    /// # use freya_elements::elements as dioxus_elements;
     /// static FERRIS: &[u8] = include_bytes!("./ferris.svg");
     ///
     /// fn app(cx: Scope) -> Element {

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -164,7 +164,6 @@ builder_constructors! {
     ///
     /// ```rust,no_run
     /// # use freya::prelude::*;
-    /// # use freya::dioxus as dioxus;
     /// fn app(cx: Scope) -> Element {
     ///     render!(
     ///         rect {

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -160,7 +160,7 @@ builder_constructors! {
     ///
     /// You can specify things like [`width`](#width-and-height), [`padding`](#padding) or even in what [`direction`](#direction) the inner elements are stacked.
     ///
-    /// ### Example:
+    /// ### Example
     ///
     /// ```rust,no_run
     /// # use dioxus::prelude::*;
@@ -245,7 +245,7 @@ builder_constructors! {
     };
     /// `label` simply let's you display some text.
     ///
-    /// ### Example:
+    /// ### Example
     ///
     /// ```rust,no_run
     /// # use dioxus::prelude::*;
@@ -420,7 +420,7 @@ builder_constructors! {
     };
     /// `image` element let's you show an image.
     ///
-    /// ### Example:
+    /// ### Example
     ///
     /// ```rust, ignore, no_run
     /// # use dioxus::prelude::*;
@@ -460,7 +460,7 @@ builder_constructors! {
     /// You will need to use the [`bytes_to_data`](https://docs.freyaui.dev/freya/prelude/fn.bytes_to_data.html)
     /// to transform the bytes into data the element can recognize.
     ///
-    /// ### Example:
+    /// ### Example
     ///
     /// ```rust,ignore
     /// # use dioxus::prelude::*;

--- a/crates/engine/src/mocked.rs
+++ b/crates/engine/src/mocked.rs
@@ -1433,6 +1433,10 @@ impl DirectContext {
     pub fn flush_and_submit(&self) {
         unimplemented!("This is mocked")
     }
+
+    pub fn abandon(&self) {
+        unimplemented!("This is mocked")
+    }
 }
 
 use std::ffi::c_void;

--- a/crates/freya/src/lib.rs
+++ b/crates/freya/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! - [Elements API reference](freya_elements::elements#structs)
 //! - [Events API reference](freya_elements::elements#functions)
-//! - [Element guides](freya_elements::_docs)
+//! - [Elements guides](freya_elements::_docs)
 //! - [Components](freya_components)
 //! - [Hooks](freya_hooks)
 //! - [Theming](self::_docs::theming)

--- a/crates/freya/src/lib.rs
+++ b/crates/freya/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! Powered by [🧬 Dioxus](https://dioxuslabs.com) and [🎨 Skia](https://skia.org/).
 //!
-//! - [Elements](freya_elements::elements#structs)
-//! - [Events](freya_elements::elements#functions)
+//! - [Elements API reference](freya_elements::elements#structs)
+//! - [Events API reference](freya_elements::elements#functions)
 //! - [Elements and events guides](freya_elements::_docs)
 //! - [Components](freya_components)
 //! - [Hooks](freya_hooks)

--- a/crates/freya/src/lib.rs
+++ b/crates/freya/src/lib.rs
@@ -8,15 +8,16 @@
 //!
 //! Powered by [🧬 Dioxus](https://dioxuslabs.com) and [🎨 Skia](https://skia.org/).
 //!
-//! - [`Elements`](freya_elements::elements#structs)
-//! - [`Events`](freya_elements::elements#functions)
-//! - [`Components`](freya_components)
-//! - [`Hooks`](freya_hooks)
-//! - [`Theming`](self::_docs::theming)
-//! - [`Hot reload`](self::_docs::hot_reload)
-//! - [`Testing`](self::_docs::testing)
-//! - [`Animating`](self::_docs::animating)
-//! - [`Devtools`](self::_docs::devtools)
+//! - [Elements](freya_elements::elements#structs)
+//! - [Events](freya_elements::elements#functions)
+//! - [Elements and events guides](freya_elements::_docs)
+//! - [Components](freya_components)
+//! - [Hooks](freya_hooks)
+//! - [Theming](self::_docs::theming)
+//! - [Hot reload](self::_docs::hot_reload)
+//! - [Testing](self::_docs::testing)
+//! - [Animating](self::_docs::animating)
+//! - [Devtools](self::_docs::devtools)
 //!
 //! ```rust,no_run
 //! use freya::prelude::*;
@@ -49,7 +50,7 @@
 //! - `log`: enables internal logs.
 //!
 
-/// Freya Docs
+/// Freya docs.
 #[cfg(doc)]
 pub mod _docs;
 

--- a/crates/freya/src/lib.rs
+++ b/crates/freya/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! - [Elements API reference](freya_elements::elements#structs)
 //! - [Events API reference](freya_elements::elements#functions)
-//! - [Elements and events guides](freya_elements::_docs)
+//! - [Element guides](freya_elements::_docs)
 //! - [Components](freya_components)
 //! - [Hooks](freya_hooks)
 //! - [Theming](self::_docs::theming)

--- a/crates/hooks/src/theming/mod.rs
+++ b/crates/hooks/src/theming/mod.rs
@@ -170,7 +170,6 @@ macro_rules! define_theme {
 /// Without the macro:
 ///
 /// ```no_run
-/// # use dioxus::prelude::*;
 /// # use freya::prelude::*;
 /// # fn theme_with_example_no_macro(cx: Scope) -> Element {
 /// render! {
@@ -191,7 +190,6 @@ macro_rules! define_theme {
 /// With the macro:
 ///
 /// ```no_run
-/// # use dioxus::prelude::*;
 /// # use freya::prelude::*;
 /// # fn theme_with_example_no_macro(cx: Scope) -> Element {
 /// render! {

--- a/crates/hooks/src/theming/mod.rs
+++ b/crates/hooks/src/theming/mod.rs
@@ -22,7 +22,14 @@ macro_rules! cow_borrowed {
 
 /// Example usage:
 ///
-/// ```rust,ignore
+/// ```rust
+/// # use crate::freya_hooks::define_theme;
+/// # use crate::freya_hooks::FontTheme;
+/// # use crate::freya_hooks::FontThemeWith;
+/// # #[derive(Clone, Debug, PartialEq, Eq)]
+/// # struct Bar;
+/// # #[derive(Clone, Debug, PartialEq, Eq)]
+/// # struct Foo;
 /// define_theme! {
 ///     %[component]
 ///     pub Test<'a> {
@@ -32,7 +39,8 @@ macro_rules! cow_borrowed {
 ///         borrowed_data: &'a Foo,
 ///         %[owned]
 ///         owned_data: Bar,
-///         %[subthemes],
+///         %[subthemes]
+///         font_theme: FontTheme,
 ///     }
 /// }
 /// ```
@@ -168,9 +176,9 @@ macro_rules! define_theme {
 /// render! {
 ///     Button {
 ///         theme: ButtonThemeWith {
-///             background: "blue".into(),
+///             background: Some("blue".into()),
 ///             font_theme: FontThemeWith {
-///                 color: "white".into(),
+///                 color: Some("white".into()),
 ///                 ..Default::default()
 ///             }.into(),
 ///             ..Default::default()
@@ -189,9 +197,9 @@ macro_rules! define_theme {
 /// render! {
 ///     Button {
 ///         theme: theme_with!(ButtonTheme {
-///             background: "blue",
+///             background: "blue".into(),
 ///             font_theme: theme_with!(FontTheme {
-///                 color: "white",
+///                 color: "white".into(),
 ///             }),
 ///         })
 ///     }

--- a/crates/hooks/src/use_animation.rs
+++ b/crates/hooks/src/use_animation.rs
@@ -84,7 +84,7 @@ impl<'a> AnimationManager<'a> {
 /// Run animations.
 ///
 /// ## Usage
-/// ```rust
+/// ```rust,no_run
 /// # use freya::prelude::*;
 /// fn app(cx: Scope) -> Element {
 ///     let animation = use_animation(cx, || 0.0);

--- a/crates/hooks/src/use_animation_transition.rs
+++ b/crates/hooks/src/use_animation_transition.rs
@@ -250,7 +250,7 @@ impl<'a> TransitionsManager<'a> {
 /// Run a group of animated transitions.
 ///
 /// ## Usage
-/// ```rust
+/// ```rust,no_run
 /// # use freya::prelude::*;
 /// fn app(cx: Scope) -> Element {
 ///     let animation = use_animation_transition(cx, TransitionAnimation::new_linear(50), (), |_| vec![

--- a/crates/hooks/src/use_canvas.rs
+++ b/crates/hooks/src/use_canvas.rs
@@ -29,7 +29,7 @@ impl UseCanvas {
 /// Register a rendering hook to gain access to the Canvas.
 ///
 /// ## Usage
-/// ```rust
+/// ```rust,no_run
 /// # use freya::prelude::*;
 /// fn app(cx: Scope) -> Element {
 ///     let canvas = use_canvas(cx, (), |_| {

--- a/crates/renderer/src/window.rs
+++ b/crates/renderer/src/window.rs
@@ -3,6 +3,7 @@ use freya_common::EventMessage;
 use freya_core::prelude::*;
 use freya_dom::prelude::FreyaDOM;
 use freya_engine::prelude::*;
+use glutin::prelude::{PossiblyCurrentContextGlSurfaceAccessor, PossiblyCurrentGlContext};
 use std::ffi::CString;
 use std::num::NonZeroU32;
 use torin::geometry::{Area, Size2D};
@@ -34,15 +35,25 @@ use crate::HoveredNode;
 
 /// Manager for a Window
 pub struct WindowEnv<T: Clone> {
+    gr_context: DirectContext,
     surface: Surface,
     gl_surface: GlutinSurface<WindowSurface>,
-    gr_context: DirectContext,
     gl_context: PossiblyCurrentContext,
     pub(crate) window: Window,
     fb_info: FramebufferInfo,
     num_samples: usize,
     stencil_size: usize,
     pub(crate) window_config: WindowConfig<T>,
+}
+
+impl<T: Clone> Drop for WindowEnv<T> {
+    fn drop(&mut self) {
+        if !self.gl_context.is_current() {
+            if self.gl_context.make_current(&self.gl_surface).is_err() {
+                self.gr_context.abandon();
+            }
+        }
+    }
 }
 
 impl<T: Clone> WindowEnv<T> {


### PR DESCRIPTION
This "builds on" https://github.com/marc2332/freya/pull/434. That PR fixed only the doctests (Rust code snippets) in the main crate docs though. This PR fixes every single code snippet and makes `cargo test --workspace --doc` pass. This command is also added to the workflow.

There's cca. 130 "new" (fixed and passing) doctests. All of them needed imports, but a lot of them didn't compile for other reasons. Other times, they compiled, but they were wrong in a different way (e.g. `max_lines.md` had a code snippet that was using `line_height`).

Additionally, the `freya_elements` docs were expanded in some cases (remove ambiguity, specify details), standardized (e.g. all examples are grouped under an example heading, previously some examples had just a plaintext `Example:` "title"), and fixed (link fixes, typos, etc.).