### PR TITLE
feat: Text Editor improvements

### DIFF
--- a/crates/hooks/src/rope_editor.rs
+++ b/crates/hooks/src/rope_editor.rs
@@ -93,6 +93,10 @@ impl TextEditor for RopeEditor {
         }
     }
 
+    fn has_any_highlight(&self) -> bool {
+        self.selected.is_some()
+    }
+
     fn highlights(&self, editor_id: usize) -> Option<(usize, usize)> {
         let (selected_from, selected_to) = self.selected?;
 


### PR DESCRIPTION
- Don't remove the highlights when pressing Alt or Ctrl alone
- Jump to the begining of the line when pressing Up and having reached the first line
- Jump to the end of the line when pressing Down and having reached the last line
- Don't mark as the highlights has changed if there is anything selected at all