### PR TITLE
fix: Prevent cursor to jump to the next line when there are no more lines, in  `TextEditor`

### DIFF
--- a/crates/hooks/src/text_editor.rs
+++ b/crates/hooks/src/text_editor.rs
@@ -285,7 +285,7 @@ pub trait TextEditor: Sized + Clone + Display {
                 let current_line = self.line(self.cursor_row()).unwrap();
 
                 // Go one line down if there isn't more characters on the right
-                if self.cursor_row() < self.len_lines()
+                if self.cursor_row() < self.len_lines() - 1
                     && self.cursor_col() == current_line.len_chars().max(1) - 1
                 {
                     self.cursor_down();


### PR DESCRIPTION
Prevent cursor to jump to the next line when there are no more lines, in  `TextEditor`