### PR TITLE
Remove required trailing comma in `theme_with` macro

### DIFF
--- a/crates/hooks/src/theming/mod.rs
+++ b/crates/hooks/src/theming/mod.rs
@@ -202,8 +202,8 @@ macro_rules! define_theme {
 macro_rules! theme_with {
     ($theme_name:ident {
         $(
-            $theme_field_name:ident: $theme_field_val:expr,
-        )*
+            $theme_field_name:ident: $theme_field_val:expr
+        ),* $(,)?
     }) => {
         $crate::paste! {
             #[allow(clippy::needless_update)]


### PR DESCRIPTION
I tend to make trailing commas required for standardization but public macros should be more permissive especially since the error without the trailing comma is not very self explanatory.