### PR TITLE
feat: Improved node reference listener

### DIFF
--- a/crates/hooks/src/use_node.rs
+++ b/crates/hooks/src/use_node.rs
@@ -8,7 +8,6 @@ use tokio::sync::watch::channel;
 
 /// Subscribe to a Node layout changes.
 pub fn use_node() -> (AttributeValue, NodeReferenceLayout) {
-
     let (tx, signal) = use_hook(|| {
         let (tx, mut rx) = channel::<NodeReferenceLayout>(NodeReferenceLayout::default());
         let mut signal = Signal::new(NodeReferenceLayout::default());

--- a/crates/state/src/custom_attributes.rs
+++ b/crates/state/src/custom_attributes.rs
@@ -11,6 +11,7 @@ use dioxus_native_core::node::FromAnyValue;
 use freya_common::{CursorLayoutResponse, NodeReferenceLayout};
 use freya_engine::prelude::*;
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::watch;
 use torin::geometry::{Area, CursorPoint};
 use uuid::Uuid;
 
@@ -32,11 +33,11 @@ impl Display for ImageReference {
 
 /// Node Reference
 #[derive(Debug, Clone)]
-pub struct NodeReference(pub UnboundedSender<NodeReferenceLayout>);
+pub struct NodeReference(pub Arc<watch::Sender<NodeReferenceLayout>>);
 
 impl PartialEq for NodeReference {
     fn eq(&self, other: &Self) -> bool {
-        self.0.same_channel(&other.0)
+        Arc::ptr_eq(&self.0, &other.0)
     }
 }
 


### PR DESCRIPTION
Depends on https://github.com/marc2332/freya/pull/346

Using `tokio::watch` is more suitable as there is only one listener and one sender