### PR TITLE
feat: Support querying nodes by a matching text in `freya-testing`

### DIFF
--- a/crates/testing/src/test_node.rs
+++ b/crates/testing/src/test_node.rs
@@ -121,4 +121,18 @@ impl TestNode {
     pub fn children_ids(&self) -> Vec<NodeId> {
         self.children_ids.clone()
     }
+
+    /// Get a Node by a matching text.
+    pub fn get_by_text(&self, matching_text: &str) -> Option<Self> {
+        self.utils()
+            .get_node_matching_inside_id(self.node_id, |node| {
+                if let NodeType::Text(TextNode { text, .. }) = &*node.node_type() {
+                    matching_text == text
+                } else {
+                    false
+                }
+            })
+            .first()
+            .cloned()
+    }
 }

--- a/crates/testing/src/test_utils.rs
+++ b/crates/testing/src/test_utils.rs
@@ -2,7 +2,7 @@ use dioxus_native_core::real_dom::NodeImmutable;
 use dioxus_native_core::tree::TreeRef;
 use dioxus_native_core::NodeId;
 use freya_core::prelude::*;
-use freya_dom::prelude::{DioxusNode, SafeDOM};
+use freya_dom::prelude::{DioxusDOM, DioxusNode, SafeDOM};
 use std::sync::{Arc, Mutex};
 
 use crate::test_node::TestNode;
@@ -52,5 +52,52 @@ impl TestUtils {
             state,
             node_type,
         }
+    }
+
+    /// Get a list of Nodes matching the text
+    pub fn get_node_matching_inside_id(
+        &self,
+        node_id: NodeId,
+        matcher: impl Fn(&DioxusNode) -> bool,
+    ) -> Vec<TestNode> {
+        fn traverse_dom(rdom: &DioxusDOM, start_id: NodeId, mut f: impl FnMut(&DioxusNode)) {
+            let mut stack = vec![start_id];
+            let tree = rdom.tree_ref();
+            while let Some(id) = stack.pop() {
+                if let Some(node) = rdom.get(id) {
+                    f(&node);
+                    let children = tree.children_ids_advanced(id, true);
+                    stack.extend(children.iter().copied().rev());
+                }
+            }
+        }
+
+        let dom = self.sdom.get();
+        let rdom = dom.rdom();
+
+        let mut nodes = Vec::default();
+
+        traverse_dom(rdom, node_id, |node| {
+            if matcher(node) {
+                let utils = self.clone();
+
+                let height = node.height();
+                let children_ids = node.child_ids();
+
+                let state = get_node_state(node);
+                let node_type = node.node_type().clone();
+
+                nodes.push(TestNode {
+                    node_id,
+                    utils,
+                    children_ids,
+                    height,
+                    state,
+                    node_type,
+                });
+            }
+        });
+
+        nodes
     }
 }

--- a/crates/testing/tests/test.rs
+++ b/crates/testing/tests/test.rs
@@ -110,3 +110,33 @@ async fn simulate_events() {
 
     assert_eq!(text.text(), Some("Is enabled? true"));
 }
+
+#[tokio::test]
+async fn match_by_text() {
+    fn app() -> Element {
+        rsx!(
+            label {
+                "Hello, World!"
+            }
+            rect {
+                label {
+                    "Hello, Rust!"
+                }
+            }
+        )
+    }
+
+    let mut utils = launch_test(app);
+
+    assert_eq!(
+        utils.root().get_by_text("Hello, World!").unwrap().text(),
+        Some("Hello, World!")
+    );
+
+    assert!(utils.root().get_by_text("Blabla").is_none());
+
+    assert_eq!(
+        utils.root().get_by_text("Hello, Rust!").unwrap().text(),
+        Some("Hello, Rust!")
+    );
+}


### PR DESCRIPTION
Example:

```rs
#[tokio::test]
async fn match_by_text() {
    fn app() -> Element {
        rsx!(
            label {
                "Hello, World!"
            }
            rect {
                label {
                    "Hello, Rust!"
                }
            }
        )
    }

    let mut utils = launch_test(app);

    assert_eq!(
        utils.root().get_by_text("Hello, World!").unwrap().text(),
        Some("Hello, World!")
    );

    assert!(utils.root().get_by_text("Blabla").is_none());

    assert_eq!(
        utils.root().get_by_text("Hello, Rust!").unwrap().text(),
        Some("Hello, Rust!")
    );
}
```