### PR TITLE
feat: Close app with `use_platform`

### DIFF
--- a/crates/common/src/event_messages.rs
+++ b/crates/common/src/event_messages.rs
@@ -26,7 +26,9 @@ pub enum EventMessage {
     /// Focus the previous accessibility Node
     FocusPrevAccessibilityNode,
     /// Trigger window dragging
-    DragWindow
+    DragWindow,
+    /// Close the whole app
+    ExitApp,
 }
 
 impl From<ActionRequestEvent> for EventMessage {

--- a/crates/components/src/window_drag_area.rs
+++ b/crates/components/src/window_drag_area.rs
@@ -1,6 +1,6 @@
 use dioxus::prelude::*;
-use freya_hooks::use_platform;
 use freya_elements::{elements as dioxus_elements, events::MouseEvent};
+use freya_hooks::use_platform;
 
 /// Allow dragging the window when the cursor drag this component with a left mouse click.
 ///
@@ -25,7 +25,7 @@ use freya_elements::{elements as dioxus_elements, events::MouseEvent};
 #[component]
 pub fn WindowDragArea(
     /// The inner children for the WindowDragArea
-    children: Element
+    children: Element,
 ) -> Element {
     let platform = use_platform();
 

--- a/crates/hooks/src/use_platform.rs
+++ b/crates/hooks/src/use_platform.rs
@@ -63,6 +63,11 @@ impl UsePlatform {
         }
     }
 
+    /// Closes the whole app.
+    pub fn exit(&self) {
+        self.send(EventMessage::ExitApp).ok();
+    }
+
     /// Read information about the platform.
     ///
     /// **Important**: This will not subscribe to any changes about the information.

--- a/crates/renderer/src/event_loop.rs
+++ b/crates/renderer/src/event_loop.rs
@@ -38,6 +38,9 @@ pub fn run_event_loop<State: Clone>(
             Event::NewEvents(StartCause::Init) => {
                 _ = proxy.send_event(EventMessage::PollVDOM);
             }
+            Event::UserEvent(EventMessage::ExitApp) => {
+                event_loop.exit();
+            }
             Event::UserEvent(EventMessage::FocusAccessibilityNode(id)) => {
                 app.accessibility
                     .set_accessibility_focus(id, &app.window_env.window);


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/612
Example:

```rs
fn app() -> Element {
    let platform = use_platform();

    rsx!(
        Button {
            onclick: move |_| platform.exit(),
            label { "Close" }
        }
    )
}
```