### PR TITLE
fix: Fix performance dropping rapidly after selecting a text for some time

### DIFF
--- a/crates/core/src/dom/doms.rs
+++ b/crates/core/src/dom/doms.rs
@@ -215,7 +215,7 @@ impl FreyaDOM {
                 let node = rdom.get(*node_id);
                 let layout_node = layout.get(*node_id);
                 if let Some((node, layout_node)) = node.zip(layout_node) {
-                    measure_paragraph(&node, layout_node, true, scale_factor);
+                    measure_paragraph(&node, layout_node, scale_factor);
                 }
             }
         }
@@ -232,7 +232,7 @@ impl FreyaDOM {
                 let layout_node = layout.get(*node_id);
 
                 if let Some((node, layout_node)) = node.zip(layout_node) {
-                    measure_paragraph(&node, layout_node, true, scale_factor);
+                    measure_paragraph(&node, layout_node, scale_factor);
                 }
             }
         }

--- a/crates/core/src/dom/paragraph_utils.rs
+++ b/crates/core/src/dom/paragraph_utils.rs
@@ -8,12 +8,7 @@ use torin::prelude::*;
 
 use crate::dom::DioxusNode;
 
-pub fn measure_paragraph(
-    node: &DioxusNode,
-    layout_node: &LayoutNode,
-    is_editable: bool,
-    scale_factor: f32,
-) {
+pub fn measure_paragraph(node: &DioxusNode, layout_node: &LayoutNode, scale_factor: f32) {
     let paragraph = &layout_node
         .data
         .as_ref()
@@ -21,46 +16,42 @@ pub fn measure_paragraph(
         .get::<CachedParagraph>()
         .unwrap()
         .0;
+
     let scale_factors = scale_factor as f64;
 
-    if is_editable {
-        if let Some((cursor_ref, id, cursor_position, cursor_selections)) =
-            get_cursor_reference(node)
-        {
-            if let Some(cursor_position) = cursor_position {
-                // Calculate the new cursor position
-                let char_position = paragraph.get_glyph_position_at_coordinate(
-                    cursor_position.mul(scale_factors).to_i32().to_tuple(),
-                );
+    if let Some((cursor_ref, id, cursor_position, cursor_selections)) = get_cursor_reference(node) {
+        if let Some(cursor_position) = cursor_position {
+            // Calculate the new cursor position
+            let char_position = paragraph.get_glyph_position_at_coordinate(
+                cursor_position.mul(scale_factors).to_i32().to_tuple(),
+            );
 
-                // Notify the cursor reference listener
-                cursor_ref
-                    .cursor_sender
-                    .send(CursorLayoutResponse::CursorPosition {
-                        position: char_position.position as usize,
-                        id,
-                    })
-                    .ok();
-            }
+            // Notify the cursor reference listener
+            cursor_ref
+                .cursor_sender
+                .send(CursorLayoutResponse::CursorPosition {
+                    position: char_position.position as usize,
+                    id,
+                })
+                .ok();
+        }
 
-            if let Some((origin, dist)) = cursor_selections {
-                // Calculate the start of the highlighting
-                let origin_char = paragraph.get_glyph_position_at_coordinate(
-                    origin.mul(scale_factors).to_i32().to_tuple(),
-                );
-                // Calculate the end of the highlighting
-                let dist_char = paragraph
-                    .get_glyph_position_at_coordinate(dist.mul(scale_factors).to_i32().to_tuple());
+        if let Some((origin, dist)) = cursor_selections {
+            // Calculate the start of the highlighting
+            let origin_char = paragraph
+                .get_glyph_position_at_coordinate(origin.mul(scale_factors).to_i32().to_tuple());
+            // Calculate the end of the highlighting
+            let dist_char = paragraph
+                .get_glyph_position_at_coordinate(dist.mul(scale_factors).to_i32().to_tuple());
 
-                cursor_ref
-                    .cursor_sender
-                    .send(CursorLayoutResponse::TextSelection {
-                        from: origin_char.position as usize,
-                        to: dist_char.position as usize,
-                        id,
-                    })
-                    .ok();
-            }
+            cursor_ref
+                .cursor_sender
+                .send(CursorLayoutResponse::TextSelection {
+                    from: origin_char.position as usize,
+                    to: dist_char.position as usize,
+                    id,
+                })
+                .ok();
         }
     }
 }
@@ -81,8 +72,8 @@ fn get_cursor_reference(
     let cursor_id = cursor_settings.cursor_id?;
 
     let current_cursor_id = { *cursor_ref.cursor_id.lock().unwrap().as_ref()? };
-    let cursor_selections = *cursor_ref.cursor_selections.lock().unwrap();
-    let cursor_position = *cursor_ref.cursor_position.lock().unwrap();
+    let cursor_selections = cursor_ref.cursor_selections.lock().unwrap().take();
+    let cursor_position = cursor_ref.cursor_position.lock().unwrap().take();
 
     if current_cursor_id == cursor_id {
         Some((cursor_ref, cursor_id, cursor_position, cursor_selections))

--- a/crates/core/src/dom/paragraph_utils.rs
+++ b/crates/core/src/dom/paragraph_utils.rs
@@ -71,11 +71,11 @@ fn get_cursor_reference(
     let cursor_ref = cursor_settings.cursor_ref.clone()?;
     let cursor_id = cursor_settings.cursor_id?;
 
-    let current_cursor_id = { *cursor_ref.cursor_id.lock().unwrap().as_ref()? };
-    let cursor_selections = cursor_ref.cursor_selections.lock().unwrap().take();
-    let cursor_position = cursor_ref.cursor_position.lock().unwrap().take();
+    let current_cursor_id = *cursor_ref.cursor_id.lock().unwrap().as_ref()?;
 
     if current_cursor_id == cursor_id {
+        let cursor_selections = cursor_ref.cursor_selections.lock().unwrap().take();
+        let cursor_position = cursor_ref.cursor_position.lock().unwrap().take();
         Some((cursor_ref, cursor_id, cursor_position, cursor_selections))
     } else {
         None

--- a/examples/simple_editor.rs
+++ b/examples/simple_editor.rs
@@ -6,7 +6,7 @@
 use freya::prelude::*;
 
 fn main() {
-    launch(app);
+    launch_with_props(app, "Simple editor", (900.0, 650.0));
 }
 
 fn app() -> Element {


### PR DESCRIPTION
Take the cursor position and selections the moment it is measured instead of received by `use_editable` to avoid unnecessary measurements

Closes https://github.com/marc2332/freya/issues/623