### PR TITLE
fix: Store cached assets in Root Scope

### DIFF
--- a/crates/hooks/src/use_asset_cacher.rs
+++ b/crates/hooks/src/use_asset_cacher.rs
@@ -1,8 +1,9 @@
 use bytes::Bytes;
 use dioxus_core::{
-    prelude::{current_scope_id, provide_root_context, spawn, try_consume_context, ScopeId, Task},
+    prelude::{current_scope_id, spawn, ScopeId, Task},
     Runtime,
 };
+use dioxus_hooks::{use_context, use_context_provider};
 use dioxus_signals::Signal;
 use dioxus_signals::{Readable, Writable};
 use std::{
@@ -74,7 +75,9 @@ impl AssetCacher {
         }
 
         // Insert the asset into the cache
-        let asset_bytes = Signal::new(asset_bytes);
+        let value = ScopeId::ROOT.in_runtime(|| asset_bytes);
+        let asset_bytes = Signal::new_in_scope(value, ScopeId::ROOT);
+
         self.registry.write().insert(
             asset_config.clone(),
             AssetState {
@@ -182,8 +185,12 @@ impl AssetCacher {
 ///
 /// This is a "low level" hook, so you probably won't need it.
 pub fn use_asset_cacher() -> AssetCacher {
-    match try_consume_context() {
-        Some(asset_cacher) => asset_cacher,
-        None => provide_root_context(AssetCacher::default()),
-    }
+    use_context()
+}
+
+/// Initialize the global caching system for assets.
+///
+/// This is a "low level" hook, so you probably won't need it.
+pub fn use_init_asset_cacher() {
+    use_context_provider(AssetCacher::default);
 }

--- a/crates/hooks/src/use_init_native_platform.rs
+++ b/crates/hooks/src/use_init_native_platform.rs
@@ -7,6 +7,8 @@ use dioxus_core::{
 use dioxus_hooks::use_context_provider;
 use dioxus_signals::{Readable, Signal, Writable};
 use freya_core::prelude::NativePlatformReceiver;
+
+use crate::use_init_asset_cacher;
 pub type AccessibilityIdCounter = Rc<RefCell<u64>>;
 
 #[derive(Clone)]
@@ -29,6 +31,9 @@ pub struct UsePlatformEvents {
 
 /// Keep some native features (focused element, preferred theme, etc) on sync between the platform and the components
 pub fn use_init_native_platform() -> UsePlatformEvents {
+    // Inithe global asset cacher
+    use_init_asset_cacher();
+
     // Init the Accessibility Node ID generator
     use_context_provider(|| Rc::new(RefCell::new(0u64)));
 


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/666

This PR modifies under what Scope the cached assets are stored, previously they were stored under the first Scope that called use_asset_cacher, this is obviously a problem if that Scope is dropped. Therefore, this PR will make all assets be stored under The ROOT scope.