### PR TITLE
feat: Simplify return type of `use_animation`

### DIFF
--- a/crates/hooks/src/use_animation.rs
+++ b/crates/hooks/src/use_animation.rs
@@ -361,7 +361,7 @@ pub trait AnimatedValue {
     fn advance(&mut self, index: i32, direction: AnimDirection);
 }
 
-pub type ReadAnimatedValue = ReadOnlySignal<Box<dyn AnimatedValue>>; 
+pub type ReadAnimatedValue = ReadOnlySignal<Box<dyn AnimatedValue>>;
 
 #[derive(Default, PartialEq, Clone)]
 pub struct Context {
@@ -371,10 +371,7 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn with(
-        &mut self,
-        animated_value: impl AnimatedValue + 'static,
-    ) -> ReadAnimatedValue {
+    pub fn with(&mut self, animated_value: impl AnimatedValue + 'static) -> ReadAnimatedValue {
         let val: Box<dyn AnimatedValue> = Box::new(animated_value);
         let signal = Signal::new(val);
         self.animated_values.push(signal);

--- a/crates/hooks/src/use_animation.rs
+++ b/crates/hooks/src/use_animation.rs
@@ -663,16 +663,6 @@ pub fn use_animation<Animated: PartialEq + Clone + 'static>(
     animator
 }
 
-fn use_custom_animation(origin: &'static str, target: &'static str) -> UseAnimator<ReadAnimatedValue> {
-    use_animation(|ctx| {
-        ctx.with(
-            AnimColor::new(origin, target)
-                .time(100)
-                .ease(Ease::Out)
-        )
-    })
-}
-
 pub fn use_animation_with_dependencies<Animated: PartialEq + Clone + 'static, D: Dependency>(
     deps: D,
     run: impl Fn(&mut Context, D::Out) -> Animated + 'static,

--- a/crates/hooks/src/use_animation.rs
+++ b/crates/hooks/src/use_animation.rs
@@ -361,6 +361,8 @@ pub trait AnimatedValue {
     fn advance(&mut self, index: i32, direction: AnimDirection);
 }
 
+pub type ReadAnimatedValue = ReadOnlySignal<Box<dyn AnimatedValue>>; 
+
 #[derive(Default, PartialEq, Clone)]
 pub struct Context {
     animated_values: Vec<Signal<Box<dyn AnimatedValue>>>,
@@ -372,7 +374,7 @@ impl Context {
     pub fn with(
         &mut self,
         animated_value: impl AnimatedValue + 'static,
-    ) -> ReadOnlySignal<Box<dyn AnimatedValue>> {
+    ) -> ReadAnimatedValue {
         let val: Box<dyn AnimatedValue> = Box::new(animated_value);
         let signal = Signal::new(val);
         self.animated_values.push(signal);
@@ -659,6 +661,16 @@ pub fn use_animation<Animated: PartialEq + Clone + 'static>(
     });
 
     animator
+}
+
+fn use_custom_animation(origin: &'static str, target: &'static str) -> UseAnimator<ReadAnimatedValue> {
+    use_animation(|ctx| {
+        ctx.with(
+            AnimColor::new(origin, target)
+                .time(100)
+                .ease(Ease::Out)
+        )
+    })
 }
 
 pub fn use_animation_with_dependencies<Animated: PartialEq + Clone + 'static, D: Dependency>(


### PR DESCRIPTION
This makes it easier to make custom hooks with use_animation

example:
```rs
fn use_custom_animation(origin: &'static str, target: &'static str) -> UseAnimator<ReadAnimatedValue> {
    use_animation(|ctx| {
        ctx.with(
            AnimColor::new(origin, target)
                .time(100)
                .ease(Ease::Out)
        )
    })
}
```