### PR TITLE
fix: Require to pass both the width and height for window size at once when desired

### DIFF
--- a/crates/freya/src/launch.rs
+++ b/crates/freya/src/launch.rs
@@ -40,8 +40,7 @@ pub fn launch(app: AppComponent) {
         app,
         LaunchConfig::<()> {
             window_config: WindowConfig {
-                width: 600.0,
-                height: 600.0,
+                size: (600.0, 600.0),
                 decorations: true,
                 transparent: false,
                 title: "Freya",
@@ -86,8 +85,7 @@ pub fn launch_with_title(app: AppComponent, title: &'static str) {
         app,
         LaunchConfig::<()> {
             window_config: WindowConfig {
-                width: 400.0,
-                height: 300.0,
+                size: (400.0, 300.0),
                 decorations: true,
                 transparent: false,
                 title,
@@ -130,8 +128,7 @@ pub fn launch_with_props(app: AppComponent, title: &'static str, (width, height)
         app,
         LaunchConfig::<()> {
             window_config: WindowConfig {
-                width,
-                height,
+                size: (width, height),
                 decorations: true,
                 transparent: false,
                 title,
@@ -160,8 +157,7 @@ pub fn launch_with_props(app: AppComponent, title: &'static str, (width, height)
 ///     launch_cfg(
 ///         app,
 ///         LaunchConfig::<()>::new()
-///             .with_width(500.0)
-///             .with_height(400.0)
+///             .with_size(500.0, 400.0)
 ///             .with_decorations(true)
 ///             .with_transparency(false)
 ///             .with_title("Freya App")

--- a/crates/renderer/src/config.rs
+++ b/crates/renderer/src/config.rs
@@ -24,18 +24,12 @@ pub type EmbeddedFonts<'a> = Vec<(&'a str, &'a [u8])>;
 
 /// Configuration for a Window.
 pub struct WindowConfig {
-    /// Width of the Window.
-    pub width: f64,
-    /// Height of the window.
-    pub height: f64,
-    /// Minimum width of the Window.
-    pub min_width: Option<f64>,
-    /// Minimum height of the window.
-    pub min_height: Option<f64>,
-    /// Maximum width of the Window.
-    pub max_width: Option<f64>,
-    /// Maximum height of the window.
-    pub max_height: Option<f64>,
+    /// Size of the Window.
+    pub size: (f64, f64),
+    /// Minimum size of the Window.
+    pub min_size: Option<(f64, f64)>,
+    /// Maximum size of the Window.
+    pub max_size: Option<(f64, f64)>,
     /// Enable Window decorations.
     pub decorations: bool,
     /// Title for the Window.
@@ -57,12 +51,9 @@ pub struct WindowConfig {
 impl Default for WindowConfig {
     fn default() -> Self {
         Self {
-            width: 600.0,
-            height: 600.0,
-            min_width: None,
-            min_height: None,
-            max_height: None,
-            max_width: None,
+            size: (600.0, 600.0),
+            min_size: None,
+            max_size: None,
             decorations: true,
             title: "Freya app",
             transparent: false,
@@ -120,39 +111,21 @@ impl LaunchConfig<'_, ()> {
 pub type WindowCallback = Arc<Box<fn(&mut Window)>>;
 
 impl<'a, T: Clone> LaunchConfig<'a, T> {
-    /// Specify a Window width.
-    pub fn with_width(mut self, width: f64) -> Self {
-        self.window_config.width = width;
+    /// Specify a Window size.
+    pub fn with_size(mut self, width: f64, height: f64) -> Self {
+        self.window_config.size = (width, height);
         self
     }
 
-    /// Specify a Window height.
-    pub fn with_height(mut self, height: f64) -> Self {
-        self.window_config.height = height;
+    /// Specify a minimum Window size.
+    pub fn with_min_size(mut self, min_width: f64, min_height: f64) -> Self {
+        self.window_config.min_size = Some((min_width, min_height));
         self
     }
 
-    /// Specify a minimum Window width.
-    pub fn with_min_width(mut self, min_width: f64) -> Self {
-        self.window_config.min_width = Some(min_width);
-        self
-    }
-
-    /// Specify a minimum Window height.
-    pub fn with_min_height(mut self, min_height: f64) -> Self {
-        self.window_config.min_height = Some(min_height);
-        self
-    }
-
-    /// Specify a maximum Window width.
-    pub fn with_max_width(mut self, max_width: f64) -> Self {
-        self.window_config.max_width = Some(max_width);
-        self
-    }
-
-    /// Specify a maximum Window height.
-    pub fn with_max_height(mut self, max_height: f64) -> Self {
-        self.window_config.max_height = Some(max_height);
+    /// Specify a maximum Window size.
+    pub fn with_max_size(mut self, max_width: f64, max_height: f64) -> Self {
+        self.window_config.max_size = Some((max_width, max_height));
         self
     }
 

--- a/crates/renderer/src/window_state.rs
+++ b/crates/renderer/src/window_state.rs
@@ -114,30 +114,18 @@ impl<'a, State: Clone + 'a> WindowState<'a, State> {
             .with_decorations(config.window_config.decorations)
             .with_transparent(config.window_config.transparent)
             .with_window_icon(config.window_config.icon.take())
-            .with_inner_size(LogicalSize::<f64>::new(
-                config.window_config.width,
-                config.window_config.height,
-            ));
+            .with_inner_size(LogicalSize::<f64>::from(config.window_config.size));
 
         set_resource_cache_total_bytes_limit(1000000); // 1MB
         set_resource_cache_single_allocation_byte_limit(Some(500000)); // 0.5MB
 
-        if let Some(min_size) = config
-            .window_config
-            .min_width
-            .zip(config.window_config.min_height)
-        {
-            window_attributes =
-                window_attributes.with_min_inner_size(LogicalSize::<f64>::from(min_size))
+        if let Some((min_width, min_height)) = config.window_config.min_size {
+            window_attributes = window_attributes
+                .with_min_inner_size(LogicalSize::<f64>::new(min_width, min_height));
         }
-
-        if let Some(max_size) = config
-            .window_config
-            .max_width
-            .zip(config.window_config.max_height)
-        {
-            window_attributes =
-                window_attributes.with_max_inner_size(LogicalSize::<f64>::from(max_size))
+        if let Some((max_width, max_height)) = config.window_config.max_size {
+            window_attributes = window_attributes
+                .with_max_inner_size(LogicalSize::<f64>::new(max_width, max_height));
         }
 
         if let Some(with_window_attributes) = &config.window_config.window_attributes_hook {

--- a/crates/renderer/src/window_state.rs
+++ b/crates/renderer/src/window_state.rs
@@ -119,13 +119,13 @@ impl<'a, State: Clone + 'a> WindowState<'a, State> {
         set_resource_cache_total_bytes_limit(1000000); // 1MB
         set_resource_cache_single_allocation_byte_limit(Some(500000)); // 0.5MB
 
-        if let Some((min_width, min_height)) = config.window_config.min_size {
-            window_attributes = window_attributes
-                .with_min_inner_size(LogicalSize::<f64>::new(min_width, min_height));
+        if let Some(min_size) = config.window_config.min_size {
+            window_attributes =
+                window_attributes.with_min_inner_size(LogicalSize::<f64>::from(min_size));
         }
-        if let Some((max_width, max_height)) = config.window_config.max_size {
-            window_attributes = window_attributes
-                .with_max_inner_size(LogicalSize::<f64>::new(max_width, max_height));
+        if let Some(max_size) = config.window_config.max_size {
+            window_attributes =
+                window_attributes.with_max_inner_size(LogicalSize::<f64>::from(max_size));
         }
 
         if let Some(with_window_attributes) = &config.window_config.window_attributes_hook {

--- a/examples/cloned_editor.rs
+++ b/examples/cloned_editor.rs
@@ -7,8 +7,7 @@ fn main() {
     launch_cfg(
         app,
         LaunchConfig::<()>::new()
-            .with_width(900.0)
-            .with_height(500.0)
+            .with_size(900.0, 500.0)
             .with_decorations(true)
             .with_transparency(false)
             .with_title("Editor"),

--- a/examples/custom_font.rs
+++ b/examples/custom_font.rs
@@ -11,8 +11,7 @@ fn main() {
     launch_cfg(
         app,
         LaunchConfig::<()>::new()
-            .with_width(200.0)
-            .with_height(200.0)
+            .with_size(200.0, 200.)
             .with_font("Sansita Swashed", SANSITA_SWASHED),
     );
 }

--- a/examples/frameless_window.rs
+++ b/examples/frameless_window.rs
@@ -9,8 +9,7 @@ fn main() {
     launch_cfg(
         app,
         LaunchConfig::<()>::new()
-            .with_width(400.0)
-            .with_height(200.0)
+            .with_size(400.0, 600.0)
             .with_decorations(false)
             .with_transparency(true)
             .with_title("Floating window"),

--- a/examples/installer/src/main.rs
+++ b/examples/installer/src/main.rs
@@ -12,8 +12,7 @@ fn main() {
         app,
         LaunchConfig::<()>::new()
             .with_title("Freya & cargo-packager")
-            .with_width(400.)
-            .with_height(300.)
+            .with_size(400., 300.)
             .with_icon(LaunchConfig::load_icon(ICON)),
     )
 }

--- a/examples/launch_setup.rs
+++ b/examples/launch_setup.rs
@@ -9,8 +9,7 @@ fn main() {
     launch_cfg(
         app,
         LaunchConfig::<()>::new()
-            .with_height(60.0)
-            .with_width(250.0)
+            .with_size(250.0, 60.0)
             .on_setup(|window| {
                 window.set_title("Hello World");
             })

--- a/examples/performance_overlay_plugin.rs
+++ b/examples/performance_overlay_plugin.rs
@@ -10,8 +10,7 @@ fn main() {
         app,
         LaunchConfig::<()>::new()
             .with_title("Performance Overlay Plugin")
-            .with_width(700.)
-            .with_height(500.)
+            .with_size(700., 500.)
             .with_plugin(PerformanceOverlayPlugin::default()),
     )
 }

--- a/examples/plugin.rs
+++ b/examples/plugin.rs
@@ -24,8 +24,7 @@ fn main() {
         app,
         LaunchConfig::<()>::new()
             .with_plugin(DummyPlugin)
-            .with_width(250.0)
-            .with_height(200.0),
+            .with_size(250.0, 250.),
     )
 }
 

--- a/examples/shader_editor.rs
+++ b/examples/shader_editor.rs
@@ -40,8 +40,7 @@ fn main() {
     launch_cfg(
         app,
         LaunchConfig::<()>::new()
-            .with_width(900.0)
-            .with_height(500.0)
+            .with_size(900.0, 500.0)
             .with_title("Shader Editor"),
     );
 }

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -11,8 +11,7 @@ fn main() {
     launch_cfg(
         app,
         LaunchConfig::<()>::new()
-            .with_width(400.)
-            .with_height(300.)
+            .with_size(400., 300.)
             .with_icon(LaunchConfig::load_icon(ICON)),
     )
 }


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/756

It will not be allowed anymore to pass individual values for window sizing as it can lead to unexpected behaviors.