### PR TITLE
feat: Replace `mouseover` with `mousemove` and add new `mouseover` and `mouseout` events

### DIFF
--- a/crates/components/src/button.rs
+++ b/crates/components/src/button.rs
@@ -3,6 +3,7 @@ use freya_elements::{
     elements as dioxus_elements,
     events::{
         KeyboardEvent,
+        MouseEvent,
         PointerEvent,
         PointerType,
     },
@@ -112,6 +113,7 @@ pub fn Button(
         to_owned![onpress, onclick];
         move |ev: PointerEvent| {
             focus.focus();
+            ev.stop_propagation();
             if let Some(onpress) = &onpress {
                 let is_valid = match ev.data.pointer_type {
                     PointerType::Mouse {
@@ -141,12 +143,13 @@ pub fn Button(
         }
     });
 
-    let onmouseenter = move |_| {
+    let onmouseover = move |e: MouseEvent| {
+        e.stop_propagation();
         platform.set_cursor(CursorIcon::Pointer);
         status.set(ButtonStatus::Hovering);
     };
 
-    let onmouseleave = move |_| {
+    let onmouseout = move |_| {
         platform.set_cursor(CursorIcon::default());
         status.set(ButtonStatus::default());
     };
@@ -172,8 +175,8 @@ pub fn Button(
     rsx!(
         rect {
             onpointerup,
-            onmouseenter,
-            onmouseleave,
+            onmouseover,
+            onmouseout,
             onkeydown,
             focus_id,
             width: "{width}",

--- a/crates/components/src/cursor_area.rs
+++ b/crates/components/src/cursor_area.rs
@@ -37,7 +37,7 @@ pub fn CursorArea(CursorAreaProps { children, icon }: CursorAreaProps) -> Elemen
     let platform = use_platform();
     let mut is_hovering = use_signal(|| false);
 
-    let onmouseover = move |_| {
+    let onmousemove = move |_| {
         *is_hovering.write() = true;
         platform.set_cursor(icon);
     };
@@ -55,7 +55,7 @@ pub fn CursorArea(CursorAreaProps { children, icon }: CursorAreaProps) -> Elemen
 
     rsx!(
         rect {
-            onmouseover,
+            onmousemove,
             onmouseleave,
             {children}
         }
@@ -98,7 +98,7 @@ mod test {
         assert_eq!(utils.cursor_icon(), CursorIcon::default());
 
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (100., 100.).into(),
             button: Some(MouseButton::Left),
         });
@@ -109,7 +109,7 @@ mod test {
         assert_eq!(utils.cursor_icon(), CursorIcon::Progress);
 
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (100., 300.).into(),
             button: Some(MouseButton::Left),
         });
@@ -120,7 +120,7 @@ mod test {
         assert_eq!(utils.cursor_icon(), CursorIcon::Pointer);
 
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (-1., -1.).into(),
             button: Some(MouseButton::Left),
         });

--- a/crates/components/src/drag_drop.rs
+++ b/crates/components/src/drag_drop.rs
@@ -45,7 +45,7 @@ pub fn DragZone<T: 'static + Clone + PartialEq>(
     let mut pos = use_signal(CursorPoint::default);
     let (node_reference, size) = use_node_signal();
 
-    let onglobalmouseover = move |e: MouseEvent| {
+    let onglobalmousemove = move |e: MouseEvent| {
         if *dragging.read() {
             let size = size.read();
             let coord = e.get_screen_coordinates();
@@ -94,7 +94,7 @@ pub fn DragZone<T: 'static + Clone + PartialEq>(
         rect {
             reference: node_reference,
             onglobalclick,
-            onglobalmouseover: onglobalmouseover,
+            onglobalmousemove: onglobalmousemove,
             onmousedown,
             {children}
         }
@@ -189,7 +189,7 @@ mod test {
         utils.wait_for_update().await;
 
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (5.0, 5.0).into(),
             button: Some(MouseButton::Left),
         });
@@ -197,7 +197,7 @@ mod test {
         utils.wait_for_update().await;
 
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (5.0, 300.0).into(),
             button: Some(MouseButton::Left),
         });

--- a/crates/components/src/input.rs
+++ b/crates/components/src/input.rs
@@ -138,8 +138,8 @@ pub fn Input(
         focus.focus();
     };
 
-    let onmouseover = move |e: MouseEvent| {
-        editable.process_event(&EditableEvent::MouseOver(e.data, 0));
+    let onmousemove = move |e: MouseEvent| {
+        editable.process_event(&EditableEvent::MouseMove(e.data, 0));
     };
 
     let onmouseenter = move |_| {
@@ -219,7 +219,7 @@ pub fn Input(
                 onmouseenter,
                 onmouseleave,
                 onmousedown,
-                onmouseover,
+                onmousemove,
                 width: "100%",
                 cursor_id: "0",
                 cursor_index: "{cursor_char}",

--- a/crates/components/src/menu.rs
+++ b/crates/components/src/menu.rs
@@ -428,7 +428,7 @@ mod test {
 
         // Open the SubMenu
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (15.0, 130.0).into(),
             button: Some(MouseButton::Left),
         });
@@ -456,7 +456,7 @@ mod test {
 
         // Stop showing the submenu
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (15.0, 90.0).into(),
             button: Some(MouseButton::Left),
         });

--- a/crates/components/src/scroll_views/scroll_view.rs
+++ b/crates/components/src/scroll_views/scroll_view.rs
@@ -163,7 +163,7 @@ pub fn ScrollView(props: ScrollViewProps) -> Element {
     };
 
     // Drag the scrollbars
-    let onmouseover = move |e: MouseEvent| {
+    let onmousemove = move |e: MouseEvent| {
         let clicking_scrollbar = clicking_scrollbar.peek();
 
         if let Some((Axis::Y, y)) = *clicking_scrollbar {
@@ -297,7 +297,7 @@ pub fn ScrollView(props: ScrollViewProps) -> Element {
             width: "{user_container_width}",
             height: "{user_container_height}",
             onglobalclick: onclick,
-            onglobalmouseover: onmouseover,
+            onglobalmousemove: onmousemove,
             onkeydown,
             onkeyup,
             focus_id,
@@ -447,7 +447,7 @@ mod test {
 
         // Simulate the user dragging the scrollbar
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (490., 20.).into(),
             button: Some(MouseButton::Left),
         });
@@ -457,7 +457,7 @@ mod test {
             button: Some(MouseButton::Left),
         });
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (490., 320.).into(),
             button: Some(MouseButton::Left),
         });

--- a/crates/components/src/scroll_views/virtual_scroll_view.rs
+++ b/crates/components/src/scroll_views/virtual_scroll_view.rs
@@ -224,7 +224,7 @@ pub fn VirtualScrollView<
     };
 
     // Drag the scrollbars
-    let onmouseover = move |e: MouseEvent| {
+    let onmousemove = move |e: MouseEvent| {
         let clicking_scrollbar = clicking_scrollbar.peek();
 
         if let Some((Axis::Y, y)) = *clicking_scrollbar {
@@ -387,7 +387,7 @@ pub fn VirtualScrollView<
             width: "{user_container_width}",
             height: "{user_container_height}",
             onglobalclick: onclick,
-            onglobalmouseover: onmouseover,
+            onglobalmousemove: onmousemove,
             onkeydown,
             onkeyup,
             focus_id,
@@ -550,7 +550,7 @@ mod test {
 
         // Simulate the user dragging the scrollbar
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (490., 20.).into(),
             button: Some(MouseButton::Left),
         });
@@ -560,7 +560,7 @@ mod test {
             button: Some(MouseButton::Left),
         });
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (490., 320.).into(),
             button: Some(MouseButton::Left),
         });

--- a/crates/components/src/slider.rs
+++ b/crates/components/src/slider.rs
@@ -118,7 +118,7 @@ pub fn Slider(
         platform.set_cursor(CursorIcon::Pointer);
     };
 
-    let onmouseover = {
+    let onmousemove = {
         to_owned![onmoved];
         move |e: MouseEvent| {
             e.stop_propagation();
@@ -177,7 +177,7 @@ pub fn Slider(
             onglobalclick: onclick,
             focus_id,
             onmouseenter,
-            onglobalmouseover: onmouseover,
+            onglobalmousemove: onmousemove,
             onmouseleave,
             onwheel: onwheel,
             main_align: "center",
@@ -252,7 +252,7 @@ mod test {
         assert_eq!(label.get(0).text(), Some("50"));
 
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (250.0, 7.0).into(),
             button: Some(MouseButton::Left),
         });
@@ -262,7 +262,7 @@ mod test {
             button: Some(MouseButton::Left),
         });
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::MouseOver,
+            name: EventName::MouseMove,
             cursor: (500.0, 7.0).into(),
             button: Some(MouseButton::Left),
         });

--- a/crates/core/src/events/events_measurer.rs
+++ b/crates/core/src/events/events_measurer.rs
@@ -35,7 +35,7 @@ pub fn process_events(
     // 3. Get what events can be actually emitted based on what elements are listening
     let dom_events = measure_dom_events(potential_events, dom, scale_factor);
 
-    // 4. Filter the dom events and get potential collateral events, e.g. mouseover -> mouseenter
+    // 4. Filter the dom events and get potential collateral events, e.g. mousemove -> mouseenter
     let (potential_collateral_events, mut to_emit_dom_events) =
         nodes_state.process_events(&dom_events, events);
 
@@ -195,7 +195,7 @@ fn measure_dom_events(
         let mut valid_events: Vec<PotentialEvent> = Vec::new();
 
         // Iterate over the collateral events (including the source)
-        'event: for collateral_event in collateral_events {
+        'collateral_event: for collateral_event in collateral_events {
             let mut child_node: Option<NodeId> = None;
 
             // Iterate over the event nodes
@@ -227,7 +227,7 @@ fn measure_dom_events(
 
                         // Stack events that do not bubble up
                         if event.get_name().does_bubble() {
-                            continue 'event;
+                            continue 'collateral_event;
                         }
                     }
                 }

--- a/crates/core/tests/pointer_events.rs
+++ b/crates/core/tests/pointer_events.rs
@@ -12,7 +12,7 @@ pub async fn pointer_events_from_mouse() {
 
         let onpointerup = move |_| state.push("up".to_string());
 
-        let onpointerover = move |_| state.push("over".to_string());
+        let onpointermove = move |_| state.push("over".to_string());
 
         let onpointerenter = move |_| state.push("enter".to_string());
 
@@ -30,7 +30,7 @@ pub async fn pointer_events_from_mouse() {
                     width: "100%",
                     onpointerdown,
                     onpointerup,
-                    onpointerover,
+                    onpointermove,
                     onpointerenter,
                     onpointerleave,
                     onglobalpointerup,
@@ -48,9 +48,9 @@ pub async fn pointer_events_from_mouse() {
 
     assert_eq!(label.get(0).text(), Some("[]"));
 
-    // Moving the mouse for the first time will cause `mouseenter` and `mouseover` events
+    // Moving the mouse for the first time will cause `mouseenter` and `mousemove` events
     utils.push_event(PlatformEvent::Mouse {
-        name: EventName::MouseOver,
+        name: EventName::MouseMove,
         cursor: CursorPoint::new(100.0, 100.0),
         button: Some(MouseButton::Left),
     });
@@ -83,7 +83,7 @@ pub async fn pointer_events_from_mouse() {
     );
 
     utils.push_event(PlatformEvent::Mouse {
-        name: EventName::MouseOver,
+        name: EventName::MouseMove,
         cursor: CursorPoint::new(0.0, 0.0),
         button: Some(MouseButton::Left),
     });
@@ -120,7 +120,7 @@ pub async fn pointer_events_from_touch() {
 
         let onpointerup = move |_| state.push("up".to_string());
 
-        let onpointerover = move |_| state.push("over".to_string());
+        let onpointermove = move |_| state.push("over".to_string());
 
         let onpointerenter = move |_| state.push("enter".to_string());
 
@@ -134,7 +134,7 @@ pub async fn pointer_events_from_touch() {
                     width: "100%",
                     onpointerdown: onpointerdown,
                     onpointerup: onpointerup,
-                    onpointerover: onpointerover,
+                    onpointermove: onpointermove,
                     onpointerenter: onpointerenter,
                     label { "{state:?}" }
                 }

--- a/crates/elements/src/_docs/events/globalmousemove.md
+++ b/crates/elements/src/_docs/events/globalmousemove.md
@@ -1,4 +1,4 @@
-The `globalmouseover` event fires when the user moves the mouse anywhere in the app.
+The `globalmousemove` event fires when the user moves the mouse anywhere in the app.
 
 Event Data: [`MouseData`](crate::events::MouseData)
 
@@ -9,7 +9,7 @@ Event Data: [`MouseData`](crate::events::MouseData)
 fn app() -> Element {
     rsx!(
         rect {
-            onglobalmouseover: |_| println!("Moving the mouse somewhere!")
+            onglobalmousemove: |_| println!("Moving the mouse somewhere!")
         }
         rect {
             width: "100",

--- a/crates/elements/src/_docs/events/mouseleave.md
+++ b/crates/elements/src/_docs/events/mouseleave.md
@@ -1,4 +1,4 @@
-The `mouseleave` event fires when the user stops hovering an element.
+The `mouseleave` event fires when the user stops hovering an element. Used in combination of [`mouseenter`](crate::elements::onmouseenter).
 
 Event Data: [`MouseData`](crate::events::MouseData)
 

--- a/crates/elements/src/_docs/events/mousemove.md
+++ b/crates/elements/src/_docs/events/mousemove.md
@@ -1,6 +1,6 @@
-The `mousemove` event fires when the user moves the mouse over an element.
-Unlike [`onmousemove`](crate::elements::onmousemove), this fires even if the user was already hovering over
-the element. For that reason, it's less efficient.
+The `mousemove` event fires when the user moves the mouse over an element or any of its children.
+Unlike [`mouseenter`](crate::elements::onmouseenter), this fires even if the user was already hovering over
+the element.
 
 Event Data: [`MouseData`](crate::events::MouseData)
 

--- a/crates/elements/src/_docs/events/mousemove.md
+++ b/crates/elements/src/_docs/events/mousemove.md
@@ -1,5 +1,5 @@
-The `mouseover` event fires when the user moves the mouse over an element.
-Unlike [`onmouseover`](crate::elements::onmouseover), this fires even if the user was already hovering over
+The `mousemove` event fires when the user moves the mouse over an element.
+Unlike [`onmousemove`](crate::elements::onmousemove), this fires even if the user was already hovering over
 the element. For that reason, it's less efficient.
 
 Event Data: [`MouseData`](crate::events::MouseData)
@@ -14,7 +14,7 @@ fn app() -> Element {
             width: "100",
             height: "100",
             background: "red",
-            onmouseover: |_| println!("Hovering!")
+            onmousemove: |_| println!("Hovering!")
         }
     )
 }

--- a/crates/elements/src/_docs/events/mouseout.md
+++ b/crates/elements/src/_docs/events/mouseout.md
@@ -1,4 +1,4 @@
-The `mouseenter` event fires when the user starts hovering an element. Usually used in combination of [`mouseleave`](crate::elements::onmouseleave).
+The `mouseout` event fires when the user stops hovering an element. Used in combination of [`mouseover`](crate::elements::mouseover).
 
 Event Data: [`MouseData`](crate::events::MouseData)
 
@@ -12,7 +12,7 @@ fn app() -> Element {
             width: "100",
             height: "100",
             background: "red",
-            onmouseenter: |_| println!("Started hovering!")
+            onmouseout: |_| println!("Stopped hovering!")
         }
     )
 }

--- a/crates/elements/src/_docs/events/mouseover.md
+++ b/crates/elements/src/_docs/events/mouseover.md
@@ -1,4 +1,4 @@
-The `mouseenter` event fires when the user starts hovering an element. Usually used in combination of [`mouseleave`](crate::elements::onmouseleave).
+The `mouseover` event fires when the user starts hovering an element. Usually used in combination of [`mouseleave`](crate::elements::onmouseleave).
 
 Event Data: [`MouseData`](crate::events::MouseData)
 
@@ -12,7 +12,7 @@ fn app() -> Element {
             width: "100",
             height: "100",
             background: "red",
-            onmouseenter: |_| println!("Started hovering!")
+            onmouseover: |_| println!("Started hovering!")
         }
     )
 }

--- a/crates/elements/src/_docs/events/pointermove.md
+++ b/crates/elements/src/_docs/events/pointermove.md
@@ -1,4 +1,4 @@
-The `pointerover` event fires when the user hovers/touches over an element.
+The `pointermove` event fires when is hovering/touching over an element.
 Unlike [`onpointerenter`](crate::elements::onpointerenter), this fires even if the user was already hovering over
 the element. For that reason, it's less efficient.
 
@@ -14,7 +14,7 @@ fn app() -> Element {
             width: "100",
             height: "100",
             background: "red",
-            onpointerover: |_| println!("Hovering or touching!")
+            onpointermove: |_| println!("Hovering or touching!")
         }
     )
 }

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -587,14 +587,17 @@ pub mod events {
         onmousedown
         #[doc = include_str!("_docs/events/globalmousedown.md")]
         onglobalmousedown
-        #[doc = include_str!("_docs/events/mouseover.md")]
-        onmouseover
-        #[doc = include_str!("_docs/events/globalmouseover.md")]
-        onglobalmouseover
+        #[doc = include_str!("_docs/events/mousemove.md")]
+        onmousemove
+        #[doc = include_str!("_docs/events/globalmousemove.md")]
+        onglobalmousemove
         #[doc = include_str!("_docs/events/mouseleave.md")]
         onmouseleave
         #[doc = include_str!("_docs/events/mouseenter.md")]
         onmouseenter
+
+        onmouseover
+        onmouseout
     ];
 
     impl_event! [
@@ -635,8 +638,8 @@ pub mod events {
         onpointerup
         #[doc = include_str!("_docs/events/onglobalpointerup.md")]
         onglobalpointerup
-        #[doc = include_str!("_docs/events/pointerover.md")]
-        onpointerover
+        #[doc = include_str!("_docs/events/pointermove.md")]
+        onpointermove
         #[doc = include_str!("_docs/events/pointerenter.md")]
         onpointerenter
         #[doc = include_str!("_docs/events/pointerleave.md")]

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -595,8 +595,9 @@ pub mod events {
         onmouseleave
         #[doc = include_str!("_docs/events/mouseenter.md")]
         onmouseenter
-
+        #[doc = include_str!("_docs/events/mouseover.md")]
         onmouseover
+        #[doc = include_str!("_docs/events/mouseout.md")]
         onmouseout
     ];
 

--- a/crates/hooks/src/use_editable.rs
+++ b/crates/hooks/src/use_editable.rs
@@ -42,7 +42,7 @@ use crate::{
 /// Events emitted to the [`UseEditable`].
 pub enum EditableEvent {
     Click,
-    MouseOver(Rc<MouseData>, usize),
+    MouseMove(Rc<MouseData>, usize),
     MouseDown(Rc<MouseData>, usize),
     KeyDown(Rc<KeyboardData>),
     KeyUp(Rc<KeyboardData>),
@@ -166,7 +166,7 @@ impl UseEditable {
 
                 Some((*id, Some(coords), None))
             }
-            EditableEvent::MouseOver(e, id) => {
+            EditableEvent::MouseMove(e, id) => {
                 if let Some(src) = self.dragging.peek().get_cursor_coords() {
                     let new_dist = e.get_element_coordinates();
 

--- a/crates/hooks/tests/use_editable.rs
+++ b/crates/hooks/tests/use_editable.rs
@@ -302,8 +302,8 @@ pub async fn highlight_multiple_lines_single_editor() {
             editable.process_event(&EditableEvent::MouseDown(e.data, 0));
         };
 
-        let onmouseover = move |e: MouseEvent| {
-            editable.process_event(&EditableEvent::MouseOver(e.data, 0));
+        let onmousemove = move |e: MouseEvent| {
+            editable.process_event(&EditableEvent::MouseMove(e.data, 0));
         };
 
         let onkeydown = move |e: Event<KeyboardData>| {
@@ -326,7 +326,7 @@ pub async fn highlight_multiple_lines_single_editor() {
                     highlights,
                     onkeydown,
                     onmousedown,
-                    onmouseover,
+                    onmousemove,
                     text {
                         color: "black",
                         "{editor}"
@@ -356,7 +356,7 @@ pub async fn highlight_multiple_lines_single_editor() {
 
     // Move cursor
     utils.push_event(PlatformEvent::Mouse {
-        name: EventName::MouseOver,
+        name: EventName::MouseMove,
         cursor: (80.0, 20.0).into(),
         button: Some(MouseButton::Left),
     });
@@ -407,8 +407,8 @@ pub async fn highlights_single_line_multiple_editors() {
                         "none".to_string()
                     };
 
-                    let onmouseover = move |e: MouseEvent| {
-                        editable.process_event(&EditableEvent::MouseOver(e.data, i));
+                    let onmousemove = move |e: MouseEvent| {
+                        editable.process_event(&EditableEvent::MouseMove(e.data, i));
                     };
 
                     let onmousedown = move |e: MouseEvent| {
@@ -424,7 +424,7 @@ pub async fn highlights_single_line_multiple_editors() {
                             cursor_index: "{character_index}",
                             cursor_color: "black",
                             cursor_mode: "editable",
-                            onmouseover,
+                            onmousemove,
                             onmousedown,
                             highlights,
                             text {
@@ -458,7 +458,7 @@ pub async fn highlights_single_line_multiple_editors() {
 
     // Move cursor
     utils.push_event(PlatformEvent::Mouse {
-        name: EventName::MouseOver,
+        name: EventName::MouseMove,
         cursor: (35.0, 3.0).into(),
         button: Some(MouseButton::Left),
     });
@@ -468,7 +468,7 @@ pub async fn highlights_single_line_multiple_editors() {
 
     // Move cursor
     utils.push_event(PlatformEvent::Mouse {
-        name: EventName::MouseOver,
+        name: EventName::MouseMove,
         cursor: (80.0, 35.0).into(),
         button: Some(MouseButton::Left),
     });
@@ -803,8 +803,8 @@ pub async fn highlight_shift_click_multiple_lines_single_editor() {
             editable.process_event(&EditableEvent::MouseDown(e.data, 0));
         };
 
-        let onmouseover = move |e: MouseEvent| {
-            editable.process_event(&EditableEvent::MouseOver(e.data, 0));
+        let onmousemove = move |e: MouseEvent| {
+            editable.process_event(&EditableEvent::MouseMove(e.data, 0));
         };
 
         let onkeydown = move |e: Event<KeyboardData>| {
@@ -832,7 +832,7 @@ pub async fn highlight_shift_click_multiple_lines_single_editor() {
                     onkeydown,
                     onclick,
                     onmousedown,
-                    onmouseover,
+                    onmousemove,
                     text {
                         color: "black",
                         "{editor}"
@@ -934,8 +934,8 @@ pub async fn highlights_shift_click_single_line_multiple_editors() {
                         "none".to_string()
                     };
 
-                    let onmouseover = move |e: MouseEvent| {
-                        editable.process_event(&EditableEvent::MouseOver(e.data, i));
+                    let onmousemove = move |e: MouseEvent| {
+                        editable.process_event(&EditableEvent::MouseMove(e.data, i));
                     };
 
                     let onmousedown = move |e: MouseEvent| {
@@ -956,7 +956,7 @@ pub async fn highlights_shift_click_single_line_multiple_editors() {
                             cursor_color: "black",
                             cursor_mode: "editable",
                             onclick,
-                            onmouseover,
+                            onmousemove,
                             onmousedown,
                             highlights,
                             text {
@@ -1047,8 +1047,8 @@ pub async fn highlight_all_text() {
             editable.process_event(&EditableEvent::MouseDown(e.data, 0));
         };
 
-        let onmouseover = move |e: MouseEvent| {
-            editable.process_event(&EditableEvent::MouseOver(e.data, 0));
+        let onmousemove = move |e: MouseEvent| {
+            editable.process_event(&EditableEvent::MouseMove(e.data, 0));
         };
 
         let onkeydown = move |e: Event<KeyboardData>| {
@@ -1076,7 +1076,7 @@ pub async fn highlight_all_text() {
                     onkeydown,
                     onclick,
                     onmousedown,
-                    onmouseover,
+                    onmousemove,
                     text {
                         color: "black",
                         "{editor}"

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -216,11 +216,17 @@ impl EventName {
 
     // Bubble all events except:
     // - Keyboard events
-    // - Mouse movements
+    // - Mouse movements events
     pub fn does_bubble(&self) -> bool {
         !matches!(
             self,
-            Self::KeyDown | Self::KeyUp | Self::MouseEnter | Self::PointerEnter
+            Self::KeyDown
+                | Self::KeyUp
+                | Self::MouseEnter
+                | Self::PointerEnter
+                | Self::MouseLeave
+                | Self::MouseOut
+                | Self::PointerLeave
         )
     }
 

--- a/crates/renderer/src/renderer.rs
+++ b/crates/renderer/src/renderer.rs
@@ -365,7 +365,7 @@ impl<'a, State: Clone> ApplicationHandler<EventMessage> for DesktopRenderer<'a, 
                 self.cursor_pos = CursorPoint::new(-1.0, -1.0);
 
                 self.send_event(PlatformEvent::Mouse {
-                    name: EventName::MouseOver,
+                    name: EventName::MouseMove,
                     cursor: self.cursor_pos,
                     button: None,
                 });
@@ -374,7 +374,7 @@ impl<'a, State: Clone> ApplicationHandler<EventMessage> for DesktopRenderer<'a, 
                 self.cursor_pos = CursorPoint::from((position.x, position.y));
 
                 self.send_event(PlatformEvent::Mouse {
-                    name: EventName::MouseOver,
+                    name: EventName::MouseMove,
                     cursor: self.cursor_pos,
                     button: None,
                 });

--- a/examples/cloned_editor.rs
+++ b/examples/cloned_editor.rs
@@ -89,8 +89,8 @@ fn Body() -> Element {
                         editable.process_event(&EditableEvent::MouseDown(e.data, line_index));
                     };
 
-                    let onmouseover = move |e: MouseEvent| {
-                        editable.process_event(&EditableEvent::MouseOver(e.data, line_index));
+                    let onmousemove = move |e: MouseEvent| {
+                        editable.process_event(&EditableEvent::MouseMove(e.data, line_index));
                     };
 
                     let highlights = editable.highlights_attr(line_index);
@@ -121,7 +121,7 @@ fn Body() -> Element {
                                 cursor_mode: "editable",
                                 cursor_id: "{line_index}",
                                 onmousedown,
-                                onmouseover,
+                                onmousemove,
                                 highlights,
                                 text {
                                     color: "rgb(240, 240, 240)",
@@ -165,8 +165,8 @@ fn Body() -> Element {
                         editable.process_event(&EditableEvent::MouseDown(e.data, line_index));
                     };
 
-                    let onmouseover = move |e: MouseEvent| {
-                        editable.process_event(&EditableEvent::MouseOver(e.data, line_index));
+                    let onmousemove = move |e: MouseEvent| {
+                        editable.process_event(&EditableEvent::MouseMove(e.data, line_index));
                     };
 
                     let highlights = editable.highlights_attr(line_index);
@@ -197,7 +197,7 @@ fn Body() -> Element {
                                 cursor_mode: "editable",
                                 cursor_id: "{line_index}",
                                 onmousedown,
-                                onmouseover,
+                                onmousemove,
                                 highlights,
                                 highlight_mode: "expanded",
                                 text {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -35,7 +35,10 @@ fn app() -> Element {
             direction: "horizontal",
             Button {
                 onclick: move |_| count += 1,
-                label { "Increase" }
+                Button {
+                    onclick: move |_| count += 1,
+                    label { "Increase" }
+                }
             }
             Button {
                 onclick: move |_| count -= 1,

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -35,10 +35,7 @@ fn app() -> Element {
             direction: "horizontal",
             Button {
                 onclick: move |_| count += 1,
-                Button {
-                    onclick: move |_| count += 1,
-                    label { "Increase" }
-                }
+                label { "Increase" }
             }
             Button {
                 onclick: move |_| count -= 1,

--- a/examples/drag.rs
+++ b/examples/drag.rs
@@ -13,7 +13,7 @@ fn app() -> Element {
     let mut positions = use_signal(|| (0.0f64, 0.0f64));
     let mut clicking = use_signal::<Option<CursorPoint>>(|| None);
 
-    let onglobalmouseover = move |e: MouseEvent| {
+    let onglobalmousemove = move |e: MouseEvent| {
         if let Some(clicked) = *clicking.read() {
             let coordinates = e.get_screen_coordinates();
             positions.set((coordinates.x - clicked.x, coordinates.y - clicked.y));
@@ -42,7 +42,7 @@ fn app() -> Element {
                 corner_radius: "16",
                 shadow: "0 0 35 10 rgb(255, 255, 255, 0.4)",
                 onglobalclick,
-                onglobalmouseover,
+                onglobalmousemove,
                 onmousedown,
                 main_align: "center",
                 cross_align: "center",

--- a/examples/floating_editors.rs
+++ b/examples/floating_editors.rs
@@ -26,7 +26,7 @@ fn app() -> Element {
         }
     };
 
-    let onmouseover = move |e: MouseEvent| {
+    let onmousemove = move |e: MouseEvent| {
         hovering.set(true);
         if let Some(clicking_cords) = *clicking.peek() {
             let coordinates = e.get_screen_coordinates();
@@ -75,7 +75,7 @@ fn app() -> Element {
                 offset_y: "{canvas_pos.read().1}",
                 onmousedown,
                 onclick,
-                onmouseover,
+                onmousemove,
                 onmouseleave,
                 label {
                     font_size: "25",
@@ -303,8 +303,8 @@ fn Editor() -> Element {
                                     editable.process_event(&EditableEvent::MouseDown(e.data, line_index));
                                 };
 
-                                let onmouseover = move |e: MouseEvent| {
-                                    editable.process_event(&EditableEvent::MouseOver(e.data, line_index));
+                                let onmousemove = move |e: MouseEvent| {
+                                    editable.process_event(&EditableEvent::MouseMove(e.data, line_index));
                                 };
 
                                 let onglobalclick = move |_: MouseEvent| {
@@ -344,7 +344,7 @@ fn Editor() -> Element {
                                             cursor_mode: "editable",
                                             cursor_id: "{cursor_id}",
                                             onmousedown,
-                                            onmouseover,
+                                            onmousemove,
                                             onglobalclick,
                                             highlights: highlights,
                                             text {

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -52,7 +52,7 @@ fn Area() -> Element {
             width: "100%",
             background: "blue",
             padding: "5",
-            onmouseover: cursor_moved,
+            onmousemove: cursor_moved,
             onclick: cursor_clicked,
             label {
                 "Mouse is at [x: {cursor_pos_over.read().0}, y: {cursor_pos_over.read().1}] ",

--- a/examples/mouse_trace.rs
+++ b/examples/mouse_trace.rs
@@ -43,7 +43,7 @@ fn Box() -> Element {
 fn app() -> Element {
     let mut positions = use_signal::<Vec<CursorPoint>>(Vec::new);
 
-    let onmouseover = move |e: MouseEvent| {
+    let onmousemove = move |e: MouseEvent| {
         let coordinates = e.get_screen_coordinates();
         positions.with_mut(|positions| {
             if let Some(pos) = positions.first() {
@@ -62,7 +62,7 @@ fn app() -> Element {
 
     rsx!(
         rect {
-            onmouseover,
+            onmousemove,
             width: "100%",
             height: "100%",
             {positions.read().iter().map(|pos| rsx!(

--- a/examples/pointer.rs
+++ b/examples/pointer.rs
@@ -18,7 +18,7 @@ fn app() -> Element {
         println!("Up -> {:?}", ev.data.get_pointer_type());
     };
 
-    let onpointerover = move |ev: PointerEvent| {
+    let onpointermove = move |ev: PointerEvent| {
         println!("Over -> {:?}", ev.data.get_pointer_type());
     };
 
@@ -50,7 +50,7 @@ fn app() -> Element {
                 padding: "12",
                 onpointerdown,
                 onpointerup,
-                onpointerover,
+                onpointermove,
                 onpointerenter,
                 onpointerleave,
                 onglobalpointerup,

--- a/examples/shader_editor.rs
+++ b/examples/shader_editor.rs
@@ -122,8 +122,8 @@ fn ShaderEditor(editable: UseEditable) -> Element {
                         editable.process_event(&EditableEvent::MouseDown(e.data, line_index));
                     };
 
-                    let onmouseover = move |e: MouseEvent| {
-                        editable.process_event(&EditableEvent::MouseOver(e.data, line_index));
+                    let onmousemove = move |e: MouseEvent| {
+                        editable.process_event(&EditableEvent::MouseMove(e.data, line_index));
                     };
 
                     let highlights = editable.highlights_attr(line_index);
@@ -154,7 +154,7 @@ fn ShaderEditor(editable: UseEditable) -> Element {
                                 cursor_mode: "editable",
                                 cursor_id: "{line_index}",
                                 onmousedown,
-                                onmouseover,
+                                onmousemove,
                                 highlights,
                                 highlight_mode: "expanded",
                                 text {

--- a/examples/simple_editor.rs
+++ b/examples/simple_editor.rs
@@ -32,8 +32,8 @@ fn app() -> Element {
         editable.process_event(&EditableEvent::MouseDown(e.data, 0));
     };
 
-    let onmouseover = move |e: MouseEvent| {
-        editable.process_event(&EditableEvent::MouseOver(e.data, 0));
+    let onmousemove = move |e: MouseEvent| {
+        editable.process_event(&EditableEvent::MouseMove(e.data, 0));
     };
 
     let onclick = move |_: MouseEvent| {
@@ -69,7 +69,7 @@ fn app() -> Element {
                     cursor_color: "black",
                     highlights,
                     onclick,
-                    onmouseover,
+                    onmousemove,
                     onmousedown,
                     onkeydown,
                     onkeyup,

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -183,7 +183,7 @@ fn Area() -> Element {
             corner_radius: "12",
             main_align: "center",
             cross_align: "center",
-            onmouseover: cursor_moved,
+            onmousemove: cursor_moved,
             onclick: cursor_clicked,
             label {
                 "Mouse is at [x: {cursor_pos_over.read().0}, y: {cursor_pos_over.read().1}] ",


### PR DESCRIPTION
- Replaces `mouseover` with `mousemove`
- Adds a new `mouseover`, similar to `mousenter` but only for the actual visible area instead of also triggering uppon entering child elements.
- Adds a new `mouseout` to be used in combination with `mouseover`, so just like the former one it would be similar to `mouseleave`, but only trigger when leaving the visible area, which might include hovering a child element for example.


## To Do
- Examples
- Tests
- Docs
- check if `does_bubble` is correct