### PR TITLE
feat: round to physical pixel boundaries while rendering

### DIFF
--- a/crates/core/src/elements/image.rs
+++ b/crates/core/src/elements/image.rs
@@ -21,7 +21,7 @@ impl ElementUtils for ImageElement {
         _default_fonts: &[String],
         _scale_factor: f32,
     ) {
-        let area = layout_node.visible_area();
+        let area = layout_node.visible_area().round();
         let node_style = node_ref.get::<StyleState>().unwrap();
         let node_references = node_ref.get::<ReferencesState>().unwrap();
 

--- a/crates/core/src/elements/label.rs
+++ b/crates/core/src/elements/label.rs
@@ -27,7 +27,7 @@ impl ElementUtils for LabelElement {
             .get::<CachedParagraph>()
             .unwrap()
             .0;
-        let area = layout_node.visible_area();
+        let area = layout_node.visible_area().round();
 
         let x = area.min_x();
         let y = area.min_y() + align_main_align_paragraph(node_ref, &area, paragraph);

--- a/crates/core/src/elements/paragraph.rs
+++ b/crates/core/src/elements/paragraph.rs
@@ -27,7 +27,7 @@ impl ElementUtils for ParagraphElement {
         default_fonts: &[String],
         scale_factor: f32,
     ) {
-        let area = layout_node.visible_area();
+        let area = layout_node.visible_area().round();
         let node_cursor_state = &*node_ref.get::<CursorState>().unwrap();
 
         let paint = |paragraph: &Paragraph| {

--- a/crates/core/src/elements/rect.rs
+++ b/crates/core/src/elements/rect.rs
@@ -29,7 +29,7 @@ impl RectElement {
         node_ref: &DioxusNode,
         scale_factor: f32,
     ) -> RRect {
-        let area = layout_node.visible_area().to_f32();
+        let area = layout_node.visible_area().to_f32().round();
         let node_style = &*node_ref.get::<StyleState>().unwrap();
         let mut radius = node_style.corner_radius;
         radius.scale(scale_factor);
@@ -85,7 +85,7 @@ impl ElementUtils for RectElement {
 
         let mut paint = Paint::default();
         let mut path = Path::new();
-        let area = layout_node.visible_area().to_f32();
+        let area = layout_node.visible_area().to_f32().round();
 
         paint.set_anti_alias(true);
         paint.set_style(PaintStyle::Fill);

--- a/crates/core/src/elements/svg.rs
+++ b/crates/core/src/elements/svg.rs
@@ -19,7 +19,7 @@ impl ElementUtils for SvgElement {
         _default_fonts: &[String],
         _scale_factor: f32,
     ) {
-        let area = layout_node.visible_area();
+        let area = layout_node.visible_area().round();
         let node_style = &*node_ref.get::<StyleState>().unwrap();
 
         let x = area.min_x();


### PR DESCRIPTION
This is a rewrite of #245 that's up to date. Same deal - it just rounds all elements to render on physical pixel boundaries rather than relying subpixel antialiasing which results in blurry borders or incorrect rendering in the case of #836.