### PR TITLE
Update animated_sidebar.rs

### DIFF
--- a/examples/animated_sidebar.rs
+++ b/examples/animated_sidebar.rs
@@ -73,7 +73,7 @@ fn FromRouteToCurrent(from: Element, upwards: bool) -> Element {
                 width: "fill",
                 Expand { {from} }
             }
-        )
+        );
     }
 
     let offset = height - (offset * height);

--- a/examples/animated_sidebar.rs
+++ b/examples/animated_sidebar.rs
@@ -62,6 +62,20 @@ fn FromRouteToCurrent(from: Element, upwards: bool) -> Element {
     let offset = animations.get().read().as_f32();
     let height = node_size.area.height();
 
+    // The node height is at the begging of the animation a few frames 0.
+    // This leads to flickering when moving up because the offset is 0 and not the page height
+    // An easy fix would be
+    if height == 0.0 {
+        return rsx!(
+            rect {
+                reference,
+                height: "fill",
+                width: "fill",
+                Expand { {from} }
+            }
+        )
+    }
+
     let offset = height - (offset * height);
     let to = rsx!(Outlet::<Route> {});
     let (top, bottom) = if upwards { (from, to) } else { (to, from) };


### PR DESCRIPTION
The node height is at the beginning of the animation a few frames 0. This leads to flickering when moving up because the offset is 0 an not the page height. This is an easy fix but maybe it would be better to fix the node_size because this is very unintuitive. This problem exists in the tabs as well I believe. It's easily visible when using ease In.