### PR TITLE
feat: Improved nodes events states

### DIFF
--- a/crates/components/src/drag_drop.rs
+++ b/crates/components/src/drag_drop.rs
@@ -115,7 +115,7 @@ pub struct DropZoneProps<T: 'static + PartialEq + Clone> {
 pub fn DropZone<T: 'static + Clone + PartialEq>(props: DropZoneProps<T>) -> Element {
     let mut drags = use_context::<Signal<Option<T>>>();
 
-    let onclick = move |_: MouseEvent| {
+    let onmouseup = move |_: MouseEvent| {
         if let Some(current_drags) = &*drags.read() {
             props.ondrop.call(current_drags.clone());
         }
@@ -126,7 +126,7 @@ pub fn DropZone<T: 'static + Clone + PartialEq>(props: DropZoneProps<T>) -> Elem
 
     rsx!(
         rect {
-            onclick,
+            onmouseup,
             {props.children}
         }
     )

--- a/crates/components/src/drag_drop.rs
+++ b/crates/components/src/drag_drop.rs
@@ -207,7 +207,7 @@ mod test {
         assert_eq!(root.get(0).get(0).get(0).get(0).text(), Some("Moving"));
 
         utils.push_event(PlatformEvent::Mouse {
-            name: EventName::Click,
+            name: EventName::MouseUp,
             cursor: (5.0, 300.0).into(),
             button: Some(MouseButton::Left),
         });

--- a/crates/core/src/events/events_measurer.rs
+++ b/crates/core/src/events/events_measurer.rs
@@ -27,6 +27,7 @@ pub fn process_events(
     events: &mut EventsQueue,
     event_emitter: &EventEmitter,
     nodes_state: &mut NodesState,
+    always_allow_events: bool,
     scale_factor: f64,
 ) {
     // 1. Get global events created from the incoming events
@@ -36,33 +37,44 @@ pub fn process_events(
     let potential_events = measure_potential_event_listeners(events, dom, scale_factor);
 
     // 3. Get what events can be actually emitted based on what elements are listening
-    let dom_events = measure_dom_events(potential_events, dom, scale_factor);
+    let mut dom_events = measure_dom_events(
+        &potential_events,
+        dom,
+        nodes_state,
+        always_allow_events,
+        scale_factor,
+    );
 
-    // 4. Filter the dom events and get potential collateral events, e.g. mouseover -> mouseenter
-    let (potential_collateral_events, mut to_emit_dom_events) =
-        nodes_state.process_events(&dom_events, events);
+    // 4. Get potential collateral events, e.g. mouseover -> mouseenter
+    let potential_collateral_events =
+        nodes_state.process_collateral(&potential_events, &dom_events, events);
 
     // 5. Get what collateral events can actually be emitted
-    let to_emit_dom_collateral_events =
-        measure_dom_events(potential_collateral_events, dom, scale_factor);
+    let to_emit_dom_collateral_events = measure_dom_events(
+        &potential_collateral_events,
+        dom,
+        nodes_state,
+        always_allow_events,
+        scale_factor,
+    );
 
     let colateral_global_events = measure_colateral_global_events(&to_emit_dom_collateral_events);
 
     // 6. Join both the dom and colateral dom events and sort them
-    to_emit_dom_events.extend(to_emit_dom_collateral_events);
-    to_emit_dom_events.sort_unstable();
+    dom_events.extend(to_emit_dom_collateral_events);
+    dom_events.sort_unstable();
 
     // 7. Emit the global events
     measure_global_events_listeners(
         global_events,
         colateral_global_events,
         dom,
-        &mut to_emit_dom_events,
+        &mut dom_events,
         scale_factor,
     );
 
     // 8. Emit all the vents
-    event_emitter.send(to_emit_dom_events).unwrap();
+    event_emitter.send(dom_events).unwrap();
 
     // 9. Clear the events queue
     events.clear();
@@ -211,8 +223,10 @@ fn is_node_parent_of(rdom: &DioxusDOM, node: NodeId, parent_node: NodeId) -> boo
 
 /// Measure what DOM events could be emitted
 fn measure_dom_events(
-    potential_events: PotentialEvents,
+    potential_events: &PotentialEvents,
     fdom: &FreyaDOM,
+    nodes_state: &NodesState,
+    always_allow_events: bool,
     scale_factor: f64,
 ) -> Vec<DomEvent> {
     let mut new_events = Vec::new();
@@ -246,7 +260,10 @@ fn measure_dom_events(
                         true
                     };
 
-                    if valid_node {
+                    let allowed_event =
+                        always_allow_events || nodes_state.is_event_allowed(event, node_id);
+
+                    if valid_node && allowed_event {
                         let mut valid_event = event.clone();
                         valid_event.set_name(collateral_event);
                         valid_events.push(PotentialEvent {

--- a/crates/core/src/events/nodes_state.rs
+++ b/crates/core/src/events/nodes_state.rs
@@ -23,30 +23,64 @@ struct NodeMetadata {
 /// [`NodesState`] stores the nodes states given incoming events.
 #[derive(Default)]
 pub struct NodesState {
+    pressed_nodes: FxHashMap<NodeId, NodeMetadata>,
     hovered_nodes: FxHashMap<NodeId, NodeMetadata>,
 }
 
 impl NodesState {
-    /// Update the node states given the new events
-    pub fn process_events(
+    /// Given the current state, event, and NodeID check if it is allowed to be emitted
+    /// For example, it will not make sense to emit a Click event on an element that was not pressed before.
+    pub fn is_event_allowed(&self, event: &PlatformEvent, node_id: &NodeId) -> bool {
+        if event.get_name().is_up() {
+            self.pressed_nodes.contains_key(node_id)
+        } else {
+            true
+        }
+    }
+
+    /// Update the node states given the new events and suggest potential collateral new events
+    pub fn process_collateral(
         &mut self,
+        pontential_events: &PotentialEvents,
         events_to_emit: &[DomEvent],
         events: &[PlatformEvent],
-    ) -> (PotentialEvents, Vec<DomEvent>) {
-        let mut new_events_to_emit = Vec::default();
+    ) -> PotentialEvents {
         let mut potential_events = PotentialEvents::default();
 
-        let recent_mouse_movement_event = any_recent_mouse_movement(events);
+        // Any mouse press event at all
+        let recent_mouse_press_event = any_event_of(events, |e| e.was_cursor_pressed_or_released());
 
+        // Pressed Nodes
+        self.pressed_nodes.retain(|node_id, _| {
+            // Always unmark as pressed when there has been a new mouse down or click event
+            if recent_mouse_press_event.is_some() {
+                #[cfg(debug_assertions)]
+                tracing::info!("Unmarked as pressed {:?}", node_id);
+
+                // Remove the node from the list of pressed nodes
+                return false;
+            }
+
+            true
+        });
+
+        // Any mouse movement event at all
+        let recent_mouse_movement_event = any_event_of(events, |e| e.was_cursor_moved());
+
+        // Hovered Nodes
         self.hovered_nodes.retain(|node_id, metadata| {
-            let no_recent_mouse_movement_on_me =
-                has_node_been_hovered_recently(events_to_emit, node_id);
+            // Check if a DOM event that moves the cursor in this Node will get emitted
+            let no_recently_hovered =
+                filter_dom_events_by(events_to_emit, node_id, |e| e.was_cursor_moved());
 
-            if no_recent_mouse_movement_on_me {
+            if no_recently_hovered {
+                // If there has been a mouse movement but a DOM event was not emitted to this node, then we safely assume
+                // the user does no longer want to hover this Node
                 if let Some(PlatformEvent::Mouse { cursor, button, .. }) =
                     recent_mouse_movement_event
                 {
                     let events = potential_events.entry(EventName::MouseLeave).or_default();
+
                     // Emit a MouseLeave event as the cursor was moved outside the Node bounds
                     events.push(PotentialEvent {
                         node_id: *node_id,
@@ -58,45 +92,67 @@ impl NodesState {
                         },
                     });
 
-                    // Remove the node from the list of hovered nodes as now, the cursor has left
+                    #[cfg(debug_assertions)]
+                    tracing::info!("Unmarked as hovered {:?}", node_id);
+
+                    // Remove the node from the list of hovered nodes
                     return false;
                 }
             }
             true
         });
 
+        // Update the state of the noves given the new events.
+
         // We clone this here so events emitted in the same batch that mark an node
-        // as hovered will not affect the other events
+        // as hovered or pressed will not affect the other events
         let hovered_nodes = self.hovered_nodes.clone();
+        let pressed_nodes = self.pressed_nodes.clone();
 
-        // Emit new colateral events
-        for event in events_to_emit {
-            if event.name.can_change_hover_state() {
-                let is_hovered = hovered_nodes.contains_key(&event.node_id);
+        for events in pontential_events.values() {
+            for PotentialEvent {
+                node_id,
+                event,
+                layer,
+            } in events
+            {
+                match event {
+                    // Update hovered nodes state
+                    PlatformEvent::Mouse { name, .. } if name.can_change_hover_state() => {
+                        let is_hovered = hovered_nodes.contains_key(node_id);
 
-                // Mark the Node as hovered if it wasn't already
-                if !is_hovered {
-                    self.hovered_nodes
-                        .insert(event.node_id, NodeMetadata { layer: event.layer });
-                }
+                        // Mark the Node as hovered if it wasn't already
+                        if !is_hovered {
+                            self.hovered_nodes
+                                .insert(*node_id, NodeMetadata { layer: *layer });
 
-                if event.name.is_enter() {
-                    // If the Node was already hovered, we don't need to emit an `enter` event again.
-                    if is_hovered {
-                        continue;
+                            #[cfg(debug_assertions)]
+                            tracing::info!("Marked as hovered {:?}", node_id);
+                        }
+
+                        if name.is_enter() {
+                            // If the Node was already hovered, we don't need to emit an `enter` event again.
+                            if is_hovered {
+                                continue;
+                            }
+                        }
                     }
+
+                    // Update pressed nodes state
+                    PlatformEvent::Mouse { name, .. } if name.can_change_press_state() => {
+                        let is_pressed = pressed_nodes.contains_key(node_id);
+
+                        // Mark the Node as pressed if it wasn't already
+                        if !is_pressed {
+                            self.pressed_nodes
+                                .insert(*node_id, NodeMetadata { layer: *layer });
+
+                            #[cfg(debug_assertions)]
+                            tracing::info!("Marked as pressed {:?}", node_id);
+                        }
+                    }
+                    _ => {}
                 }
-            }
-
-            new_events_to_emit.push(event.clone());
-        }
-
-        // Update the internal states of nodes given the events
-        // e.g `mouseover` will mark the node as hovered.
-        for event in events_to_emit {
-            if event.name.was_cursor_moved() && !self.hovered_nodes.contains_key(&event.node_id) {
-                self.hovered_nodes
-                    .insert(event.node_id, NodeMetadata { layer: event.layer });
             }
         }
 
@@ -105,22 +161,29 @@ impl NodesState {
             events.sort_by(|left, right| left.layer.cmp(&right.layer))
         }
 
-        (potential_events, new_events_to_emit)
+        potential_events
     }
 }
 
-fn any_recent_mouse_movement(events: &[PlatformEvent]) -> Option<PlatformEvent> {
+fn any_event_of(
+    events: &[PlatformEvent],
+    filter: impl Fn(EventName) -> bool,
+) -> Option<PlatformEvent> {
     events
         .iter()
-        .find(|event| event.get_name().was_cursor_moved())
+        .find(|event| filter(event.get_name()))
         .cloned()
 }
 
-fn has_node_been_hovered_recently(events_to_emit: &[DomEvent], node_id: &NodeId) -> bool {
+fn filter_dom_events_by(
+    events_to_emit: &[DomEvent],
+    node_id: &NodeId,
+    filter: impl Fn(EventName) -> bool,
+) -> bool {
     events_to_emit
         .iter()
         .find_map(|event| {
-            if event.name.was_cursor_moved() && &event.node_id == node_id {
+            if filter(event.name) && &event.node_id == node_id {
                 Some(false)
             } else {
                 None

--- a/crates/core/src/events/nodes_state.rs
+++ b/crates/core/src/events/nodes_state.rs
@@ -31,7 +31,7 @@ impl NodesState {
     /// Given the current state, event, and NodeID check if it is allowed to be emitted
     /// For example, it will not make sense to emit a Click event on an element that was not pressed before.
     pub fn is_event_allowed(&self, event: &PlatformEvent, node_id: &NodeId) -> bool {
-        if event.get_name().is_up() {
+        if event.get_name().is_click() {
             self.pressed_nodes.contains_key(node_id)
         } else {
             true

--- a/crates/elements/src/_docs/events/mouseup.md
+++ b/crates/elements/src/_docs/events/mouseup.md
@@ -1,4 +1,4 @@
-The `click` event fires when the user starts and ends a click in an element with the left button of the mouse.
+The `mouseup` event fires when the user ends the click in an element with the left button of the mouse.
 
 Event Data: [`MouseData`](crate::events::MouseData)
 
@@ -12,7 +12,7 @@ fn app() -> Element {
             width: "100",
             height: "100",
             background: "red",
-            onclick: |_| println!("Clicked!")
+            onmouseup: |_| println!("Clicked!")
         }
     )
 }

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -585,6 +585,8 @@ pub mod events {
         onmiddleclick
         #[doc = include_str!("_docs/events/onrightclick.md")]
         onrightclick
+        #[doc = include_str!("_docs/events/onmouseup.md")]
+        onmouseup
         #[doc = include_str!("_docs/events/mousedown.md")]
         onmousedown
         #[doc = include_str!("_docs/events/globalmousedown.md")]

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -581,7 +581,7 @@ pub mod events {
         onclick
         #[doc = include_str!("_docs/events/globalclick.md")]
         onglobalclick
-        #[doc = include_str!("_docs/events/onmiddleclick.md")]
+        #[doc = include_str!("_docs/events/onmiddleclick.md")] // REMOVE "on"
         onmiddleclick
         #[doc = include_str!("_docs/events/onrightclick.md")]
         onrightclick

--- a/crates/elements/src/definitions.rs
+++ b/crates/elements/src/definitions.rs
@@ -585,7 +585,7 @@ pub mod events {
         onmiddleclick
         #[doc = include_str!("_docs/events/onrightclick.md")]
         onrightclick
-        #[doc = include_str!("_docs/events/onmouseup.md")]
+        #[doc = include_str!("_docs/events/mouseup.md")]
         onmouseup
         #[doc = include_str!("_docs/events/mousedown.md")]
         onmousedown

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -139,7 +139,7 @@ impl EventName {
     /// Get the equivalent to a global event
     pub fn get_global_event(&self) -> Option<Self> {
         match self {
-            Self::MouseUp => Some(Self::GlobalClick),
+            Self::Click | Self::MouseUp => Some(Self::GlobalClick),
             Self::PointerUp => Some(Self::GlobalPointerUp),
             Self::MouseDown => Some(Self::GlobalMouseDown),
             Self::MouseOver => Some(Self::GlobalMouseOver),

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -8,6 +8,7 @@ pub enum EventName {
     MiddleClick,
     RightClick,
 
+    MouseUp,
     MouseDown,
     MouseOver,
     MouseEnter,
@@ -47,6 +48,7 @@ impl FromStr for EventName {
             "click" => Ok(EventName::Click),
             "rightclick" => Ok(EventName::RightClick),
             "middleclick" => Ok(EventName::MiddleClick),
+            "mouseup" => Ok(EventName::MouseUp),
             "mousedown" => Ok(EventName::MouseDown),
             "mouseover" => Ok(EventName::MouseOver),
             "mouseenter" => Ok(EventName::MouseEnter),
@@ -81,6 +83,7 @@ impl From<EventName> for &str {
             EventName::Click => "click",
             EventName::MiddleClick => "middleclick",
             EventName::RightClick => "rightclick",
+            EventName::MouseUp => "mouseup",
             EventName::MouseDown => "mousedown",
             EventName::MouseOver => "mouseover",
             EventName::MouseEnter => "mouseenter",
@@ -136,7 +139,7 @@ impl EventName {
     /// Get the equivalent to a global event
     pub fn get_global_event(&self) -> Option<Self> {
         match self {
-            Self::Click => Some(Self::GlobalClick),
+            Self::MouseUp => Some(Self::GlobalClick),
             Self::PointerUp => Some(Self::GlobalPointerUp),
             Self::MouseDown => Some(Self::GlobalMouseDown),
             Self::MouseOver => Some(Self::GlobalMouseOver),
@@ -159,8 +162,8 @@ impl EventName {
                 events.extend([Self::MouseEnter, Self::PointerEnter, Self::PointerOver])
             }
             Self::MouseDown | Self::TouchStart => events.push(Self::PointerDown),
-            Self::Click | Self::MiddleClick | Self::RightClick | Self::TouchEnd => {
-                events.push(Self::PointerUp)
+            Self::MouseUp | Self::MiddleClick | Self::RightClick | Self::TouchEnd => {
+                events.extend([Self::Click, Self::PointerUp])
             }
             Self::MouseLeave => events.push(Self::PointerLeave),
             Self::GlobalFileHover | Self::GlobalFileHoverCancelled => events.clear(),
@@ -235,12 +238,12 @@ impl EventName {
     pub fn was_cursor_pressed_or_released(&self) -> bool {
         matches!(
             &self,
-            Self::MouseDown | Self::PointerDown | Self::Click | Self::PointerUp
+            Self::MouseDown | Self::PointerDown | Self::MouseUp | Self::Click | Self::PointerUp
         )
     }
 
-    /// Check if the event means the cursor was released
-    pub fn is_up(&self) -> bool {
-        matches!(&self, Self::Click | Self::PointerUp)
+    /// Check if the event was a click
+    pub fn is_click(&self) -> bool {
+        matches!(&self, Self::Click)
     }
 }

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -213,16 +213,34 @@ impl EventName {
         )
     }
 
-    // Only let events that do not move the mouse, go through solid nodes
+    /// Only let events that do not move the mouse, go through solid nodes
     pub fn does_go_through_solid(&self) -> bool {
         matches!(self, Self::KeyDown | Self::KeyUp)
     }
 
-    // Check if this event can change the hover state of a Node.
+    /// Check if this event can change the hover state of a Node.
     pub fn can_change_hover_state(&self) -> bool {
         matches!(
             self,
             Self::MouseOver | Self::MouseEnter | Self::PointerOver | Self::PointerEnter
         )
+    }
+
+    /// Check if this event can change the press state of a Node.
+    pub fn can_change_press_state(&self) -> bool {
+        matches!(self, Self::MouseDown | Self::PointerDown)
+    }
+
+    /// Check if the event means the cursor started or released a click
+    pub fn was_cursor_pressed_or_released(&self) -> bool {
+        matches!(
+            &self,
+            Self::MouseDown | Self::PointerDown | Self::Click | Self::PointerUp
+        )
+    }
+
+    /// Check if the event means the cursor was released
+    pub fn is_up(&self) -> bool {
+        matches!(&self, Self::Click | Self::PointerUp)
     }
 }

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -162,8 +162,8 @@ impl EventName {
                 events.extend([Self::MouseEnter, Self::PointerEnter, Self::PointerOver])
             }
             Self::MouseDown | Self::TouchStart => events.push(Self::PointerDown),
-            Self::MouseUp | Self::MiddleClick | Self::RightClick | Self::TouchEnd => {
-                events.extend([Self::Click, Self::PointerUp])
+            Self::Click | Self::MiddleClick | Self::RightClick | Self::TouchEnd => {
+                events.extend([Self::MouseUp, Self::PointerUp])
             }
             Self::MouseLeave => events.push(Self::PointerLeave),
             Self::GlobalFileHover | Self::GlobalFileHoverCancelled => events.clear(),

--- a/crates/renderer/src/app.rs
+++ b/crates/renderer/src/app.rs
@@ -237,6 +237,7 @@ impl Application {
             &mut self.events,
             &self.event_emitter,
             &mut self.nodes_state,
+            false,
             scale_factor,
         )
     }

--- a/crates/renderer/src/renderer.rs
+++ b/crates/renderer/src/renderer.rs
@@ -309,7 +309,7 @@ impl<'a, State: Clone> ApplicationHandler<EventMessage> for DesktopRenderer<'a, 
                     ElementState::Released => match button {
                         MouseButton::Middle => EventName::MiddleClick,
                         MouseButton::Right => EventName::RightClick,
-                        MouseButton::Left => EventName::Click,
+                        MouseButton::Left => EventName::MouseUp,
                         _ => EventName::PointerUp,
                     },
                 };

--- a/crates/renderer/src/renderer.rs
+++ b/crates/renderer/src/renderer.rs
@@ -309,7 +309,7 @@ impl<'a, State: Clone> ApplicationHandler<EventMessage> for DesktopRenderer<'a, 
                     ElementState::Released => match button {
                         MouseButton::Middle => EventName::MiddleClick,
                         MouseButton::Right => EventName::RightClick,
-                        MouseButton::Left => EventName::MouseUp,
+                        MouseButton::Left => EventName::Click,
                         _ => EventName::PointerUp,
                     },
                 };

--- a/crates/testing/src/test_handler.rs
+++ b/crates/testing/src/test_handler.rs
@@ -231,6 +231,7 @@ impl TestingHandler {
             &mut self.events_queue,
             &self.event_emitter,
             &mut self.nodes_state,
+            true,
             SCALE_FACTOR,
         );
     }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -14,22 +14,33 @@ fn app() -> Element {
 
     rsx!(
         rect {
-            height: "200",
-            width: "200",
-            direction: "horizontal",
-            rect {
-                onclick: move |_| count -= 1,
-                height: "200",
-                width: "200",
-                background: "red"
+            height: "50%",
+            width: "100%",
+            main_align: "center",
+            cross_align: "center",
+            background: "rgb(0, 119, 182)",
+            color: "white",
+            shadow: "0 4 20 5 rgb(0, 0, 0, 80)",
+            label {
+                font_size: "75",
+                font_weight: "bold",
+                "{count}"
             }
-            paragraph {
+        }
+        rect {
+            height: "50%",
+            width: "100%",
+            main_align: "center",
+            cross_align: "center",
+            direction: "horizontal",
+            spacing: "8",
+            Button {
                 onclick: move |_| count += 1,
-                text {
-                    font_size: "75",
-                    font_weight: "bold",
-                    "{count}"
-                }
+                label { "Increase" }
+            }
+            Button {
+                onclick: move |_| count -= 1,
+                label { "Decrease" }
             }
         }
     )

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -14,33 +14,22 @@ fn app() -> Element {
 
     rsx!(
         rect {
-            height: "50%",
-            width: "100%",
-            main_align: "center",
-            cross_align: "center",
-            background: "rgb(0, 119, 182)",
-            color: "white",
-            shadow: "0 4 20 5 rgb(0, 0, 0, 80)",
-            label {
-                font_size: "75",
-                font_weight: "bold",
-                "{count}"
-            }
-        }
-        rect {
-            height: "50%",
-            width: "100%",
-            main_align: "center",
-            cross_align: "center",
+            height: "200",
+            width: "200",
             direction: "horizontal",
-            spacing: "8",
-            Button {
-                onclick: move |_| count += 1,
-                label { "Increase" }
-            }
-            Button {
+            rect {
                 onclick: move |_| count -= 1,
-                label { "Decrease" }
+                height: "200",
+                width: "200",
+                background: "red"
+            }
+            paragraph {
+                onclick: move |_| count += 1,
+                text {
+                    font_size: "75",
+                    font_weight: "bold",
+                    "{count}"
+                }
             }
         }
     )


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/849

Click events will only be emitted to elements that were previously pressed down (no need to register a mousedown event). Mouse leave events wont need a mouseenter or mouseevents to be registered in the nodes. Added a new `mouseup` event that behaves like the old onclick

This also cleans up a bit the internals.

I also made an exception for `freya-testing` so it can emit click events without the need of sending mousedown events before.