### PR TITLE
fix(torin): Ignore absolute nodes for spacing and alignments

### DIFF
--- a/crates/torin/src/measure.rs
+++ b/crates/torin/src/measure.rs
@@ -345,8 +345,7 @@ where
                                 None
                             }
                         },
-                    )
-                    .unwrap();
+                    );
 
                 let inner_area = initial_phase_inner_area;
 
@@ -432,8 +431,7 @@ where
                             None
                         }
                     },
-                )
-                .unwrap();
+                );
 
             let mut adapted_available_area = *available_area;
 
@@ -446,6 +444,7 @@ where
                     &initial_phase_inner_sizes,
                     &parent_node.main_alignment,
                     &parent_node.direction,
+                    &child_data,
                     non_absolute_children.len(),
                     child_n,
                 );
@@ -553,9 +552,17 @@ where
         inner_sizes: &Size2D,
         alignment: &Alignment,
         direction: &DirectionMode,
+        child_node: &Node,
         siblings_len: usize,
-        child_position: usize,
+        child_position: Option<usize>,
     ) {
+        // No need to align a node that is positioned absolutely
+        if child_node.position.is_absolute() {
+            return;
+        }
+
+        let child_position = child_position.unwrap();
+
         let axis = AlignAxis::new(direction, alignment_direction);
 
         match axis {
@@ -619,12 +626,14 @@ where
         child_area: &Area,
         child_node: &Node,
         siblings_len: usize,
-        child_position: usize,
+        child_position: Option<usize>,
     ) {
         // No need to stack a node that is positioned absolutely
         if child_node.position.is_absolute() {
             return;
         }
+
+        let child_position = child_position.unwrap();
 
         // Only apply the spacing to elements after `i > 0` and `i < len - 1`
         let spacing = (child_position < siblings_len - 1)

--- a/crates/torin/src/measure.rs
+++ b/crates/torin/src/measure.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 pub use euclid::Rect;
 use rustc_hash::FxHashMap;
 
@@ -298,8 +296,6 @@ where
         let mut initial_phase_sizes = FxHashMap::default();
         let mut initial_phase_inner_sizes = *inner_sizes;
 
-        let i = Instant::now();
-
         // Used to calculate the spacing and some alignments
         let (non_absolute_children_len, first_child, last_child) = if parent_node.spacing.get() > 0.
         {
@@ -330,10 +326,6 @@ where
                 children.last().cloned(),
             )
         };
-
-        if i.elapsed().as_millis() > 0 {
-            println!("{}", i.elapsed().as_millis());
-        }
 
         // Initial phase: Measure the size and position of the children if the parent has a
         // non-start cross alignment, non-start main aligment of a fit-content.

--- a/crates/torin/src/measure.rs
+++ b/crates/torin/src/measure.rs
@@ -296,7 +296,7 @@ where
         let mut initial_phase_sizes = FxHashMap::default();
         let mut initial_phase_inner_sizes = *inner_sizes;
 
-        // Used to calculate the spacing
+        // Used to calculate the spacing and some alignments
         let non_absolute_children = if parent_node.spacing.get() > 0. {
             children
                 .clone()

--- a/crates/torin/src/measure.rs
+++ b/crates/torin/src/measure.rs
@@ -472,7 +472,7 @@ where
             // Adjust the size of the area if needed
             child_areas.area.adjust_size(&child_data);
 
-            // Stack this s child into the parent
+            // Stack this child into the parent
             if !child_data.position.is_absolute() {
                 Self::stack_child(
                     available_area,

--- a/crates/torin/src/node.rs
+++ b/crates/torin/src/node.rs
@@ -135,6 +135,26 @@ impl Node {
         }
     }
 
+    /// Construct a new Node given a size, alignments, direction and spacing
+    pub fn from_size_and_alignments_and_direction_and_spacing(
+        width: Size,
+        height: Size,
+        main_alignment: Alignment,
+        cross_alignment: Alignment,
+        direction: DirectionMode,
+        spacing: Length,
+    ) -> Self {
+        Self {
+            width,
+            height,
+            main_alignment,
+            cross_alignment,
+            direction,
+            spacing,
+            ..Default::default()
+        }
+    }
+
     /// Construct a new Node given a size and a direction
     pub fn from_size_and_margin(width: Size, height: Size, margin: Gaps) -> Self {
         Self {

--- a/crates/torin/tests/alignment.rs
+++ b/crates/torin/tests/alignment.rs
@@ -591,3 +591,75 @@ pub fn space_evenly_alignment() {
         Rect::new(Point2D::new(0.0, 780.0), Size2D::new(100.0, 100.0)),
     );
 }
+
+#[test]
+pub fn alignment_with_absolute_child() {
+    let (mut layout, mut measurer) = test_utils();
+
+    let mut mocked_dom = TestingDOM::default();
+    mocked_dom.add(
+        0,
+        None,
+        vec![1, 2, 3],
+        Node::from_size_and_alignments_and_direction_and_spacing(
+            Size::Percentage(Length::new(100.)),
+            Size::Percentage(Length::new(100.)),
+            Alignment::Center,
+            Alignment::Center,
+            DirectionMode::Vertical,
+            Length::new(15.0),
+        ),
+    );
+    mocked_dom.add(
+        1,
+        Some(0),
+        vec![],
+        Node::from_size_and_direction(
+            Size::Pixels(Length::new(100.)),
+            Size::Pixels(Length::new(100.)),
+            DirectionMode::Vertical,
+        ),
+    );
+    mocked_dom.add(
+        2,
+        Some(0),
+        vec![],
+        Node::from_size_and_position(
+            Size::Pixels(Length::new(100.)),
+            Size::Pixels(Length::new(100.)),
+            Position::Absolute(Box::new(AbsolutePosition::default())),
+        ),
+    );
+    mocked_dom.add(
+        3,
+        Some(0),
+        vec![],
+        Node::from_size_and_direction(
+            Size::Pixels(Length::new(100.)),
+            Size::Pixels(Length::new(100.)),
+            DirectionMode::Vertical,
+        ),
+    );
+
+    layout.measure(
+        0,
+        Rect::new(Point2D::new(0.0, 0.0), Size2D::new(1000.0, 1000.0)),
+        &mut measurer,
+        &mut mocked_dom,
+    );
+
+    assert_eq!(
+        layout.get(1).unwrap().visible_area(),
+        Rect::new(Point2D::new(450.0, 392.5), Size2D::new(100.0, 100.0)),
+    );
+
+    assert_eq!(
+        layout.get(2).unwrap().visible_area(),
+        Rect::new(Point2D::new(0.0, 0.0), Size2D::new(100.0, 100.0)),
+    );
+
+    assert_eq!(
+        layout.get(3).unwrap().visible_area(),
+        Rect::new(Point2D::new(450.0, 507.5), Size2D::new(100.0, 100.0)),
+    );
+}


### PR DESCRIPTION
Completely ignore absolute nodes when measuring the required spacing between children and also for axis alignments