### PR TITLE
fix: Use paragraph's full width if text align is non-start

### DIFF
--- a/crates/core/src/elements/paragraph.rs
+++ b/crates/core/src/elements/paragraph.rs
@@ -37,6 +37,7 @@ use crate::{
         create_paragraph,
         draw_cursor,
         draw_cursor_highlights,
+        ParagraphData,
     },
 };
 
@@ -139,7 +140,7 @@ impl ElementUtils for ParagraphElement {
         };
 
         if node_cursor_state.position.is_some() {
-            let paragraph = create_paragraph(
+            let ParagraphData { paragraph, .. } = create_paragraph(
                 node_ref,
                 &area.size,
                 font_collection,
@@ -177,7 +178,7 @@ impl ElementUtils for ParagraphElement {
         false
     }
 
-    fn drawing_area(
+    fn element_drawing_area(
         &self,
         layout_node: &LayoutNode,
         node_ref: &DioxusNode,

--- a/crates/core/src/render/skia_measurer.rs
+++ b/crates/core/src/render/skia_measurer.rs
@@ -27,7 +27,10 @@ use super::{
     create_label,
     create_paragraph,
 };
-use crate::dom::*;
+use crate::{
+    dom::*,
+    render::ParagraphData,
+};
 
 /// Provides Text measurements using Skia APIs like SkParagraph
 pub struct SkiaMeasurer<'a> {
@@ -65,21 +68,19 @@ impl<'a> LayoutMeasurer<NodeId> for SkiaMeasurer<'a> {
 
         match &*node_type {
             NodeType::Element(ElementNode { tag, .. }) if tag == &TagName::Label => {
-                let label = create_label(
+                let ParagraphData { paragraph, size } = create_label(
                     &node,
                     area_size,
                     self.font_collection,
                     self.default_fonts,
                     self.scale_factor,
                 );
-                let height = label.height();
-                let res = Size2D::new(label.longest_line(), height);
                 let mut map = SendAnyMap::new();
-                map.insert(CachedParagraph(label, height));
-                Some((res, Arc::new(map)))
+                map.insert(CachedParagraph(paragraph, size.height));
+                Some((size, Arc::new(map)))
             }
             NodeType::Element(ElementNode { tag, .. }) if tag == &TagName::Paragraph => {
-                let paragraph = create_paragraph(
+                let ParagraphData { paragraph, size } = create_paragraph(
                     &node,
                     area_size,
                     self.font_collection,
@@ -87,11 +88,9 @@ impl<'a> LayoutMeasurer<NodeId> for SkiaMeasurer<'a> {
                     self.default_fonts,
                     self.scale_factor,
                 );
-                let height = paragraph.height();
-                let res = Size2D::new(paragraph.longest_line(), height);
                 let mut map = SendAnyMap::new();
-                map.insert(CachedParagraph(paragraph, height));
-                Some((res, Arc::new(map)))
+                map.insert(CachedParagraph(paragraph, size.height));
+                Some((size, Arc::new(map)))
             }
             _ => None,
         }

--- a/crates/core/src/render/utils/label.rs
+++ b/crates/core/src/render/utils/label.rs
@@ -6,6 +6,7 @@ use freya_native_core::{
 use freya_node_state::FontStyleState;
 use torin::prelude::Size2D;
 
+use super::ParagraphData;
 use crate::dom::*;
 
 pub fn create_label(
@@ -14,7 +15,7 @@ pub fn create_label(
     font_collection: &FontCollection,
     default_font_family: &[String],
     scale_factor: f32,
-) -> Paragraph {
+) -> ParagraphData {
     let font_style = &*node.get::<FontStyleState>().unwrap();
 
     let mut paragraph_style = ParagraphStyle::default();
@@ -48,5 +49,13 @@ pub fn create_label(
         },
     );
 
-    paragraph
+    let width = match font_style.text_align {
+        TextAlign::Start | TextAlign::Left => paragraph.longest_line(),
+        _ => paragraph.max_width(),
+    };
+
+    ParagraphData {
+        size: Size2D::new(width, paragraph.height()),
+        paragraph,
+    }
 }

--- a/crates/core/src/render/utils/paragraph.rs
+++ b/crates/core/src/render/utils/paragraph.rs
@@ -19,6 +19,11 @@ use torin::prelude::{
 
 use crate::dom::DioxusNode;
 
+pub struct ParagraphData {
+    pub paragraph: Paragraph,
+    pub size: Size2D,
+}
+
 /// Compose a new SkParagraph
 pub fn create_paragraph(
     node: &DioxusNode,
@@ -27,7 +32,7 @@ pub fn create_paragraph(
     is_rendering: bool,
     default_font_family: &[String],
     scale_factor: f32,
-) -> Paragraph {
+) -> ParagraphData {
     let font_style = &*node.get::<FontStyleState>().unwrap();
 
     let mut paragraph_style = ParagraphStyle::default();
@@ -82,7 +87,15 @@ pub fn create_paragraph(
         },
     );
 
-    paragraph
+    let width = match font_style.text_align {
+        TextAlign::Start | TextAlign::Left => paragraph.longest_line(),
+        _ => paragraph.max_width(),
+    };
+
+    ParagraphData {
+        size: Size2D::new(width, paragraph.height()),
+        paragraph,
+    }
 }
 
 pub fn draw_cursor_highlights(


### PR DESCRIPTION
Prevents text with non-start alignment like the new upcoming Clock example from using an incorrect layout and thus causing issues with incremental rendering

![image](https://github.com/user-attachments/assets/6b8944ea-a595-428b-8711-1e6902e97a0f)
