### PR TITLE
Revert "Fix scale factor behavior in `calc()`"

### DIFF
--- a/crates/torin/src/lib.rs
+++ b/crates/torin/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod custom_measurer;
 pub mod dom_adapter;
 pub mod geometry;
-pub mod measure;
+mod measure;
 pub mod node;
 pub mod scaled;
 pub mod torin;
@@ -15,7 +15,6 @@ pub mod prelude {
         dom_adapter::*,
         gaps::*,
         geometry::*,
-        measure::*,
         node::*,
         scaled::*,
         torin::*,

--- a/crates/torin/src/values/size.rs
+++ b/crates/torin/src/values/size.rs
@@ -166,10 +166,7 @@ impl Scaled for Size {
         match self {
             Size::Pixels(s) => *s *= scale_factor,
             Size::DynamicCalculations(calcs) => {
-                calcs.insert(0, DynamicCalculation::OpenParenthesis);
-                calcs.push(DynamicCalculation::ClosedParenthesis);
-                calcs.push(DynamicCalculation::Mul);
-                calcs.push(DynamicCalculation::Pixels(scale_factor));
+                calcs.iter_mut().for_each(|calc| calc.scale(scale_factor));
             }
             _ => (),
         }
@@ -187,6 +184,14 @@ pub enum DynamicCalculation {
     Percentage(f32),
     RootPercentage(f32),
     Pixels(f32),
+}
+
+impl Scaled for DynamicCalculation {
+    fn scale(&mut self, scale_factor: f32) {
+        if let DynamicCalculation::Pixels(s) = self {
+            *s *= scale_factor;
+        }
+    }
 }
 
 impl std::fmt::Display for DynamicCalculation {

--- a/crates/torin/tests/size.rs
+++ b/crates/torin/tests/size.rs
@@ -897,9 +897,11 @@ pub fn test_calc() {
 
     assert_eq!(
         run_calculations(
-            &[DynamicCalculation::OpenParenthesis,
+            &[
+                DynamicCalculation::OpenParenthesis,
                 DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::ClosedParenthesis],
+                DynamicCalculation::ClosedParenthesis
+            ],
             PARENT_VALUE,
             PARENT_VALUE
         ),
@@ -908,7 +910,8 @@ pub fn test_calc() {
 
     assert_eq!(
         run_calculations(
-            &[DynamicCalculation::Pixels(10.0),
+            &[
+                DynamicCalculation::Pixels(10.0),
                 DynamicCalculation::OpenParenthesis,
                 DynamicCalculation::Pixels(10.0),
                 DynamicCalculation::Add,
@@ -920,7 +923,8 @@ pub fn test_calc() {
                 DynamicCalculation::OpenParenthesis,
                 DynamicCalculation::Pixels(10.0),
                 DynamicCalculation::ClosedParenthesis,
-                DynamicCalculation::Pixels(10.0)],
+                DynamicCalculation::Pixels(10.0)
+            ],
             PARENT_VALUE,
             PARENT_VALUE
         ),
@@ -929,11 +933,13 @@ pub fn test_calc() {
 
     assert_eq!(
         run_calculations(
-            &[DynamicCalculation::Sub,
+            &[
+                DynamicCalculation::Sub,
                 DynamicCalculation::OpenParenthesis,
                 DynamicCalculation::Pixels(10.0),
                 DynamicCalculation::ClosedParenthesis,
-                DynamicCalculation::Pixels(20.0)],
+                DynamicCalculation::Pixels(20.0)
+            ],
             PARENT_VALUE,
             PARENT_VALUE
         ),
@@ -942,8 +948,10 @@ pub fn test_calc() {
 
     assert_eq!(
         run_calculations(
-            &[DynamicCalculation::OpenParenthesis,
-                DynamicCalculation::Pixels(10.0)],
+            &[
+                DynamicCalculation::OpenParenthesis,
+                DynamicCalculation::Pixels(10.0)
+            ],
             PARENT_VALUE,
             PARENT_VALUE
         ),

--- a/crates/torin/tests/size.rs
+++ b/crates/torin/tests/size.rs
@@ -897,11 +897,9 @@ pub fn test_calc() {
 
     assert_eq!(
         run_calculations(
-            &[
-                DynamicCalculation::OpenParenthesis,
+            &[DynamicCalculation::OpenParenthesis,
                 DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::ClosedParenthesis
-            ],
+                DynamicCalculation::ClosedParenthesis],
             PARENT_VALUE,
             PARENT_VALUE
         ),
@@ -910,8 +908,7 @@ pub fn test_calc() {
 
     assert_eq!(
         run_calculations(
-            &[
-                DynamicCalculation::Pixels(10.0),
+            &[DynamicCalculation::Pixels(10.0),
                 DynamicCalculation::OpenParenthesis,
                 DynamicCalculation::Pixels(10.0),
                 DynamicCalculation::Add,
@@ -923,8 +920,7 @@ pub fn test_calc() {
                 DynamicCalculation::OpenParenthesis,
                 DynamicCalculation::Pixels(10.0),
                 DynamicCalculation::ClosedParenthesis,
-                DynamicCalculation::Pixels(10.0)
-            ],
+                DynamicCalculation::Pixels(10.0)],
             PARENT_VALUE,
             PARENT_VALUE
         ),
@@ -933,13 +929,11 @@ pub fn test_calc() {
 
     assert_eq!(
         run_calculations(
-            &[
-                DynamicCalculation::Sub,
+            &[DynamicCalculation::Sub,
                 DynamicCalculation::OpenParenthesis,
                 DynamicCalculation::Pixels(10.0),
                 DynamicCalculation::ClosedParenthesis,
-                DynamicCalculation::Pixels(20.0)
-            ],
+                DynamicCalculation::Pixels(20.0)],
             PARENT_VALUE,
             PARENT_VALUE
         ),
@@ -948,95 +942,11 @@ pub fn test_calc() {
 
     assert_eq!(
         run_calculations(
-            &[
-                DynamicCalculation::OpenParenthesis,
-                DynamicCalculation::Pixels(10.0)
-            ],
+            &[DynamicCalculation::OpenParenthesis,
+                DynamicCalculation::Pixels(10.0)],
             PARENT_VALUE,
             PARENT_VALUE
         ),
         None
-    );
-}
-
-#[test]
-pub fn test_scaling_factor() {
-    const PARENT_VALUE: f32 = 500.0;
-
-    assert_eq!(
-        {
-            let mut size =
-                Size::DynamicCalculations(Box::new(vec![DynamicCalculation::Pixels(10.0)]));
-            size.scale(1.5);
-            size
-        }
-        .eval(
-            PARENT_VALUE,
-            PARENT_VALUE,
-            0.0,
-            PARENT_VALUE,
-            Phase::Initial
-        ),
-        Some((10.0) * 1.5)
-    );
-
-    assert_eq!(
-        {
-            let mut size = Size::DynamicCalculations(Box::new(vec![
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::OpenParenthesis,
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::Add,
-                DynamicCalculation::Pixels(20.0),
-                DynamicCalculation::ClosedParenthesis,
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::Add,
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::OpenParenthesis,
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::ClosedParenthesis,
-                DynamicCalculation::Pixels(10.0),
-            ]));
-            size.scale(1.5);
-            size
-        }
-        .eval(
-            PARENT_VALUE,
-            PARENT_VALUE,
-            0.0,
-            PARENT_VALUE,
-            Phase::Initial
-        ),
-        Some(((10.0 * (10.0 + 20.0) * 10.0) + (10.0 * (10.0) * 10.0)) * 1.5)
-    );
-
-    assert_eq!(
-        {
-            let mut size = Size::DynamicCalculations(Box::new(vec![
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::OpenParenthesis,
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::Add,
-                DynamicCalculation::Pixels(20.0),
-                DynamicCalculation::ClosedParenthesis,
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::Add,
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::OpenParenthesis,
-                DynamicCalculation::Pixels(10.0),
-                DynamicCalculation::ClosedParenthesis,
-                DynamicCalculation::Pixels(10.0),
-            ]));
-            size.scale(1.2);
-            size
-        }
-        .eval(
-            PARENT_VALUE,
-            PARENT_VALUE,
-            0.0,
-            PARENT_VALUE,
-            Phase::Initial
-        ),
-        Some(((10.0 * (10.0 + 20.0) * 10.0) + (10.0 * (10.0) * 10.0)) * 1.2)
     );
 }


### PR DESCRIPTION
Reverts marc2332/freya#1006

This causes incosistent behavior when using e.g percentages:

```rs
    rsx!(
        rect {
            width: "calc(50%)", // Not expected
            height: "50%",
            background: "red"
        }
        rect {
            width: "50%", // Expected
            height: "50%",
            background: "blue"
        }
    )
```