### PR TITLE
fix: Handle reordedering of keyed children

### DIFF
--- a/crates/core/src/dom/mutations_writer.rs
+++ b/crates/core/src/dom/mutations_writer.rs
@@ -160,12 +160,24 @@ impl<'a> WriteMutations for MutationsWriter<'a> {
 
     fn insert_nodes_after(&mut self, id: dioxus_core::ElementId, m: usize) {
         if m > 0 {
+            self.layout.invalidate(self.native_writer.state.element_to_node_id(id));
+            let new_nodes = &self.native_writer.state.stack[self.native_writer.state.stack.len() - m..];
+            for new in new_nodes {
+                self.layout.invalidate(*new);
+            }
+
             self.native_writer.insert_nodes_after(id, m);
         }
     }
 
     fn insert_nodes_before(&mut self, id: dioxus_core::ElementId, m: usize) {
         if m > 0 {
+            self.layout.invalidate(self.native_writer.state.element_to_node_id(id));
+            let new_nodes = &self.native_writer.state.stack[self.native_writer.state.stack.len() - m..];
+            for new in new_nodes {
+                self.layout.invalidate(*new);
+            }
+
             self.native_writer.insert_nodes_before(id, m);
         }
     }

--- a/crates/core/src/dom/mutations_writer.rs
+++ b/crates/core/src/dom/mutations_writer.rs
@@ -21,7 +21,10 @@ use freya_node_state::{
     CustomAttributeValues,
     LayerState,
 };
-use torin::torin::Torin;
+use torin::torin::{
+    DirtyReason,
+    Torin,
+};
 
 use crate::prelude::{
     Compositor,
@@ -160,12 +163,15 @@ impl<'a> WriteMutations for MutationsWriter<'a> {
 
     fn insert_nodes_after(&mut self, id: dioxus_core::ElementId, m: usize) {
         if m > 0 {
-            self.layout
-                .invalidate(self.native_writer.state.element_to_node_id(id));
+            self.layout.invalidate_with_reason(
+                self.native_writer.state.element_to_node_id(id),
+                DirtyReason::Reorder,
+            );
             let new_nodes =
                 &self.native_writer.state.stack[self.native_writer.state.stack.len() - m..];
             for new in new_nodes {
-                self.layout.invalidate(*new);
+                self.layout
+                    .invalidate_with_reason(*new, DirtyReason::Reorder);
             }
 
             self.native_writer.insert_nodes_after(id, m);
@@ -174,12 +180,15 @@ impl<'a> WriteMutations for MutationsWriter<'a> {
 
     fn insert_nodes_before(&mut self, id: dioxus_core::ElementId, m: usize) {
         if m > 0 {
-            self.layout
-                .invalidate(self.native_writer.state.element_to_node_id(id));
+            self.layout.invalidate_with_reason(
+                self.native_writer.state.element_to_node_id(id),
+                DirtyReason::Reorder,
+            );
             let new_nodes =
                 &self.native_writer.state.stack[self.native_writer.state.stack.len() - m..];
             for new in new_nodes {
-                self.layout.invalidate(*new);
+                self.layout
+                    .invalidate_with_reason(*new, DirtyReason::Reorder);
             }
 
             self.native_writer.insert_nodes_before(id, m);

--- a/crates/core/src/dom/mutations_writer.rs
+++ b/crates/core/src/dom/mutations_writer.rs
@@ -160,8 +160,10 @@ impl<'a> WriteMutations for MutationsWriter<'a> {
 
     fn insert_nodes_after(&mut self, id: dioxus_core::ElementId, m: usize) {
         if m > 0 {
-            self.layout.invalidate(self.native_writer.state.element_to_node_id(id));
-            let new_nodes = &self.native_writer.state.stack[self.native_writer.state.stack.len() - m..];
+            self.layout
+                .invalidate(self.native_writer.state.element_to_node_id(id));
+            let new_nodes =
+                &self.native_writer.state.stack[self.native_writer.state.stack.len() - m..];
             for new in new_nodes {
                 self.layout.invalidate(*new);
             }
@@ -172,8 +174,10 @@ impl<'a> WriteMutations for MutationsWriter<'a> {
 
     fn insert_nodes_before(&mut self, id: dioxus_core::ElementId, m: usize) {
         if m > 0 {
-            self.layout.invalidate(self.native_writer.state.element_to_node_id(id));
-            let new_nodes = &self.native_writer.state.stack[self.native_writer.state.stack.len() - m..];
+            self.layout
+                .invalidate(self.native_writer.state.element_to_node_id(id));
+            let new_nodes =
+                &self.native_writer.state.stack[self.native_writer.state.stack.len() - m..];
             for new in new_nodes {
                 self.layout.invalidate(*new);
             }

--- a/crates/core/src/layout.rs
+++ b/crates/core/src/layout.rs
@@ -33,7 +33,7 @@ pub fn process_layout(
         let mut dirty_accessibility_tree = fdom.accessibility_dirty_nodes();
         let mut compositor_dirty_nodes = fdom.compositor_dirty_nodes();
         let mut compositor_dirty_area = fdom.compositor_dirty_area();
-        let mut buffer = layout.dirty.iter().copied().collect_vec();
+        let mut buffer = layout.dirty.keys().copied().collect_vec();
         while let Some(node_id) = buffer.pop() {
             if let Some(node) = rdom.get(node_id) {
                 if let Some(area) =

--- a/crates/core/src/render/compositor.rs
+++ b/crates/core/src/render/compositor.rs
@@ -356,144 +356,144 @@ mod test {
         assert_eq!(label.get(0).text(), Some("1"));
     }
 
-    #[tokio::test]
-    pub async fn after_shadow_drawing() {
-        fn compositor_app() -> Element {
-            let mut height = use_signal(|| 200);
-            let mut shadow = use_signal(|| 20);
+    // #[tokio::test]
+    // pub async fn after_shadow_drawing() {
+    //     fn compositor_app() -> Element {
+    //         let mut height = use_signal(|| 200);
+    //         let mut shadow = use_signal(|| 20);
 
-            rsx!(
-                rect {
-                    height: "100",
-                    width: "200",
-                    background: "red",
-                    margin: "0 0 2 0",
-                    onclick: move |_| height += 10,
-                }
-                rect {
-                    height: "{height}",
-                    width: "200",
-                    background: "green",
-                    shadow: "0 {shadow} 8 0 rgb(0, 0, 0, 0.5)",
-                    margin: "0 0 2 0",
-                    onclick: move |_| height -= 10,
-                }
-                rect {
-                    height: "100",
-                    width: "200",
-                    background: "blue",
-                    onclick: move |_| shadow.set(-20),
-                }
-            )
-        }
+    //         rsx!(
+    //             rect {
+    //                 height: "100",
+    //                 width: "200",
+    //                 background: "red",
+    //                 margin: "0 0 2 0",
+    //                 onclick: move |_| height += 10,
+    //             }
+    //             rect {
+    //                 height: "{height}",
+    //                 width: "200",
+    //                 background: "green",
+    //                 shadow: "0 {shadow} 8 0 rgb(0, 0, 0, 0.5)",
+    //                 margin: "0 0 2 0",
+    //                 onclick: move |_| height -= 10,
+    //             }
+    //             rect {
+    //                 height: "100",
+    //                 width: "200",
+    //                 background: "blue",
+    //                 onclick: move |_| shadow.set(-20),
+    //             }
+    //         )
+    //     }
 
-        let mut compositor = Compositor::default();
-        let mut utils = launch_test(compositor_app);
-        utils.wait_for_update().await;
+    //     let mut compositor = Compositor::default();
+    //     let mut utils = launch_test(compositor_app);
+    //     utils.wait_for_update().await;
 
-        let (layers, rendering_layers, _) = run_compositor(&utils, &mut compositor);
-        // First render is always a full render
-        assert_eq!(layers, rendering_layers);
+    //     let (layers, rendering_layers, _) = run_compositor(&utils, &mut compositor);
+    //     // First render is always a full render
+    //     assert_eq!(layers, rendering_layers);
 
-        utils.click_cursor((5., 5.)).await;
+    //     utils.click_cursor((5., 5.)).await;
 
-        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-        // Root + Second rect + Third rect
-        assert_eq!(painted_nodes, 3);
+    //     // Root + Second rect + Third rect
+    //     assert_eq!(painted_nodes, 3);
 
-        utils.click_cursor((5., 150.)).await;
+    //     utils.click_cursor((5., 150.)).await;
 
-        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-        // Root + Second rect + Third rect
-        assert_eq!(painted_nodes, 3);
+    //     // Root + Second rect + Third rect
+    //     assert_eq!(painted_nodes, 3);
 
-        utils.click_cursor((5., 350.)).await;
+    //     utils.click_cursor((5., 350.)).await;
 
-        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-        // Root + First rect + Second rect + Third Rect
-        assert_eq!(painted_nodes, 4);
+    //     // Root + First rect + Second rect + Third Rect
+    //     assert_eq!(painted_nodes, 4);
 
-        utils.click_cursor((5., 150.)).await;
+    //     utils.click_cursor((5., 150.)).await;
 
-        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-        // Root + First rect + Second rect + Third Rect
-        assert_eq!(painted_nodes, 4);
-    }
+    //     // Root + First rect + Second rect + Third Rect
+    //     assert_eq!(painted_nodes, 4);
+    // }
 
-    #[tokio::test]
-    pub async fn paragraph_drawing() {
-        fn compositor_app() -> Element {
-            let mut msg_state = use_signal(|| true);
-            let mut shadow_state = use_signal(|| true);
+    // #[tokio::test]
+    // pub async fn paragraph_drawing() {
+    //     fn compositor_app() -> Element {
+    //         let mut msg_state = use_signal(|| true);
+    //         let mut shadow_state = use_signal(|| true);
 
-            let msg = if msg_state() { "12" } else { "23" };
-            let shadow = if shadow_state() {
-                "-40 0 20 black"
-            } else {
-                "none"
-            };
+    //         let msg = if msg_state() { "12" } else { "23" };
+    //         let shadow = if shadow_state() {
+    //             "-40 0 20 black"
+    //         } else {
+    //             "none"
+    //         };
 
-            rsx!(
-                rect {
-                    height: "200",
-                    width: "200",
-                    direction: "horizontal",
-                    spacing: "2",
-                    rect {
-                        onclick: move |_| msg_state.toggle(),
-                        height: "200",
-                        width: "200",
-                        background: "red"
-                    }
-                    paragraph {
-                        onclick: move |_| shadow_state.toggle(),
-                        text {
-                            font_size: "75",
-                            font_weight: "bold",
-                            text_shadow: "{shadow}",
-                            "{msg}"
-                        }
-                    }
-                }
-            )
-        }
+    //         rsx!(
+    //             rect {
+    //                 height: "200",
+    //                 width: "200",
+    //                 direction: "horizontal",
+    //                 spacing: "2",
+    //                 rect {
+    //                     onclick: move |_| msg_state.toggle(),
+    //                     height: "200",
+    //                     width: "200",
+    //                     background: "red"
+    //                 }
+    //                 paragraph {
+    //                     onclick: move |_| shadow_state.toggle(),
+    //                     text {
+    //                         font_size: "75",
+    //                         font_weight: "bold",
+    //                         text_shadow: "{shadow}",
+    //                         "{msg}"
+    //                     }
+    //                 }
+    //             }
+    //         )
+    //     }
 
-        let mut compositor = Compositor::default();
-        let mut utils = launch_test(compositor_app);
-        let root = utils.root();
-        utils.wait_for_update().await;
+    //     let mut compositor = Compositor::default();
+    //     let mut utils = launch_test(compositor_app);
+    //     let root = utils.root();
+    //     utils.wait_for_update().await;
 
-        assert_eq!(root.get(0).get(1).get(0).get(0).text(), Some("12"));
+    //     assert_eq!(root.get(0).get(1).get(0).get(0).text(), Some("12"));
 
-        let (layers, rendering_layers, _) = run_compositor(&utils, &mut compositor);
-        // First render is always a full render
-        assert_eq!(layers, rendering_layers);
+    //     let (layers, rendering_layers, _) = run_compositor(&utils, &mut compositor);
+    //     // First render is always a full render
+    //     assert_eq!(layers, rendering_layers);
 
-        utils.click_cursor((5., 5.)).await;
+    //     utils.click_cursor((5., 5.)).await;
 
-        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-        // Root + First rect + Paragraph + Second rect
-        assert_eq!(painted_nodes, 4);
+    //     // Root + First rect + Paragraph + Second rect
+    //     assert_eq!(painted_nodes, 4);
 
-        utils.click_cursor((205., 5.)).await;
+    //     utils.click_cursor((205., 5.)).await;
 
-        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-        // Root + First rect + Paragraph + Second rect
-        assert_eq!(painted_nodes, 4);
+    //     // Root + First rect + Paragraph + Second rect
+    //     assert_eq!(painted_nodes, 4);
 
-        utils.click_cursor((5., 5.)).await;
+    //     utils.click_cursor((5., 5.)).await;
 
-        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-        // Root + First rect + Paragraph
-        assert_eq!(painted_nodes, 2);
-    }
+    //     // Root + First rect + Paragraph
+    //     assert_eq!(painted_nodes, 2);
+    // }
 
     #[tokio::test]
     pub async fn rotated_drawing() {

--- a/crates/core/src/render/compositor.rs
+++ b/crates/core/src/render/compositor.rs
@@ -356,144 +356,144 @@ mod test {
         assert_eq!(label.get(0).text(), Some("1"));
     }
 
-    // #[tokio::test]
-    // pub async fn after_shadow_drawing() {
-    //     fn compositor_app() -> Element {
-    //         let mut height = use_signal(|| 200);
-    //         let mut shadow = use_signal(|| 20);
+    #[tokio::test]
+    pub async fn after_shadow_drawing() {
+        fn compositor_app() -> Element {
+            let mut height = use_signal(|| 200);
+            let mut shadow = use_signal(|| 20);
 
-    //         rsx!(
-    //             rect {
-    //                 height: "100",
-    //                 width: "200",
-    //                 background: "red",
-    //                 margin: "0 0 2 0",
-    //                 onclick: move |_| height += 10,
-    //             }
-    //             rect {
-    //                 height: "{height}",
-    //                 width: "200",
-    //                 background: "green",
-    //                 shadow: "0 {shadow} 8 0 rgb(0, 0, 0, 0.5)",
-    //                 margin: "0 0 2 0",
-    //                 onclick: move |_| height -= 10,
-    //             }
-    //             rect {
-    //                 height: "100",
-    //                 width: "200",
-    //                 background: "blue",
-    //                 onclick: move |_| shadow.set(-20),
-    //             }
-    //         )
-    //     }
+            rsx!(
+                rect {
+                    height: "100",
+                    width: "200",
+                    background: "red",
+                    margin: "0 0 2 0",
+                    onclick: move |_| height += 10,
+                }
+                rect {
+                    height: "{height}",
+                    width: "200",
+                    background: "green",
+                    shadow: "0 {shadow} 8 0 rgb(0, 0, 0, 0.5)",
+                    margin: "0 0 2 0",
+                    onclick: move |_| height -= 10,
+                }
+                rect {
+                    height: "100",
+                    width: "200",
+                    background: "blue",
+                    onclick: move |_| shadow.set(-20),
+                }
+            )
+        }
 
-    //     let mut compositor = Compositor::default();
-    //     let mut utils = launch_test(compositor_app);
-    //     utils.wait_for_update().await;
+        let mut compositor = Compositor::default();
+        let mut utils = launch_test(compositor_app);
+        utils.wait_for_update().await;
 
-    //     let (layers, rendering_layers, _) = run_compositor(&utils, &mut compositor);
-    //     // First render is always a full render
-    //     assert_eq!(layers, rendering_layers);
+        let (layers, rendering_layers, _) = run_compositor(&utils, &mut compositor);
+        // First render is always a full render
+        assert_eq!(layers, rendering_layers);
 
-    //     utils.click_cursor((5., 5.)).await;
+        utils.click_cursor((5., 5.)).await;
 
-    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-    //     // Root + Second rect + Third rect
-    //     assert_eq!(painted_nodes, 3);
+        // Root + Second rect + Third rect
+        assert_eq!(painted_nodes, 3);
 
-    //     utils.click_cursor((5., 150.)).await;
+        utils.click_cursor((5., 150.)).await;
 
-    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-    //     // Root + Second rect + Third rect
-    //     assert_eq!(painted_nodes, 3);
+        // Root + Second rect + Third rect
+        assert_eq!(painted_nodes, 3);
 
-    //     utils.click_cursor((5., 350.)).await;
+        utils.click_cursor((5., 350.)).await;
 
-    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-    //     // Root + First rect + Second rect + Third Rect
-    //     assert_eq!(painted_nodes, 4);
+        // Root + First rect + Second rect + Third Rect
+        assert_eq!(painted_nodes, 4);
 
-    //     utils.click_cursor((5., 150.)).await;
+        utils.click_cursor((5., 150.)).await;
 
-    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-    //     // Root + First rect + Second rect + Third Rect
-    //     assert_eq!(painted_nodes, 4);
-    // }
+        // Root + First rect + Second rect + Third Rect
+        assert_eq!(painted_nodes, 4);
+    }
 
-    // #[tokio::test]
-    // pub async fn paragraph_drawing() {
-    //     fn compositor_app() -> Element {
-    //         let mut msg_state = use_signal(|| true);
-    //         let mut shadow_state = use_signal(|| true);
+    #[tokio::test]
+    pub async fn paragraph_drawing() {
+        fn compositor_app() -> Element {
+            let mut msg_state = use_signal(|| true);
+            let mut shadow_state = use_signal(|| true);
 
-    //         let msg = if msg_state() { "12" } else { "23" };
-    //         let shadow = if shadow_state() {
-    //             "-40 0 20 black"
-    //         } else {
-    //             "none"
-    //         };
+            let msg = if msg_state() { "12" } else { "23" };
+            let shadow = if shadow_state() {
+                "-40 0 20 black"
+            } else {
+                "none"
+            };
 
-    //         rsx!(
-    //             rect {
-    //                 height: "200",
-    //                 width: "200",
-    //                 direction: "horizontal",
-    //                 spacing: "2",
-    //                 rect {
-    //                     onclick: move |_| msg_state.toggle(),
-    //                     height: "200",
-    //                     width: "200",
-    //                     background: "red"
-    //                 }
-    //                 paragraph {
-    //                     onclick: move |_| shadow_state.toggle(),
-    //                     text {
-    //                         font_size: "75",
-    //                         font_weight: "bold",
-    //                         text_shadow: "{shadow}",
-    //                         "{msg}"
-    //                     }
-    //                 }
-    //             }
-    //         )
-    //     }
+            rsx!(
+                rect {
+                    height: "200",
+                    width: "200",
+                    direction: "horizontal",
+                    spacing: "2",
+                    rect {
+                        onclick: move |_| msg_state.toggle(),
+                        height: "200",
+                        width: "200",
+                        background: "red"
+                    }
+                    paragraph {
+                        onclick: move |_| shadow_state.toggle(),
+                        text {
+                            font_size: "75",
+                            font_weight: "bold",
+                            text_shadow: "{shadow}",
+                            "{msg}"
+                        }
+                    }
+                }
+            )
+        }
 
-    //     let mut compositor = Compositor::default();
-    //     let mut utils = launch_test(compositor_app);
-    //     let root = utils.root();
-    //     utils.wait_for_update().await;
+        let mut compositor = Compositor::default();
+        let mut utils = launch_test(compositor_app);
+        let root = utils.root();
+        utils.wait_for_update().await;
 
-    //     assert_eq!(root.get(0).get(1).get(0).get(0).text(), Some("12"));
+        assert_eq!(root.get(0).get(1).get(0).get(0).text(), Some("12"));
 
-    //     let (layers, rendering_layers, _) = run_compositor(&utils, &mut compositor);
-    //     // First render is always a full render
-    //     assert_eq!(layers, rendering_layers);
+        let (layers, rendering_layers, _) = run_compositor(&utils, &mut compositor);
+        // First render is always a full render
+        assert_eq!(layers, rendering_layers);
 
-    //     utils.click_cursor((5., 5.)).await;
+        utils.click_cursor((5., 5.)).await;
 
-    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-    //     // Root + First rect + Paragraph + Second rect
-    //     assert_eq!(painted_nodes, 4);
+        // Root + First rect + Paragraph + Second rect
+        assert_eq!(painted_nodes, 4);
 
-    //     utils.click_cursor((205., 5.)).await;
+        utils.click_cursor((205., 5.)).await;
 
-    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-    //     // Root + First rect + Paragraph + Second rect
-    //     assert_eq!(painted_nodes, 4);
+        // Root + First rect + Paragraph + Second rect
+        assert_eq!(painted_nodes, 4);
 
-    //     utils.click_cursor((5., 5.)).await;
+        utils.click_cursor((5., 5.)).await;
 
-    //     let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
+        let (_, _, painted_nodes) = run_compositor(&utils, &mut compositor);
 
-    //     // Root + First rect + Paragraph
-    //     assert_eq!(painted_nodes, 2);
-    // }
+        // Root + First rect + Paragraph
+        assert_eq!(painted_nodes, 2);
+    }
 
     #[tokio::test]
     pub async fn rotated_drawing() {

--- a/crates/core/tests/nodes_reorder.rs
+++ b/crates/core/tests/nodes_reorder.rs
@@ -38,4 +38,10 @@ pub async fn nodes_reorder() {
     assert_eq!(utils.root().get(1).get(0).text(), Some("2"));
     assert_eq!(utils.root().get(2).get(0).text(), Some("3"));
     assert_eq!(utils.root().get(3).get(0).text(), Some("1"));
+
+    utils.click_cursor((5., 5.)).await;
+
+    assert_eq!(utils.root().get(1).get(0).text(), Some("3"));
+    assert_eq!(utils.root().get(2).get(0).text(), Some("1"));
+    assert_eq!(utils.root().get(3).get(0).text(), Some("2"));
 }

--- a/crates/core/tests/nodes_reorder.rs
+++ b/crates/core/tests/nodes_reorder.rs
@@ -1,0 +1,41 @@
+use freya::prelude::*;
+use freya_testing::prelude::*;
+
+#[tokio::test]
+pub async fn nodes_reorder() {
+    fn nodes_reorder() -> Element {
+        let mut data = use_signal(|| vec![1, 2, 3]);
+
+        rsx!(
+            rect {
+                onclick: move |_| {
+                    let item = data.write().remove(0);
+                    data.write().push(item);
+                },
+                label {
+                    "Move"
+                }
+            }
+            for d in data.read().iter() {
+                label {
+                    key: "{d}",
+                    height: "20",
+                    "{d}"
+                }
+            }
+        )
+    }
+
+    let mut utils = launch_test(nodes_reorder);
+    utils.wait_for_update().await;
+
+    assert_eq!(utils.root().get(1).get(0).text(), Some("1"));
+    assert_eq!(utils.root().get(2).get(0).text(), Some("2"));
+    assert_eq!(utils.root().get(3).get(0).text(), Some("3"));
+
+    utils.click_cursor((5., 5.)).await;
+
+    assert_eq!(utils.root().get(1).get(0).text(), Some("2"));
+    assert_eq!(utils.root().get(2).get(0).text(), Some("3"));
+    assert_eq!(utils.root().get(3).get(0).text(), Some("1"));
+}

--- a/crates/native-core/src/dioxus.rs
+++ b/crates/native-core/src/dioxus.rs
@@ -34,7 +34,7 @@ struct ElementIdComponent(ElementId);
 /// The state of the Dioxus integration with the RealDom
 pub struct DioxusState {
     templates: FxHashMap<String, Vec<NodeId>>,
-    stack: Vec<NodeId>,
+    pub stack: Vec<NodeId>,
     node_id_mapping: Vec<Option<NodeId>>,
 }
 

--- a/crates/native-core/src/tree.rs
+++ b/crates/native-core/src/tree.rs
@@ -229,13 +229,20 @@ impl<'a> TreeMut for TreeMutView<'a> {
     }
 
     fn insert_before(&mut self, old_id: NodeId, new_id: NodeId) {
+        let new_parent_id = {
+            let new_id = self.1.get(new_id).unwrap();
+            new_id.parent
+        };
+        if let Some(new_parent_id) = new_parent_id {
+            (&mut self.1).get(new_parent_id).unwrap().children.retain(|id| *id != new_id);
+        }
+
         let parent_id = {
             let old_node = self.1.get(old_id).unwrap();
             old_node.parent.expect("tried to insert before root")
         };
-        {
-            (&mut self.1).get(new_id).unwrap().parent = Some(parent_id);
-        }
+        (&mut self.1).get(new_id).unwrap().parent = Some(parent_id);
+        
         let parent = (&mut self.1).get(parent_id).unwrap();
         let index = parent
             .children
@@ -248,6 +255,14 @@ impl<'a> TreeMut for TreeMutView<'a> {
     }
 
     fn insert_after(&mut self, old_id: NodeId, new_id: NodeId) {
+        let new_parent_id = {
+            let new_id = self.1.get(new_id).unwrap();
+            new_id.parent
+        };
+        if let Some(new_parent_id) = new_parent_id {
+            (&mut self.1).get(new_parent_id).unwrap().children.retain(|id| *id != new_id);
+        }
+
         let mut node_state = &mut self.1;
         let old_node = node_state.get(old_id).unwrap();
         let parent_id = old_node.parent.expect("tried to insert before root");

--- a/crates/native-core/src/tree.rs
+++ b/crates/native-core/src/tree.rs
@@ -273,7 +273,7 @@ impl<'a> TreeMut for TreeMutView<'a> {
 
         let mut node_state = &mut self.1;
         let old_node = node_state.get(old_id).unwrap();
-        let parent_id = old_node.parent.expect("tried to insert before root");
+        let parent_id = old_node.parent.expect("tried to insert after root");
         (&mut node_state).get(new_id).unwrap().parent = Some(parent_id);
         let parent = (&mut node_state).get(parent_id).unwrap();
         let index = parent

--- a/crates/native-core/src/tree.rs
+++ b/crates/native-core/src/tree.rs
@@ -234,7 +234,11 @@ impl<'a> TreeMut for TreeMutView<'a> {
             new_id.parent
         };
         if let Some(new_parent_id) = new_parent_id {
-            (&mut self.1).get(new_parent_id).unwrap().children.retain(|id| *id != new_id);
+            (&mut self.1)
+                .get(new_parent_id)
+                .unwrap()
+                .children
+                .retain(|id| *id != new_id);
         }
 
         let parent_id = {
@@ -242,7 +246,7 @@ impl<'a> TreeMut for TreeMutView<'a> {
             old_node.parent.expect("tried to insert before root")
         };
         (&mut self.1).get(new_id).unwrap().parent = Some(parent_id);
-        
+
         let parent = (&mut self.1).get(parent_id).unwrap();
         let index = parent
             .children
@@ -260,7 +264,11 @@ impl<'a> TreeMut for TreeMutView<'a> {
             new_id.parent
         };
         if let Some(new_parent_id) = new_parent_id {
-            (&mut self.1).get(new_parent_id).unwrap().children.retain(|id| *id != new_id);
+            (&mut self.1)
+                .get(new_parent_id)
+                .unwrap()
+                .children
+                .retain(|id| *id != new_id);
         }
 
         let mut node_state = &mut self.1;

--- a/crates/torin/src/measure.rs
+++ b/crates/torin/src/measure.rs
@@ -75,7 +75,7 @@ where
         // 2. If this Node has been marked as dirty
         // 3. If there is no know cached data about this Node.
         let must_revalidate = parent_is_dirty
-            || self.layout.dirty.contains(&node_id)
+            || self.layout.dirty.contains_key(&node_id)
             || !self.layout.results.contains_key(&node_id);
         if must_revalidate {
             // Create the initial Node area size

--- a/crates/torin/src/torin.rs
+++ b/crates/torin/src/torin.rs
@@ -185,14 +185,8 @@ impl<Key: NodeKey> Torin<Key> {
                     let parent_children = dom_adapter.children_of(&parent_id);
                     let multiple_children = parent_children.len() > 1;
 
-                    let mut found_node = false;
                     for child_id in parent_children {
-                        if found_node {
-                            self.safe_invalidate(child_id, dom_adapter);
-                        }
-                        if child_id == node_id {
-                            found_node = true;
-                        }
+                        self.safe_invalidate(child_id, dom_adapter);
                     }
 
                     // Try using the node's parent as root candidate if it has multiple children

--- a/crates/torin/tests/other.rs
+++ b/crates/torin/tests/other.rs
@@ -1,4 +1,7 @@
-use rustc_hash::FxHashSet;
+use rustc_hash::{
+    FxHashMap,
+    FxHashSet,
+};
 #[cfg(test)]
 use torin::{
     prelude::*,
@@ -139,7 +142,10 @@ pub fn layout_dirty_nodes() {
     );
     layout.invalidate(2);
 
-    assert_eq!(layout.get_dirty_nodes(), &FxHashSet::from_iter([2]));
+    assert_eq!(
+        layout.get_dirty_nodes(),
+        &FxHashMap::from_iter([(2, DirtyReason::None)])
+    );
 
     // CASE 2
     // Same as Case 1 but we make Child A depend on Child A[0]'s size
@@ -154,7 +160,10 @@ pub fn layout_dirty_nodes() {
     );
     layout.invalidate(1);
 
-    assert_eq!(layout.get_dirty_nodes(), &FxHashSet::from_iter([2, 1]));
+    assert_eq!(
+        layout.get_dirty_nodes(),
+        &FxHashMap::from_iter([(2, DirtyReason::None), (1, DirtyReason::None)])
+    );
 
     // CASE 3
     // Same as Case 2, but triggers a change in Child A[0]
@@ -169,7 +178,10 @@ pub fn layout_dirty_nodes() {
     );
     layout.invalidate(2);
 
-    assert_eq!(layout.get_dirty_nodes(), &FxHashSet::from_iter([2, 1]));
+    assert_eq!(
+        layout.get_dirty_nodes(),
+        &FxHashMap::from_iter([(2, DirtyReason::None), (1, DirtyReason::None)])
+    );
 
     // CASE 4
     // Same as Case 3, but triggers a change in the root
@@ -184,7 +196,14 @@ pub fn layout_dirty_nodes() {
     );
     layout.invalidate(0);
 
-    assert_eq!(layout.get_dirty_nodes(), &FxHashSet::from_iter([2, 1, 0]));
+    assert_eq!(
+        layout.get_dirty_nodes(),
+        &FxHashMap::from_iter([
+            (2, DirtyReason::None),
+            (1, DirtyReason::None),
+            (0, DirtyReason::None)
+        ])
+    );
 }
 
 #[test]
@@ -269,7 +288,10 @@ pub fn node_removal() {
 
     layout.find_best_root(&mut mocked_dom);
 
-    assert_eq!(layout.get_dirty_nodes(), &FxHashSet::from_iter([1]));
+    assert_eq!(
+        layout.get_dirty_nodes(),
+        &FxHashMap::from_iter([(1, DirtyReason::None)])
+    );
 
     assert_eq!(layout.size(), 3);
 


### PR DESCRIPTION
These two code blocksd didn't work correctly before:

```rust
#![cfg_attr(
    all(not(debug_assertions), target_os = "windows"),
    windows_subsystem = "windows"
)]

use freya::prelude::*;
use rand::Rng;

fn main() {
    launch_with_props(app, "Counter", (400.0, 350.0));
}

fn app() -> Element {
    let mut data = use_signal(Vec::<usize>::new);

    rsx!(
        rect {
            height: "100%",
            width: "100%",
            Button {
                onclick: move |_| {
                    let mut item = data.write().remove(0);
                    data.write().push(item);
                },
                label {
                    "Move"
                }
            }
            Button {
                onclick: move |_| {
                    let mut rng = rand::thread_rng();
                    data.write().insert(0,rng.gen());
                },
                label {
                    "Add"
                }
            }
            for d in data.read().iter() {
                label {
                    key: "{d}",
                    height: "20",
                    "{d}"
                }
            }
        }
    )
}

```

```rust
#![cfg_attr(
    all(not(debug_assertions), target_os = "windows"),
    windows_subsystem = "windows"
)]

use freya::prelude::*;
use rand::Rng;

fn main() {
    launch_with_props(app, "Counter", (400.0, 350.0));
}

fn app() -> Element {
    let mut data = use_signal(Vec::<usize>::new);

    rsx!(
        rect {
            height: "100%",
            width: "100%",
            Button {
                onclick: move |_| {
                    let l = data.len() - 1;
                    let mut item = data.write().remove(l);
                    data.write().insert(0, item);
                },
                label {
                    "Move"
                }
            }
            Button {
                onclick: move |_| {
                    let mut rng = rand::thread_rng();
                    data.write().push(rng.gen());
                },
                label {
                    "Add"
                }
            }
            for d in data.read().iter() {
                label {
                    key: "{d}",
                    height: "20",
                    "{d}"
                }
            }
        }
    )
}

```