### PR TITLE
feat: Type safety for `use_animation`

### DIFF
--- a/crates/components/src/accordion.rs
+++ b/crates/components/src/accordion.rs
@@ -44,18 +44,16 @@ pub struct AccordionProps {
 pub fn Accordion(props: AccordionProps) -> Element {
     let theme = use_applied_theme!(&props.theme, accordion);
     let mut open = use_signal(|| false);
-    let animation = use_animation(move |ctx| {
-        ctx.with(
-            AnimNum::new(0., 100.)
-                .time(300)
-                .function(Function::Expo)
-                .ease(Ease::Out),
-        )
+    let animation = use_animation(move |_conf| {
+        AnimNum::new(0., 100.)
+            .time(300)
+            .function(Function::Expo)
+            .ease(Ease::Out)
     });
     let mut status = use_signal(AccordionStatus::default);
     let platform = use_platform();
 
-    let animation_value = animation.get().read().as_f32();
+    let animation_value = animation.get().read().read();
     let AccordionTheme {
         background,
         color,

--- a/crates/components/src/animated_position.rs
+++ b/crates/components/src/animated_position.rs
@@ -23,30 +23,26 @@ pub fn AnimatedPosition(
     let mut render_element = use_signal(|| false);
     let (reference, size, old_size) = use_node_signal_with_prev();
 
-    let animations = use_animation_with_dependencies(
+    let animation = use_animation_with_dependencies(
         &(function, duration, ease),
-        move |ctx, (function, duration, ease)| {
+        move |_conf, (function, duration, ease)| {
             let old_size = old_size().unwrap_or_default();
             let size = size().unwrap_or_default();
             (
-                ctx.with(
-                    AnimNum::new(size.area.origin.x, old_size.area.origin.x)
-                        .duration(duration)
-                        .ease(ease)
-                        .function(function),
-                ),
-                ctx.with(
-                    AnimNum::new(size.area.origin.y, old_size.area.origin.y)
-                        .duration(duration)
-                        .ease(ease)
-                        .function(function),
-                ),
+                AnimNum::new(size.area.origin.x, old_size.area.origin.x)
+                    .duration(duration)
+                    .ease(ease)
+                    .function(function),
+                AnimNum::new(size.area.origin.y, old_size.area.origin.y)
+                    .duration(duration)
+                    .ease(ease)
+                    .function(function),
             )
         },
     );
 
     use_effect(move || {
-        if animations.is_running() {
+        if animation.is_running() {
             render_element.set(true);
         }
     });
@@ -55,15 +51,15 @@ pub fn AnimatedPosition(
         let has_size = size.read().is_some();
         let has_old_size = old_size.read().is_some();
         if has_size && has_old_size {
-            animations.run(AnimDirection::Reverse);
+            animation.run(AnimDirection::Reverse);
         } else if has_size {
             render_element.set(true);
         }
     });
 
-    let (offset_x, offset_y) = animations.get();
-    let offset_x = offset_x.read().as_f32();
-    let offset_y = offset_y.read().as_f32();
+    let (offset_x, offset_y) = &*animation.get().read_unchecked();
+    let offset_x = offset_x.read();
+    let offset_y = offset_y.read();
 
     rsx!(
         rect {

--- a/crates/components/src/loader.rs
+++ b/crates/components/src/loader.rs
@@ -21,15 +21,15 @@ pub struct LoaderProps {
 #[allow(non_snake_case)]
 pub fn Loader(props: LoaderProps) -> Element {
     let theme = use_applied_theme!(&props.theme, loader);
-    let anim = use_animation(|ctx| {
-        ctx.auto_start(true);
-        ctx.on_finish(OnFinish::Restart);
-        ctx.with(AnimNum::new(0.0, 360.0).time(650))
+    let animation = use_animation(|conf| {
+        conf.auto_start(true);
+        conf.on_finish(OnFinish::Restart);
+        AnimNum::new(0.0, 360.0).time(650)
     });
 
     let LoaderTheme { primary_color } = theme;
 
-    let degrees = anim.get().read().as_f32();
+    let degrees = animation.get().read().read();
 
     rsx!(svg {
         rotate: "{degrees}deg",

--- a/crates/components/src/overflowed_content.rs
+++ b/crates/components/src/overflowed_content.rs
@@ -51,25 +51,22 @@ pub fn OverflowedContent(
     let label_width = label_size.read().area.width();
     let does_overflow = label_width > rect_width;
 
-    let animations = use_animation(move |ctx| {
-        ctx.on_finish(OnFinish::Restart);
+    let animation = use_animation(move |conf| {
+        conf.on_finish(OnFinish::Restart);
 
-        ctx.with(
-            AnimNum::new(0., 100.)
-                .duration(duration)
-                .ease(Ease::InOut)
-                .function(Function::Linear),
-        )
+        AnimNum::new(0., 100.)
+            .duration(duration)
+            .ease(Ease::InOut)
+            .function(Function::Linear)
     });
 
     use_effect(use_reactive!(|does_overflow| {
         if does_overflow {
-            animations.run(AnimDirection::Forward);
+            animation.run(AnimDirection::Forward);
         }
     }));
 
-    let progress = animations.get();
-    let progress = progress.read().as_f32();
+    let progress = animation.get().read().read();
     let offset_x = if does_overflow {
         ((label_width + rect_width) * progress / 100.) - rect_width
     } else {

--- a/crates/components/src/snackbar.rs
+++ b/crates/components/src/snackbar.rs
@@ -50,13 +50,11 @@ pub fn SnackBar(
     /// Theme override.
     theme: Option<SnackBarThemeWith>,
 ) -> Element {
-    let animation = use_animation(|ctx| {
-        ctx.with(
-            AnimNum::new(50., 0.)
-                .time(200)
-                .ease(Ease::Out)
-                .function(Function::Expo),
-        )
+    let animation = use_animation(|_conf| {
+        AnimNum::new(50., 0.)
+            .time(200)
+            .ease(Ease::Out)
+            .function(Function::Expo)
     });
 
     use_effect(move || {
@@ -67,7 +65,7 @@ pub fn SnackBar(
         }
     });
 
-    let offset_y = animation.get().read().as_f32();
+    let offset_y = animation.get().read().read();
 
     rsx!(
         rect {

--- a/crates/components/src/switch.rs
+++ b/crates/components/src/switch.rs
@@ -67,33 +67,25 @@ pub enum SwitchStatus {
 #[allow(non_snake_case)]
 pub fn Switch(props: SwitchProps) -> Element {
     let theme = use_applied_theme!(&props.theme, switch);
-    let animation = use_animation_with_dependencies(&theme, |ctx, theme| {
-        ctx.on_deps_change(OnDepsChange::Run);
+    let animation = use_animation_with_dependencies(&theme, |conf, theme| {
+        conf.on_deps_change(OnDepsChange::Finish);
         (
-            ctx.with(
-                AnimNum::new(2., 22.)
-                    .time(300)
-                    .function(Function::Expo)
-                    .ease(Ease::Out),
-            ),
-            ctx.with(
-                AnimNum::new(14., 18.)
-                    .time(300)
-                    .function(Function::Expo)
-                    .ease(Ease::Out),
-            ),
-            ctx.with(
-                AnimColor::new(&theme.background, &theme.enabled_background)
-                    .time(300)
-                    .function(Function::Expo)
-                    .ease(Ease::Out),
-            ),
-            ctx.with(
-                AnimColor::new(&theme.thumb_background, &theme.enabled_thumb_background)
-                    .time(300)
-                    .function(Function::Expo)
-                    .ease(Ease::Out),
-            ),
+            AnimNum::new(2., 22.)
+                .time(300)
+                .function(Function::Expo)
+                .ease(Ease::Out),
+            AnimNum::new(14., 18.)
+                .time(300)
+                .function(Function::Expo)
+                .ease(Ease::Out),
+            AnimColor::new(&theme.background, &theme.enabled_background)
+                .time(300)
+                .function(Function::Expo)
+                .ease(Ease::Out),
+            AnimColor::new(&theme.thumb_background, &theme.enabled_thumb_background)
+                .time(300)
+                .function(Function::Expo)
+                .ease(Ease::Out),
         )
     });
     let platform = use_platform();
@@ -136,10 +128,11 @@ pub fn Switch(props: SwitchProps) -> Element {
         }
     };
 
-    let offset_x = animation.get().0.read().as_f32();
-    let size = animation.get().1.read().as_f32();
-    let background = animation.get().2.read().as_string();
-    let circle = animation.get().3.read().as_string();
+    let (offset_x, size, background, circle) = &*animation.get().read_unchecked();
+    let offset_x = offset_x.read();
+    let size = size.read();
+    let background = background.read();
+    let circle = circle.read();
 
     let border = if focus.is_selected() {
         if props.enabled {

--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! # Freya Hooks
 //! A collection of hooks to be used in Freya.
 

--- a/crates/hooks/src/use_animation.rs
+++ b/crates/hooks/src/use_animation.rs
@@ -775,6 +775,7 @@ macro_rules! impl_tuple_call {
                         $type.prepare(direction);
                     )*
                 }
+
                 fn is_finished(&self, index: u128, direction: AnimDirection) -> bool {
                     #[allow(non_snake_case)]
                     let ($($type,)*) = self;
@@ -793,6 +794,7 @@ macro_rules! impl_tuple_call {
                         $type.advance(index, direction);
                     )*
                 }
+
                 fn finish(&mut self, direction: AnimDirection) {
                     #[allow(non_snake_case)]
                     let ($($type,)*) = self;

--- a/crates/hooks/src/use_animation.rs
+++ b/crates/hooks/src/use_animation.rs
@@ -622,8 +622,8 @@ impl<Animated: AnimatedValue> UseAnimation<Animated> {
 /// }
 ///
 /// fn app() -> Element {
-///     let animation = use_animation(|ctx| {
-///         ctx.auto_start(true);
+///     let animation = use_animation(|conf| {
+///         conf.auto_start(true);
 ///         AnimNum::new(0., 100.).time(50)
 ///     });
 ///
@@ -642,8 +642,8 @@ impl<Animated: AnimatedValue> UseAnimation<Animated> {
 /// ```rust,no_run
 /// # use freya::prelude::*;
 /// fn app() -> Element {
-///     let animation = use_animation(|ctx| {
-///         ctx.auto_start(true);
+///     let animation = use_animation(|conf| {
+///         conf.auto_start(true);
 ///         (
 ///             AnimNum::new(0., 100.).time(50),
 ///             AnimColor::new("red", "blue").time(50),
@@ -660,13 +660,13 @@ impl<Animated: AnimatedValue> UseAnimation<Animated> {
 /// }
 /// ```
 ///
-/// You can also tweak what to do once the animation has finished with [`Context::on_finish`].
+/// You can also tweak what to do once the animation has finished with [`AnimConfiguration::on_finish`].
 ///
 /// ```rust,no_run
 /// # use freya::prelude::*;
 /// fn app() -> Element {
-///     let animation = use_animation(|ctx| {
-///         ctx.on_finish(OnFinish::Restart);
+///     let animation = use_animation(|conf| {
+///         conf.on_finish(OnFinish::Restart);
 ///         (
 ///             AnimNum::new(0., 100.).time(50),
 ///             AnimColor::new("red", "blue").time(50),

--- a/crates/hooks/src/use_animation.rs
+++ b/crates/hooks/src/use_animation.rs
@@ -129,6 +129,7 @@ pub enum Ease {
 }
 
 /// Animate a color.
+#[derive(Clone, PartialEq)]
 pub struct AnimColor {
     origin: Color,
     destination: Color,
@@ -175,18 +176,9 @@ impl AnimColor {
         self.function = function;
         self
     }
-}
 
-impl AnimatedValue for AnimColor {
-    fn time(&self) -> Duration {
-        self.time
-    }
-
-    fn as_f32(&self) -> f32 {
-        panic!("This is not a f32.")
-    }
-
-    fn as_string(&self) -> String {
+    /// Read the value of the [AnimColor] as a String.
+    pub fn read(&self) -> String {
         format!(
             "rgb({}, {}, {}, {})",
             self.value.r(),
@@ -195,7 +187,9 @@ impl AnimatedValue for AnimColor {
             self.value.a()
         )
     }
+}
 
+impl AnimatedValue for AnimColor {
     fn prepare(&mut self, direction: AnimDirection) {
         match direction {
             AnimDirection::Forward => self.value = self.origin,
@@ -263,9 +257,14 @@ impl AnimatedValue for AnimColor {
         );
         self.value = Color::from_argb(a as u8, r as u8, g as u8, b as u8);
     }
+
+    fn finish(&mut self, direction: AnimDirection) {
+        self.advance(self.time.as_millis(), direction);
+    }
 }
 
 /// Animate a numeric value.
+#[derive(Clone, PartialEq)]
 pub struct AnimNum {
     origin: f32,
     destination: f32,
@@ -312,21 +311,14 @@ impl AnimNum {
         self.function = function;
         self
     }
+
+    /// Read the value of the [AnimNum] as a f32.
+    pub fn read(&self) -> f32 {
+        self.value
+    }
 }
 
 impl AnimatedValue for AnimNum {
-    fn time(&self) -> Duration {
-        self.time
-    }
-
-    fn as_f32(&self) -> f32 {
-        self.value
-    }
-
-    fn as_string(&self) -> String {
-        panic!("This is not a String");
-    }
-
     fn prepare(&mut self, direction: AnimDirection) {
         match direction {
             AnimDirection::Forward => self.value = self.origin,
@@ -359,40 +351,30 @@ impl AnimatedValue for AnimNum {
             self.function,
         )
     }
+
+    fn finish(&mut self, direction: AnimDirection) {
+        self.advance(self.time.as_millis(), direction);
+    }
 }
 
-pub trait AnimatedValue {
-    fn time(&self) -> Duration;
-
-    fn as_f32(&self) -> f32;
-
-    fn as_string(&self) -> String;
-
+pub trait AnimatedValue: Clone + 'static {
     fn prepare(&mut self, direction: AnimDirection);
 
     fn is_finished(&self, index: u128, direction: AnimDirection) -> bool;
 
     fn advance(&mut self, index: u128, direction: AnimDirection);
+
+    fn finish(&mut self, direction: AnimDirection);
 }
 
-pub type ReadAnimatedValue = ReadOnlySignal<Box<dyn AnimatedValue>>;
-
 #[derive(Default, PartialEq, Clone)]
-pub struct Context {
-    animated_values: Vec<Signal<Box<dyn AnimatedValue>>>,
+pub struct AnimConfiguration {
     on_finish: OnFinish,
     auto_start: bool,
     on_deps_change: OnDepsChange,
 }
 
-impl Context {
-    pub fn with(&mut self, animated_value: impl AnimatedValue + 'static) -> ReadAnimatedValue {
-        let val: Box<dyn AnimatedValue> = Box::new(animated_value);
-        let signal = Signal::new(val);
-        self.animated_values.push(signal);
-        ReadOnlySignal::new(signal)
-    }
-
+impl AnimConfiguration {
     pub fn on_finish(&mut self, on_finish: OnFinish) -> &mut Self {
         self.on_finish = on_finish;
         self
@@ -406,6 +388,18 @@ impl Context {
     pub fn on_deps_change(&mut self, on_deps_change: OnDepsChange) -> &mut Self {
         self.on_deps_change = on_deps_change;
         self
+    }
+}
+
+#[derive(Clone)]
+pub struct Context<Animated: AnimatedValue> {
+    value: Signal<Animated>,
+    conf: AnimConfiguration,
+}
+
+impl<Animated: AnimatedValue> PartialEq for Context<Animated> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value) && self.conf.eq(&other.conf)
     }
 }
 
@@ -439,13 +433,13 @@ pub enum OnFinish {
 pub enum OnDepsChange {
     #[default]
     Reset,
-    Run,
+    Finish,
 }
 
 /// Animate your elements. Use [`use_animation`] to use this.
-#[derive(PartialEq, Clone)]
-pub struct UseAnimator<Animated: PartialEq + Clone + 'static> {
-    pub(crate) value_and_ctx: Memo<(Animated, Context)>,
+#[derive(Clone)]
+pub struct UseAnimation<Animated: AnimatedValue> {
+    pub(crate) context: Memo<Context<Animated>>,
     pub(crate) platform: UsePlatform,
     pub(crate) is_running: Signal<bool>,
     pub(crate) has_run_yet: Signal<bool>,
@@ -453,12 +447,23 @@ pub struct UseAnimator<Animated: PartialEq + Clone + 'static> {
     pub(crate) last_direction: Signal<AnimDirection>,
 }
 
-impl<T: PartialEq + Clone + 'static> Copy for UseAnimator<T> {}
+impl<T: AnimatedValue> PartialEq for UseAnimation<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.context.eq(&other.context)
+            && self.platform.eq(&other.platform)
+            && self.is_running.eq(&other.is_running)
+            && self.has_run_yet.eq(&other.has_run_yet)
+            && self.task.eq(&other.task)
+            && self.last_direction.eq(&other.last_direction)
+    }
+}
 
-impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
+impl<T: AnimatedValue> Copy for UseAnimation<T> {}
+
+impl<Animated: AnimatedValue> UseAnimation<Animated> {
     /// Get the animated value.
-    pub fn get(&self) -> Animated {
-        self.value_and_ctx.read().0.clone()
+    pub fn get(&self) -> ReadOnlySignal<Animated> {
+        self.context.read().value.into()
     }
 
     /// Reset the animation to the default state.
@@ -472,25 +477,26 @@ impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
             task.cancel();
         }
 
-        for value in &self.value_and_ctx.read().1.animated_values {
-            let mut value = *value;
-            value.write().prepare(AnimDirection::Forward);
-        }
+        self.context
+            .peek()
+            .value
+            .write_unchecked()
+            .prepare(AnimDirection::Forward);
     }
 
-    /// Update the animation.
-    pub fn run_update(&self) {
+    /// Finish the animation with the final state.
+    pub fn finish(&self) {
         let mut task = self.task;
 
         if let Some(task) = task.write().take() {
             task.cancel();
         }
 
-        for value in &self.value_and_ctx.read().1.animated_values {
-            let mut value = *value;
-            let time = value.peek().time().as_millis();
-            value.write().advance(time, *self.last_direction.peek());
-        }
+        self.context
+            .peek()
+            .value
+            .write_unchecked()
+            .finish(*self.last_direction.peek());
     }
 
     /// Checks if there is any animation running.
@@ -520,15 +526,15 @@ impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
 
     /// Run the animation with a given [`AnimDirection`]
     pub fn run(&self, mut direction: AnimDirection) {
-        let ctx = &self.value_and_ctx.peek().1;
+        let context = &self.context.peek();
         let platform = self.platform;
         let mut is_running = self.is_running;
-        let mut ticker = platform.new_ticker();
-        let mut values = ctx.animated_values.clone();
         let mut has_run_yet = self.has_run_yet;
-        let on_finish = ctx.on_finish;
         let mut task = self.task;
         let mut last_direction = self.last_direction;
+
+        let on_finish = context.conf.on_finish;
+        let mut value = context.value;
 
         last_direction.set(direction);
 
@@ -538,6 +544,7 @@ impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
         }
 
         let peek_has_run_yet = self.peek_has_run_yet();
+        let mut ticker = platform.new_ticker();
 
         let animation_task = spawn(async move {
             platform.request_animation_frame();
@@ -546,9 +553,7 @@ impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
             let mut prev_frame = Instant::now();
 
             // Prepare the animations with the the proper direction
-            for value in values.iter_mut() {
-                value.write().prepare(direction);
-            }
+            value.write().prepare(direction);
 
             if !peek_has_run_yet {
                 *has_run_yet.write() = true;
@@ -562,14 +567,10 @@ impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
 
                 index += prev_frame.elapsed().as_millis();
 
-                let is_finished = values
-                    .iter()
-                    .all(|value| value.peek().is_finished(index, direction));
+                let is_finished = value.peek().is_finished(index, direction);
 
                 // Advance the animations
-                for value in values.iter_mut() {
-                    value.write().advance(index, direction);
-                }
+                value.write().advance(index, direction);
 
                 prev_frame = Instant::now();
 
@@ -583,9 +584,7 @@ impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
                             index = 0;
 
                             // Restart the animation
-                            for value in values.iter_mut() {
-                                value.write().prepare(direction);
-                            }
+                            value.write().prepare(direction);
                         }
                         OnFinish::Stop => {
                             // Stop if all the animations are finished
@@ -625,10 +624,10 @@ impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
 /// fn app() -> Element {
 ///     let animation = use_animation(|ctx| {
 ///         ctx.auto_start(true);
-///         ctx.with(AnimNum::new(0., 100.).time(50))
+///         AnimNum::new(0., 100.).time(50)
 ///     });
 ///
-///     let width = animation.get().read().as_f32();
+///     let width = animation.get().read().read();
 ///
 ///     rsx!(rect {
 ///         width: "{width}",
@@ -646,17 +645,17 @@ impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
 ///     let animation = use_animation(|ctx| {
 ///         ctx.auto_start(true);
 ///         (
-///             ctx.with(AnimNum::new(0., 100.).time(50)),
-///             ctx.with(AnimColor::new("red", "blue").time(50)),
+///             AnimNum::new(0., 100.).time(50),
+///             AnimColor::new("red", "blue").time(50),
 ///         )
 ///     });
 ///
-///     let (width, color) = animation.get();
+///     let (width, color) = &*animation.get().read_unchecked();
 ///
 ///     rsx!(rect {
-///         width: "{width.read().as_f32()}",
+///         width: "{width.read()}",
 ///         height: "100%",
-///         background: "{color.read().as_string()}"
+///         background: "{color.read()}"
 ///     })
 /// }
 /// ```
@@ -669,36 +668,38 @@ impl<Animated: PartialEq + Clone + 'static> UseAnimator<Animated> {
 ///     let animation = use_animation(|ctx| {
 ///         ctx.on_finish(OnFinish::Restart);
 ///         (
-///             ctx.with(AnimNum::new(0., 100.).time(50)),
-///             ctx.with(AnimColor::new("red", "blue").time(50)),
+///             AnimNum::new(0., 100.).time(50),
+///             AnimColor::new("red", "blue").time(50),
 ///         )
 ///     });
 ///
-///     let (width, color) = animation.get();
+///     let (width, color) = &*animation.get().read_unchecked();
 ///
 ///     rsx!(rect {
-///         width: "{width.read().as_f32()}",
+///         width: "{width.read()}",
 ///         height: "100%",
-///         background: "{color.read().as_string()}"
+///         background: "{color.read()}"
 ///     })
 /// }
 /// ```
-pub fn use_animation<Animated: PartialEq + Clone + 'static>(
-    run: impl Fn(&mut Context) -> Animated + Clone + 'static,
-) -> UseAnimator<Animated> {
+pub fn use_animation<Animated: AnimatedValue>(
+    run: impl 'static + Fn(&mut AnimConfiguration) -> Animated,
+) -> UseAnimation<Animated> {
     let platform = use_platform();
     let is_running = use_signal(|| false);
     let has_run_yet = use_signal(|| false);
     let task = use_signal(|| None);
     let last_direction = use_signal(|| AnimDirection::Reverse);
 
-    let value_and_ctx = use_memo(move || {
-        let mut ctx = Context::default();
-        (run(&mut ctx), ctx)
+    let context = use_memo(move || {
+        let mut conf = AnimConfiguration::default();
+        let value = run(&mut conf);
+        let value = Signal::new(value);
+        Context { value, conf }
     });
 
-    let animator = UseAnimator {
-        value_and_ctx,
+    let animation = UseAnimation {
+        context,
         platform,
         is_running,
         has_run_yet,
@@ -707,18 +708,18 @@ pub fn use_animation<Animated: PartialEq + Clone + 'static>(
     };
 
     use_hook(move || {
-        if animator.value_and_ctx.read().1.auto_start {
-            animator.run(AnimDirection::Forward);
+        if animation.context.read().conf.auto_start {
+            animation.run(AnimDirection::Forward);
         }
     });
 
-    animator
+    animation
 }
 
-pub fn use_animation_with_dependencies<Animated: PartialEq + Clone + 'static, D: Dependency>(
+pub fn use_animation_with_dependencies<Animated: PartialEq + AnimatedValue, D: Dependency>(
     deps: D,
-    run: impl Fn(&mut Context, D::Out) -> Animated + 'static,
-) -> UseAnimator<Animated>
+    run: impl 'static + Fn(&mut AnimConfiguration, D::Out) -> Animated,
+) -> UseAnimation<Animated>
 where
     D::Out: 'static + Clone,
 {
@@ -728,13 +729,15 @@ where
     let task = use_signal(|| None);
     let last_direction = use_signal(|| AnimDirection::Reverse);
 
-    let value_and_ctx = use_memo(use_reactive(deps, move |vals| {
-        let mut ctx = Context::default();
-        (run(&mut ctx, vals), ctx)
+    let context = use_memo(use_reactive(deps, move |deps| {
+        let mut conf = AnimConfiguration::default();
+        let value = run(&mut conf, deps);
+        let value = Signal::new(value);
+        Context { value, conf }
     }));
 
-    let animator = UseAnimator {
-        value_and_ctx,
+    let animation = UseAnimation {
+        context,
         platform,
         is_running,
         has_run_yet,
@@ -743,17 +746,82 @@ where
     };
 
     use_memo(move || {
-        let value_and_ctx = value_and_ctx.read();
-        if *has_run_yet.peek() && value_and_ctx.1.on_deps_change == OnDepsChange::Run {
-            animator.run_update()
+        let context = context.read();
+        if *has_run_yet.peek() && context.conf.on_deps_change == OnDepsChange::Finish {
+            animation.finish()
         }
     });
 
     use_hook(move || {
-        if animator.value_and_ctx.read().1.auto_start {
-            animator.run(AnimDirection::Forward);
+        if animation.context.read().conf.auto_start {
+            animation.run(AnimDirection::Forward);
         }
     });
 
-    animator
+    animation
 }
+
+macro_rules! impl_tuple_call {
+    ($(($($type:ident),*)),*) => {
+        $(
+            impl<$($type,)*> AnimatedValue for ($($type,)*)
+            where
+                $($type: AnimatedValue,)*
+            {
+                fn prepare(&mut self, direction: AnimDirection) {
+                    #[allow(non_snake_case)]
+                    let ($($type,)*) = self;
+                    $(
+                        $type.prepare(direction);
+                    )*
+                }
+                fn is_finished(&self, index: u128, direction: AnimDirection) -> bool {
+                    #[allow(non_snake_case)]
+                    let ($($type,)*) = self;
+                    $(
+                        if !$type.is_finished(index, direction) {
+                            return false;
+                        }
+                    )*
+                    true
+                }
+
+                fn advance(&mut self, index: u128, direction: AnimDirection) {
+                    #[allow(non_snake_case)]
+                    let ($($type,)*) = self;
+                    $(
+                        $type.advance(index, direction);
+                    )*
+                }
+                fn finish(&mut self, direction: AnimDirection) {
+                    #[allow(non_snake_case)]
+                    let ($($type,)*) = self;
+                    $(
+                        $type.finish(direction);
+                    )*
+                }
+            }
+        )*
+    };
+}
+
+impl_tuple_call!(
+    (T1),
+    (T1, T2),
+    (T1, T2, T3),
+    (T1, T2, T3, T4),
+    (T1, T2, T3, T4, T5),
+    (T1, T2, T3, T4, T5, T6),
+    (T1, T2, T3, T4, T5, T6, T7),
+    (T1, T2, T3, T4, T5, T6, T7, T8),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17),
+    (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+);

--- a/crates/hooks/tests/use_animation.rs
+++ b/crates/hooks/tests/use_animation.rs
@@ -13,9 +13,9 @@ use tokio::time::sleep;
 #[tokio::test]
 pub async fn track_progress() {
     fn use_animation_app() -> Element {
-        let animation = use_animation(|ctx| ctx.with(AnimNum::new(0., 100.).time(50)));
+        let animation = use_animation(|_conf| AnimNum::new(0., 100.).time(50));
 
-        let progress = animation.get().read().as_f32();
+        let progress = animation.get().read().read();
 
         use_hook(|| {
             animation.start();
@@ -59,9 +59,9 @@ pub async fn track_progress() {
 #[tokio::test]
 pub async fn reverse_progress() {
     fn use_animation_app() -> Element {
-        let animation = use_animation(|ctx| ctx.with(AnimNum::new(10., 100.).time(50)));
+        let animation = use_animation(|_conf| AnimNum::new(10., 100.).time(50));
 
-        let progress = animation.get().read().as_f32();
+        let progress = animation.get().read().read();
 
         use_hook(|| {
             animation.start();
@@ -113,10 +113,9 @@ pub async fn reverse_progress() {
 #[tokio::test]
 pub async fn animate_color() {
     fn use_animation_app() -> Element {
-        let animation =
-            use_animation(|ctx| ctx.with(AnimColor::new("red", "rgb(50, 100, 200)").time(50)));
+        let animation = use_animation(|_conf| AnimColor::new("red", "rgb(50, 100, 200)").time(50));
 
-        let progress = animation.get().read().as_string();
+        let progress = animation.get().read().read();
 
         use_hook(|| {
             animation.start();
@@ -167,12 +166,12 @@ pub async fn animate_color() {
 #[tokio::test]
 pub async fn auto_start() {
     fn use_animation_app() -> Element {
-        let animation = use_animation(|ctx| {
-            ctx.auto_start(true);
-            ctx.with(AnimNum::new(10., 100.).time(50))
+        let animation = use_animation(|conf| {
+            conf.auto_start(true);
+            AnimNum::new(10., 100.).time(50)
         });
 
-        let progress = animation.get().read().as_f32();
+        let progress = animation.get().read().read();
 
         rsx!(rect {
             background: "white",

--- a/examples/animated_sidebar.rs
+++ b/examples/animated_sidebar.rs
@@ -43,14 +43,12 @@ fn FromRouteToCurrent(
     node_size: ReadOnlySignal<NodeReferenceLayout>,
 ) -> Element {
     let mut animated_router = use_animated_router::<Route>();
-    let animations = use_animation_with_dependencies(&upwards, move |ctx, upwards| {
+    let animations = use_animation_with_dependencies(&upwards, move |_conf, upwards| {
         let (start, end) = if upwards { (1., 0.) } else { (0., 1.) };
-        ctx.with(
-            AnimNum::new(start, end)
-                .time(500)
-                .ease(Ease::Out)
-                .function(Function::Expo),
-        )
+        AnimNum::new(start, end)
+            .time(500)
+            .ease(Ease::Out)
+            .function(Function::Expo)
     });
 
     // Only render the destination route once the animation has finished

--- a/examples/animated_sidebar.rs
+++ b/examples/animated_sidebar.rs
@@ -63,7 +63,7 @@ fn FromRouteToCurrent(
         animations.run(AnimDirection::Forward)
     }));
 
-    let offset = animations.get().read().as_f32();
+    let offset = animations.get().read().read();
     let height = node_size.read().area.height();
 
     let offset = height - (offset * height);

--- a/examples/animated_tabs.rs
+++ b/examples/animated_tabs.rs
@@ -43,13 +43,14 @@ fn FromRouteToCurrent(
     node_size: ReadOnlySignal<NodeReferenceLayout>,
 ) -> Element {
     let mut animated_router = use_animated_router::<Route>();
-    let animations = use_animation_with_dependencies(&left_to_right, move |_conf, left_to_right| {
-        let (start, end) = if left_to_right { (1., 0.) } else { (0., 1.) };
-        AnimNum::new(start, end)
-            .time(400)
-            .ease(Ease::Out)
-            .function(Function::Expo)
-    });
+    let animations =
+        use_animation_with_dependencies(&left_to_right, move |_conf, left_to_right| {
+            let (start, end) = if left_to_right { (1., 0.) } else { (0., 1.) };
+            AnimNum::new(start, end)
+                .time(400)
+                .ease(Ease::Out)
+                .function(Function::Expo)
+        });
 
     // Only render the destination route once the animation has finished
     use_memo(move || {
@@ -63,7 +64,7 @@ fn FromRouteToCurrent(
         animations.run(AnimDirection::Forward)
     }));
 
-    let offset = animations.get().read().as_f32();
+    let offset = animations.get().read().read();
     let width = node_size.read().area.width();
 
     let offset = width - (offset * width);

--- a/examples/animated_tabs.rs
+++ b/examples/animated_tabs.rs
@@ -43,14 +43,12 @@ fn FromRouteToCurrent(
     node_size: ReadOnlySignal<NodeReferenceLayout>,
 ) -> Element {
     let mut animated_router = use_animated_router::<Route>();
-    let animations = use_animation_with_dependencies(&left_to_right, move |ctx, left_to_right| {
+    let animations = use_animation_with_dependencies(&left_to_right, move |_conf, left_to_right| {
         let (start, end) = if left_to_right { (1., 0.) } else { (0., 1.) };
-        ctx.with(
-            AnimNum::new(start, end)
-                .time(400)
-                .ease(Ease::Out)
-                .function(Function::Expo),
-        )
+        AnimNum::new(start, end)
+            .time(400)
+            .ease(Ease::Out)
+            .function(Function::Expo)
     });
 
     // Only render the destination route once the animation has finished

--- a/examples/animated_virtual_scroll_view.rs
+++ b/examples/animated_virtual_scroll_view.rs
@@ -44,21 +44,19 @@ fn app() -> Element {
 
 #[component]
 fn AnimatedContainer(height: f32, children: Element) -> Element {
-    let animations = use_animation(|ctx| {
-        ctx.auto_start(true);
-        ctx.with(
-            AnimNum::new(350., 0.)
-                .time(500)
-                .ease(Ease::InOut)
-                .function(Function::Expo),
-        )
+    let animation = use_animation(|conf| {
+        conf.auto_start(true);
+        AnimNum::new(350., 0.)
+            .time(500)
+            .ease(Ease::InOut)
+            .function(Function::Expo)
     });
 
-    let pos = animations.get();
+    let pos = animation.get().read().read();
 
     rsx!(
         rect {
-            offset_x: "{pos.read().as_f32()}",
+            offset_x: "{pos}",
             height: "{height}",
             width: "100%",
             padding: "4",

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -11,35 +11,27 @@ fn main() {
 
 fn app() -> Element {
     let mut toggle = use_signal(|| true);
-    let animations = use_animation(|ctx| {
+    let animation = use_animation(|ctx| {
         (
-            ctx.with(
-                AnimNum::new(100., 200.)
-                    .time(500)
-                    .ease(Ease::Out)
-                    .function(Function::Expo),
-            ),
-            ctx.with(
-                AnimColor::new("rgb(131, 111, 255)", "rgb(255, 167, 50)")
-                    .time(170)
-                    .ease(Ease::InOut),
-            ),
-            ctx.with(
-                AnimNum::new(0., 360.)
-                    .time(1000)
-                    .ease(Ease::Out)
-                    .function(Function::Bounce),
-            ),
-            ctx.with(
-                AnimNum::new(50., 0.)
-                    .time(550)
-                    .ease(Ease::InOut)
-                    .function(Function::Bounce),
-            ),
+            AnimNum::new(100., 200.)
+                .time(500)
+                .ease(Ease::Out)
+                .function(Function::Expo),
+            AnimColor::new("rgb(131, 111, 255)", "rgb(255, 167, 50)")
+                .time(170)
+                .ease(Ease::InOut),
+            AnimNum::new(0., 360.)
+                .time(1000)
+                .ease(Ease::Out)
+                .function(Function::Bounce),
+            AnimNum::new(50., 0.)
+                .time(550)
+                .ease(Ease::InOut)
+                .function(Function::Bounce),
         )
     });
 
-    let (size, color, rotate, radius) = animations.get();
+    let (size, background, rotate, radius) = animation.get();
 
     rsx!(
         rect {
@@ -49,18 +41,18 @@ fn app() -> Element {
             width: "100%",
             onclick: move |_| {
                 if *toggle.peek() {
-                    animations.start();
+                    animation.start();
                 } else {
-                    animations.reverse();
+                    animation.reverse();
                 }
                 toggle.toggle();
             },
             rect {
-                width: "{size.read().as_f32()}",
-                rotate: "{rotate.read().as_f32()}deg",
+                width: "{size.read()}",
+                rotate: "{rotate.read()}deg",
                 height: "50%",
-                background: "{color.read().as_string()}",
-                corner_radius: "{radius.read().as_f32()}"
+                background: "{background.read()}",
+                corner_radius: "{radius.read()}"
             }
         }
     )

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -11,7 +11,7 @@ fn main() {
 
 fn app() -> Element {
     let mut toggle = use_signal(|| true);
-    let animation = use_animation(|ctx| {
+    let animation = use_animation(|_conf| {
         (
             AnimNum::new(100., 200.)
                 .time(500)

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -31,7 +31,7 @@ fn app() -> Element {
         )
     });
 
-    let (size, background, rotate, radius) = animation.get();
+    let (size, background, rotate, radius) = &*animation.get().read_unchecked();
 
     rsx!(
         rect {

--- a/examples/performance_overlay_plugin.rs
+++ b/examples/performance_overlay_plugin.rs
@@ -18,13 +18,11 @@ fn main() {
 const TARGET: f32 = 650.0;
 
 fn app() -> Element {
-    let animation = use_animation(|ctx| {
-        ctx.with(
-            AnimNum::new(15., TARGET)
-                .time(400)
-                .ease(Ease::InOut)
-                .function(Function::Sine),
-        )
+    let animation = use_animation(|_conf| {
+        AnimNum::new(15., TARGET)
+            .time(400)
+            .ease(Ease::InOut)
+            .function(Function::Sine)
     });
 
     let progress = animation.get().read().as_f32();

--- a/examples/performance_overlay_plugin.rs
+++ b/examples/performance_overlay_plugin.rs
@@ -25,7 +25,7 @@ fn app() -> Element {
             .function(Function::Sine)
     });
 
-    let progress = animation.get().read().as_f32();
+    let progress = animation.get().read().read();
 
     if !animation.is_running() {
         if progress == 15.0 {

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -11,15 +11,13 @@ fn main() {
 
 fn app() -> Element {
     let mut start_origin = use_signal(|| 50.);
-    let animation = use_animation(move |ctx| {
-        ctx.with(
-            AnimNum::new(*start_origin.read(), 100.)
-                .time(400)
-                .ease(Ease::InOut)
-                .function(Function::Sine),
-        )
+    let animation = use_animation(move |_conf| {
+        AnimNum::new(*start_origin.read(), 100.)
+            .time(400)
+            .ease(Ease::InOut)
+            .function(Function::Sine)
     });
-    let progress = animation.get().read().as_f32();
+    let progress = animation.get().read().read();
 
     let set_to_max = move |_| {
         animation.start();

--- a/examples/snackbar.rs
+++ b/examples/snackbar.rs
@@ -10,13 +10,11 @@ fn main() {
 }
 
 fn app() -> Element {
-    let animation = use_animation(move |ctx| {
-        ctx.with(
-            AnimNum::new(0., 100.)
-                .time(1850)
-                .ease(Ease::Out)
-                .function(Function::Sine),
-        )
+    let animation = use_animation(move |_conf| {
+        AnimNum::new(0., 100.)
+            .time(1850)
+            .ease(Ease::Out)
+            .function(Function::Sine)
     });
     let progress = animation.get().read().as_f32();
     let mut open = use_signal(|| false);

--- a/examples/snackbar.rs
+++ b/examples/snackbar.rs
@@ -16,7 +16,7 @@ fn app() -> Element {
             .ease(Ease::Out)
             .function(Function::Sine)
     });
-    let progress = animation.get().read().as_f32();
+    let progress = animation.get().read().read();
     let mut open = use_signal(|| false);
 
     rsx!(

--- a/examples/speedometer.rs
+++ b/examples/speedometer.rs
@@ -23,24 +23,21 @@ fn main() {
 
 fn app() -> Element {
     use_init_theme(|| DARK_THEME);
-    let animations = use_animation(|ctx| {
-        ctx.with(
-            AnimNum::new(0., 255.)
-                .time(1600)
-                .ease(Ease::Out)
-                .function(Function::Expo),
-        )
+    let animation = use_animation(|_conf| {
+        AnimNum::new(0., 255.)
+            .time(1600)
+            .ease(Ease::Out)
+            .function(Function::Expo)
     });
 
-    let speed = animations.get();
-    let speed = speed.read().as_f32() as u8;
+    let speed = animation.get().read().as_f32() as u8;
 
     let min = move |_| {
-        animations.run(AnimDirection::Reverse);
+        animation.run(AnimDirection::Reverse);
     };
 
     let max = move |_| {
-        animations.run(AnimDirection::Forward);
+        animation.run(AnimDirection::Forward);
     };
 
     rsx!(

--- a/examples/speedometer.rs
+++ b/examples/speedometer.rs
@@ -30,7 +30,7 @@ fn app() -> Element {
             .function(Function::Expo)
     });
 
-    let speed = animation.get().read().as_f32() as u8;
+    let speed = animation.get().read().read() as u8;
 
     let min = move |_| {
         animation.run(AnimDirection::Reverse);


### PR DESCRIPTION
Internally, `use_animation` now only animates 1 value, although because the trait `AnimatedValue` is now implemented for tuples with up to 18 items you can still group multiple values
