### PR TITLE
docs: fix typos and improve text in "Differences with Dioxus" section

### DIFF
--- a/book/src/differences_with_dioxus.md
+++ b/book/src/differences_with_dioxus.md
@@ -1,32 +1,32 @@
 # Differences with Dioxus
 
-**Freya** is built on top of the **core** crates from Dioxus, this means that you will effectively be creating Dioxus components, using RSX and hooks. 
+**Freya** is built on top of the **core** crates from Dioxus. This means that you will effectively be creating Dioxus components using RSX and hooks.
 
-**But**, thanks to Dioxus being a renderer-agnostic library you will **NOT** be using JavaScript, HTML, OR CSS, or any other abstraction that ends up using one of those or anything close to web.
+However, thanks to Dioxus being a renderer-agnostic library, you will **NOT** be using JavaScript, HTML, CSS, or any other abstraction that ends up using one of those or other web technologies.
 
- Freya does everything on its own when it comes to:
+Freya does everything on its own when it comes to:
 - Elements
 - Styling
 - Layout
 - Events
 - Rendering
 - Testing
-- Built-in components and hooks,
+- Built-in components and hooks
 - Editing
 - Animating
 
-And more. Dioxus only is only used to run the app components (hooks, lifecycle, state, rsx), **everything else is managed by Freya**.
+...and more. Dioxus is only used for managing app components (hooks, lifecycle, state, RSX), while **everything else is managed by Freya**.
 
-**Freya is not mean to be drop-in alternative to Dioxus renderers but as GUI library on its own.**
+**Freya is not meant to be a drop-in alternative to Dioxus renderers but a GUI library on its own.**
 
-Here is the list of the main differences between Freya and the official Dioxus renderers for Desktop (WebView and Blitz):
+Below is a comparison of the main differences between Freya and the official Dioxus renderers for Desktop (WebView and Blitz):
 
 | Category                             | Freya            | Dioxus Renderers                |
 |--------------------------------------|------------------|---------------------------------|
-| **Elements, attributes and events**  | Custom           | HTML                            |
+| **Elements, attributes, and events** | Custom           | HTML                            |
 | **Layout** | Custom ([`Torin`](https://github.com/marc2332/freya/tree/main/crates/torin)) | CSS or [`Taffy`](https://github.com/DioxusLabs/taffy) |
 | **Styling**                          | Custom                    | CSS                             |
 | **Renderer**                         | Skia                      | WebView or WGPU                 |
-| **Components library**               | Custom ([`freya-comonents`](https://github.com/marc2332/freya/tree/main/crates/components))  | None, but can use HTML elements and CSS libraries |
-| **Devtools**                         | Custom ([`freya-devtools`](https://github.com/marc2332/freya/tree/main/crates/devtools))   | Provided in Webview             |
-| **Headless testing runner**          | Custom ([`freya-testing`](https://github.com/marc2332/freya/tree/main/crates/testing))    | None, but there is Playwright and similar   |
+| **Components library**               | Custom ([`freya-components`](https://github.com/marc2332/freya/tree/main/crates/components)) | None, but can use HTML elements and CSS libraries |
+| **Devtools**                         | Custom ([`freya-devtools`](https://github.com/marc2332/freya/tree/main/crates/devtools))   | Provided in WebView              |
+| **Headless testing runner**          | Custom ([`freya-testing`](https://github.com/marc2332/freya/tree/main/crates/testing))       | None, but tools like Playwright and similar are available |


### PR DESCRIPTION
I just stumbled upon freya coming from Dioxus and noticed a couple typos in the book. This should improve this section a bit.