### PR TITLE
fix: Add missing `Data` to `[u8]` deref

### DIFF
--- a/crates/engine/src/mocked.rs
+++ b/crates/engine/src/mocked.rs
@@ -1274,6 +1274,13 @@ impl Data {
     }
 }
 
+impl Deref for Data {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        unimplemented!("This is mocked")
+    }
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
 pub struct IRect {


### PR DESCRIPTION
Fixes https://docs.rs/crate/freya/0.3.0-rc.0/builds/1603660