### PR TITLE
fix: Manually drop previous animated values when the run callback reruns

### DIFF
--- a/crates/hooks/src/use_animation.rs
+++ b/crates/hooks/src/use_animation.rs
@@ -753,11 +753,16 @@ pub fn use_animation<Animated: AnimatedValue>(
     let has_run_yet = use_signal(|| false);
     let task = use_signal(|| None);
     let last_direction = use_signal(|| AnimDirection::Reverse);
+    let mut prev_value = use_signal::<Option<Signal<Animated>>>(|| None);
 
     let context = use_memo(move || {
+        if let Some(prev_value) = prev_value.take() {
+            prev_value.manually_drop();
+        }
         let mut conf = AnimConfiguration::default();
         let value = run(&mut conf);
         let value = Signal::new(value);
+        prev_value.set(Some(value));
         Context { value, conf }
     });
 
@@ -791,11 +796,16 @@ where
     let has_run_yet = use_signal(|| false);
     let task = use_signal(|| None);
     let last_direction = use_signal(|| AnimDirection::Reverse);
+    let mut prev_value = use_signal::<Option<Signal<Animated>>>(|| None);
 
     let context = use_memo(use_reactive(deps, move |deps| {
+        if let Some(prev_value) = prev_value.take() {
+            prev_value.manually_drop();
+        }
         let mut conf = AnimConfiguration::default();
         let value = run(&mut conf, deps);
         let value = Signal::new(value);
+        prev_value.set(Some(value));
         Context { value, conf }
     }));
 


### PR DESCRIPTION
This could have technically leak memory as long as the scope was alive and the animation runner might have rerun multiple times (this will only happens if the manual dependencies or read signals, change)