### PR TITLE
fix: Poll one more time the overflowed content test

### DIFF
--- a/crates/components/src/overflowed_content.rs
+++ b/crates/components/src/overflowed_content.rs
@@ -128,6 +128,7 @@ mod test {
         utils.wait_for_update().await;
         utils.wait_for_update().await;
         utils.wait_for_update().await;
+        utils.wait_for_update().await;
         assert_ne!(label.layout().unwrap().area.min_x(), 50.);
     }
 }


### PR DESCRIPTION
Sometimes it fails in the CI, probably because of timers