### PR TITLE
refactor: Improved `UseFocus::validate_keydown`

### DIFF
--- a/crates/components/src/button.rs
+++ b/crates/components/src/button.rs
@@ -281,8 +281,8 @@ pub fn ButtonBase(
         status.set(ButtonStatus::default());
     };
 
-    let onglobalkeydown = move |ev: KeyboardEvent| {
-        if focus.validate_globalkeydown(&ev) {
+    let onkeydown = move |ev: KeyboardEvent| {
+        if focus.validate_keydown(&ev) {
             if let Some(onpress) = &onpress {
                 onpress.call(PressEvent::Key(ev))
             }
@@ -293,7 +293,7 @@ pub fn ButtonBase(
         ButtonStatus::Hovering => hover_background,
         ButtonStatus::Idle => background,
     };
-    let border = if focus.is_selected() {
+    let border = if focus.is_focused_with_keyboard() {
         format!("2 inner {focus_border_fill}")
     } else {
         format!("1 inner {border_fill}")
@@ -304,7 +304,7 @@ pub fn ButtonBase(
             onpointerup,
             onmouseenter,
             onmouseleave,
-            onglobalkeydown,
+            onkeydown,
             a11y_id,
             width: "{width}",
             height: "{height}",

--- a/crates/components/src/checkbox.rs
+++ b/crates/components/src/checkbox.rs
@@ -102,13 +102,17 @@ pub fn Checkbox(
     } else {
         ("transparent", unselected_fill.as_ref())
     };
-    let border = if focus.is_selected() {
+    let border = if focus.is_focused_with_keyboard() {
         format!("2 inner {outer_fill}, 4 outer {border_fill}")
     } else {
         format!("2 inner {outer_fill}")
     };
 
-    let onkeydown = move |_: KeyboardEvent| {};
+    let onkeydown = move |e: KeyboardEvent| {
+        if !focus.validate_keydown(&e) {
+            e.stop_propagation();
+        }
+    };
 
     rsx!(
         rect {

--- a/crates/components/src/dropdown.rs
+++ b/crates/components/src/dropdown.rs
@@ -89,7 +89,7 @@ where
         DropdownItemStatus::Hovering => hover_background,
         DropdownItemStatus::Idle => background,
     };
-    let border = if focus.is_selected() {
+    let border = if focus.is_focused_with_keyboard() {
         format!("2 inner {select_border_fill}")
     } else {
         format!("1 inner {border_fill}")
@@ -308,7 +308,7 @@ where
         DropdownStatus::Hovering => hover_background,
         DropdownStatus::Idle => background_button,
     };
-    let border = if focus.is_selected() {
+    let border = if focus.is_focused_with_keyboard() {
         format!("2 inner {focus_border_fill}")
     } else {
         format!("1 inner {border_fill}")

--- a/crates/components/src/radio.rs
+++ b/crates/components/src/radio.rs
@@ -83,13 +83,17 @@ pub fn Radio(
     } else {
         unselected_fill
     };
-    let border = if focus.is_selected() {
+    let border = if focus.is_focused_with_keyboard() {
         format!("2 inner {fill}, 4 outer {border_fill}")
     } else {
         format!("2 inner {fill}")
     };
 
-    let onkeydown = move |_: KeyboardEvent| {};
+    let onkeydown = move |e: KeyboardEvent| {
+        if !focus.validate_keydown(&e) {
+            e.stop_propagation();
+        }
+    };
 
     rsx!(
         rect {

--- a/crates/components/src/slider.rs
+++ b/crates/components/src/slider.rs
@@ -220,7 +220,7 @@ pub fn Slider(
         onmoved.call(percentage);
     };
 
-    let border = if focus.is_selected() {
+    let border = if focus.is_focused_with_keyboard() {
         format!("2 inner {}", theme.border_fill)
     } else {
         "none".to_string()

--- a/crates/components/src/switch.rs
+++ b/crates/components/src/switch.rs
@@ -167,8 +167,8 @@ pub fn Switch(props: SwitchProps) -> Element {
         props.ontoggled.call(());
     };
 
-    let onglobalkeydown = move |e: KeyboardEvent| {
-        if focus.validate_globalkeydown(&e) {
+    let onkeydown = move |e: KeyboardEvent| {
+        if focus.validate_keydown(&e) {
             props.ontoggled.call(());
         }
     };
@@ -179,7 +179,7 @@ pub fn Switch(props: SwitchProps) -> Element {
     let background = background.read();
     let circle = circle.read();
 
-    let border = if focus.is_selected() {
+    let border = if focus.is_focused_with_keyboard() {
         if props.enabled {
             format!("2 inner {}", theme.enabled_focus_border_fill)
         } else {
@@ -209,7 +209,7 @@ pub fn Switch(props: SwitchProps) -> Element {
             onmousedown,
             onmouseenter,
             onmouseleave,
-            onglobalkeydown,
+            onkeydown,
             onclick,
             a11y_id,
             offset_x: "{offset_x}",

--- a/crates/components/src/tabs.rs
+++ b/crates/components/src/tabs.rs
@@ -161,7 +161,7 @@ pub fn Tab(
         TabStatus::Hovering => hover_background,
         TabStatus::Idle => background,
     };
-    let border = if focus.is_selected() || is_active {
+    let border = if focus.is_focused_with_keyboard() || is_active {
         focus_border_fill
     } else {
         border_fill
@@ -318,7 +318,7 @@ pub fn BottomTab(
     };
 
     let background = match *status.read() {
-        _ if focus.is_selected() || is_active => hover_background,
+        _ if focus.is_focused_with_keyboard() || is_active => hover_background,
         TabStatus::Hovering => hover_background,
         TabStatus::Idle => background,
     };

--- a/crates/components/src/tile.rs
+++ b/crates/components/src/tile.rs
@@ -2,7 +2,6 @@ use dioxus::prelude::*;
 use freya_elements::{
     self as dioxus_elements,
     events::{
-        Key,
         KeyboardEvent,
         MouseEvent,
     },
@@ -53,11 +52,9 @@ pub fn Tile(
     });
 
     let onkeydown = move |e: KeyboardEvent| {
-        if e.key == Key::Enter {
-            if let Some(onselect) = &onselect {
-                e.stop_propagation();
-                onselect.call(())
-            }
+        if let Some(onselect) = &onselect {
+            e.stop_propagation();
+            onselect.call(())
         }
     };
 


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/883

Stop using `globalkeydown` for Switch and Button, and now `validate_keydown` will also fire when Space is pressed.