### PR TITLE
fix: Revert image clipping removal

### DIFF
--- a/crates/core/src/elements/image.rs
+++ b/crates/core/src/elements/image.rs
@@ -42,7 +42,13 @@ impl ElementUtils for ImageElement {
 
         let image_state = node_ref.get::<ImageState>().unwrap();
 
-        let mut rect = Rect::new(area.min_x(), area.min_y(), area.max_x(), area.max_y());
+        let mut rect = Rect::new(
+            area.min_x(),
+            area.min_y(),
+            area.min_x() + size.width,
+            area.min_y() + size.height,
+        );
+        let clip_rect = Rect::new(area.min_x(), area.min_y(), area.max_x(), area.max_y());
 
         if image_state.image_cover == ImageCover::Center {
             let width_offset = (size.width - area.width()) / 2.;
@@ -53,6 +59,9 @@ impl ElementUtils for ImageElement {
             rect.top -= height_offset;
             rect.bottom -= height_offset;
         }
+
+        canvas.save();
+        canvas.clip_rect(clip_rect, ClipOp::Intersect, true);
 
         let mut paint = Paint::default();
         paint.set_anti_alias(true);
@@ -72,6 +81,8 @@ impl ElementUtils for ImageElement {
             sampling,
             &Paint::default(),
         );
+
+        canvas.restore();
     }
     fn clip(
         &self,


### PR DESCRIPTION
Partial revert of https://github.com/marc2332/freya/commit/9226b655c3ee5a7f8908b34bd7a60066550d194f#diff-c0a88ed9a55d3f60cdd03150049f2cf5c4eb26149de400c98c4a58320c970198

This was affecting the aspect ratio feature