### PR TITLE
fix: Prevent animations stalling

### DIFF
--- a/crates/hooks/src/use_animation/anim_color.rs
+++ b/crates/hooks/src/use_animation/anim_color.rs
@@ -85,14 +85,14 @@ impl AnimatedValue for AnimColor {
     fn is_finished(&self, index: u128, direction: AnimDirection) -> bool {
         match direction {
             AnimDirection::Forward => {
-                index > self.time.as_millis()
+                index >= self.time.as_millis()
                     && self.value.r() == self.destination.r()
                     && self.value.g() == self.destination.g()
                     && self.value.b() == self.destination.b()
                     && self.value.a() == self.destination.a()
             }
             AnimDirection::Reverse => {
-                index > self.time.as_millis()
+                index >= self.time.as_millis()
                     && self.value.r() == self.origin.r()
                     && self.value.g() == self.origin.g()
                     && self.value.b() == self.origin.b()

--- a/crates/hooks/src/use_animation/anim_num.rs
+++ b/crates/hooks/src/use_animation/anim_num.rs
@@ -82,9 +82,9 @@ impl AnimatedValue for AnimNum {
     fn is_finished(&self, index: u128, direction: AnimDirection) -> bool {
         match direction {
             AnimDirection::Forward => {
-                index > self.time.as_millis() && self.value == self.destination
+                index >= self.time.as_millis() && self.value == self.destination
             }
-            AnimDirection::Reverse => index > self.time.as_millis() && self.value == self.origin,
+            AnimDirection::Reverse => index >= self.time.as_millis() && self.value == self.origin,
         }
     }
 

--- a/crates/hooks/src/use_animation/animated_value.rs
+++ b/crates/hooks/src/use_animation/animated_value.rs
@@ -39,9 +39,12 @@ pub fn apply_value(
         destination - origin,
         time.as_millis() as f32,
     );
+
+    // We can skip the easing if we have reached the last index
     if t == d {
         return destination;
     }
+    
     match function {
         Function::Back => match ease {
             Ease::In => Back::ease_in(t, b, c, d),

--- a/crates/hooks/src/use_animation/animated_value.rs
+++ b/crates/hooks/src/use_animation/animated_value.rs
@@ -41,7 +41,7 @@ pub fn apply_value(
     );
 
     // We can skip the easing if we have reached the last index
-    if t == d {
+    if t >= d {
         return destination;
     }
 

--- a/crates/hooks/src/use_animation/animated_value.rs
+++ b/crates/hooks/src/use_animation/animated_value.rs
@@ -39,7 +39,10 @@ pub fn apply_value(
         destination - origin,
         time.as_millis() as f32,
     );
-    let v = match function {
+    if t == d {
+        return destination;
+    }
+    match function {
         Function::Back => match ease {
             Ease::In => Back::ease_in(t, b, c, d),
             Ease::InOut => Back::ease_in_out(t, b, c, d),
@@ -90,10 +93,7 @@ pub fn apply_value(
             Ease::InOut => Sine::ease_in_out(t, b, c, d),
             Ease::Out => Sine::ease_out(t, b, c, d),
         },
-    };
-
-    // Round up to 3 decimals
-    (v * 1000.).round() / 1000.
+    }
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/hooks/src/use_animation/animated_value.rs
+++ b/crates/hooks/src/use_animation/animated_value.rs
@@ -44,7 +44,7 @@ pub fn apply_value(
     if t == d {
         return destination;
     }
-    
+
     match function {
         Function::Back => match ease {
             Ease::In => Back::ease_in(t, b, c, d),

--- a/crates/hooks/src/use_animation/animated_value.rs
+++ b/crates/hooks/src/use_animation/animated_value.rs
@@ -39,7 +39,7 @@ pub fn apply_value(
         destination - origin,
         time.as_millis() as f32,
     );
-    match function {
+    let v = match function {
         Function::Back => match ease {
             Ease::In => Back::ease_in(t, b, c, d),
             Ease::InOut => Back::ease_in_out(t, b, c, d),
@@ -90,7 +90,10 @@ pub fn apply_value(
             Ease::InOut => Sine::ease_in_out(t, b, c, d),
             Ease::Out => Sine::ease_out(t, b, c, d),
         },
-    }
+    };
+
+    // Round up to 3 decimals
+    (v * 1000.).round() / 1000.
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]

--- a/examples/animated_tabs.rs
+++ b/examples/animated_tabs.rs
@@ -64,17 +64,17 @@ fn FromRouteToCurrent(
             )
         });
 
-    // Only render the destination route once the animation has finished
-    use_memo(move || {
-        if !animations.is_running() && animations.has_run_yet() {
-            animated_router.write().settle();
-        }
-    });
-
     // Run the animation when any prop changes
     use_memo(use_reactive((&left_to_right, &from), move |_| {
         animations.run(AnimDirection::Forward)
     }));
+
+    // Only render the destination route once the animation has finished
+    use_effect(move || {
+        if !animations.is_running() && animations.has_run_yet() {
+            animated_router.write().settle();
+        }
+    });
 
     let animations = animations.get();
     let offset = animations.read().0.read();
@@ -163,32 +163,33 @@ fn AppSidebar() -> Element {
         NativeRouter {
             AnimatedRouter::<Route> {
                 rect {
-                    height: "calc(100% - 50)",
-                    width: "fill",
+                    content: "flex",
                     Body {
+                        height: "flex(1)",
                         AnimatedOutlet { }
                     }
+                    rect {
+                        direction: "horizontal",
+                        main_align: "center",
+                        cross_align: "center",
+                        width: "fill",
+                        padding: "8",
+                        spacing: "8",
+                        BottomTab {
+                            route: Route::Home,
+                            exact: true,
+                            "Go to Hey ! 👋"
+                        }
+                        BottomTab {
+                            route: Route::Wow,
+                            "Go to Wow! 👈"
+                        }
+                        BottomTab {
+                            route: Route::Crab,
+                            "Go to Crab! 🦀"
+                        }
+                    }
                 }
-                rect {
-                    direction: "horizontal",
-                    main_align: "center",
-                    cross_align: "center",
-                    width: "fill",
-                    BottomTab {
-                        route: Route::Home,
-                        exact: true,
-                        "Go to Hey ! 👋"
-                    }
-                    BottomTab {
-                        route: Route::Wow,
-                        "Go to Wow! 👈"
-                    }
-                    BottomTab {
-                        route: Route::Crab,
-                        "Go to Crab! 🦀"
-                    }
-                }
-
             }
         }
     )

--- a/examples/animated_tabs.rs
+++ b/examples/animated_tabs.rs
@@ -76,14 +76,14 @@ fn FromRouteToCurrent(
         }
     });
 
-    let animations = animations.get();
-    let offset = animations.read().0.read();
+    let animations = animations.get()();
+    let offset = animations.0.read();
     let (scale_out, scale_in) = if left_to_right {
-        (animations.read().1.read(), animations.read().2.read())
+        (animations.1.read(), animations.2.read())
     } else {
-        (animations.read().2.read(), animations.read().1.read())
+        (animations.2.read(), animations.1.read())
     };
-    let corner_radius = animations.read().3.read();
+    let corner_radius = animations.3.read();
     let width = node_size.read().area.width();
 
     let offset = width - (offset * width);


### PR DESCRIPTION
Some animated values were never reaching their destination even though their ease functions were given the right params, so I made it return the destination once the last index is reached