### PR TITLE
fix: Only send release events on pressed nodes

### DIFF
--- a/crates/components/src/popup.rs
+++ b/crates/components/src/popup.rs
@@ -266,7 +266,7 @@ mod test {
         // Check the popup is opened
         assert_eq!(utils.sdom().get().layout().size(), 12);
 
-        utils.click_cursor((395., 180.)).await;
+        utils.click_cursor((25., 25.)).await;
 
         // Check the popup is closed
         assert_eq!(utils.sdom().get().layout().size(), 4);

--- a/crates/core/src/events/nodes_state.rs
+++ b/crates/core/src/events/nodes_state.rs
@@ -53,9 +53,8 @@ impl NodesState {
         // Pressed Nodes
         #[allow(unused_variables)]
         self.pressed_nodes.retain(|node_id, _| {
-             // Check if a DOM event that presses this Node will get emitted
-             let no_desire_to_press =
-                filter_dom_events_by(dom_events, node_id, |e| e.is_pressed());
+            // Check if a DOM event that presses this Node will get emitted
+            let no_desire_to_press = filter_dom_events_by(dom_events, node_id, |e| e.is_pressed());
 
             // If there has been a mouse press but a DOM event was not emitted to this node, then we safely assume
             // the user does no longer want to press this Node
@@ -76,8 +75,7 @@ impl NodesState {
         // Hovered Nodes
         self.hovered_nodes.retain(|node_id, metadata| {
             // Check if a DOM event that moves the cursor in this Node will get emitted
-            let no_desire_to_hover =
-                filter_dom_events_by(dom_events, node_id, |e| e.is_moved());
+            let no_desire_to_hover = filter_dom_events_by(dom_events, node_id, |e| e.is_moved());
 
             if no_desire_to_hover {
                 // If there has been a mouse movement but a DOM event was not emitted to this node, then we safely assume
@@ -114,7 +112,7 @@ impl NodesState {
                 // Only let through enter events when the node was not hovered
                 _ if ev.name.is_enter() => !self.hovered_nodes.contains_key(&ev.node_id),
 
-                // Only let through release events when the node was already pressed 
+                // Only let through release events when the node was already pressed
                 _ if ev.name.is_released() => self.pressed_nodes.contains_key(&ev.node_id),
 
                 _ => true,

--- a/crates/core/src/events/nodes_state.rs
+++ b/crates/core/src/events/nodes_state.rs
@@ -48,13 +48,18 @@ impl NodesState {
         let mut potential_collateral_events = PotentialEvents::default();
 
         // Any mouse press event at all
-        let recent_mouse_press_event = any_event_of(events, |e| e.was_cursor_pressed_or_released());
+        let recent_mouse_press_event = any_event_of(events, |e| e.is_pressed());
 
         // Pressed Nodes
         #[allow(unused_variables)]
         self.pressed_nodes.retain(|node_id, _| {
-            // Always unmark as pressed when there has been a new mouse down or click event
-            if recent_mouse_press_event.is_some() {
+             // Check if a DOM event that presses this Node will get emitted
+             let no_desire_to_press =
+                filter_dom_events_by(dom_events, node_id, |e| e.is_pressed());
+
+            // If there has been a mouse press but a DOM event was not emitted to this node, then we safely assume
+            // the user does no longer want to press this Node
+            if no_desire_to_press && recent_mouse_press_event.is_some() {
                 #[cfg(debug_assertions)]
                 tracing::info!("Unmarked as pressed {:?}", node_id);
 
@@ -66,15 +71,15 @@ impl NodesState {
         });
 
         // Any mouse movement event at all
-        let recent_mouse_movement_event = any_event_of(events, |e| e.was_cursor_moved());
+        let recent_mouse_movement_event = any_event_of(events, |e| e.is_moved());
 
         // Hovered Nodes
         self.hovered_nodes.retain(|node_id, metadata| {
             // Check if a DOM event that moves the cursor in this Node will get emitted
-            let no_recently_hovered =
-                filter_dom_events_by(dom_events, node_id, |e| e.was_cursor_moved());
+            let no_desire_to_hover =
+                filter_dom_events_by(dom_events, node_id, |e| e.is_moved());
 
-            if no_recently_hovered {
+            if no_desire_to_hover {
                 // If there has been a mouse movement but a DOM event was not emitted to this node, then we safely assume
                 // the user does no longer want to hover this Node
                 if let Some(PlatformEventData::Mouse { cursor, button, .. }) =
@@ -106,11 +111,11 @@ impl NodesState {
 
         dom_events.retain(|ev| {
             match ev.name {
-                // Filter out enter events for nodes that were already hovered
+                // Only let through enter events when the node was not hovered
                 _ if ev.name.is_enter() => !self.hovered_nodes.contains_key(&ev.node_id),
 
-                // Filter out press events for nodes that were already pressed
-                _ if ev.name.is_pressed() => !self.pressed_nodes.contains_key(&ev.node_id),
+                // Only let through release events when the node was already pressed 
+                _ if ev.name.is_released() => self.pressed_nodes.contains_key(&ev.node_id),
 
                 _ => true,
             }
@@ -145,7 +150,7 @@ impl NodesState {
 
                 match name {
                     // Update hovered nodes state
-                    name if name.can_change_hover_state() => {
+                    name if name.is_hovered() => {
                         // Mark the Node as hovered if it wasn't already
                         self.hovered_nodes.entry(*node_id).or_insert_with(|| {
                             #[cfg(debug_assertions)]
@@ -156,7 +161,7 @@ impl NodesState {
                     }
 
                     // Update pressed nodes state
-                    name if name.can_change_press_state() => {
+                    name if name.is_pressed() => {
                         // Mark the Node as pressed if it wasn't already
                         self.pressed_nodes.entry(*node_id).or_insert_with(|| {
                             #[cfg(debug_assertions)]

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -247,7 +247,7 @@ impl EventName {
     pub fn is_released(&self) -> bool {
         matches!(
             &self,
-            Self::Click | Self::PointerUp | Self::TouchEnd | Self::MouseUp
+            Self::Click | Self::PointerUp | Self::TouchEnd
         )
     }
 }

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -243,8 +243,8 @@ impl EventName {
         matches!(self, Self::MouseDown | Self::TouchStart | Self::PointerDown)
     }
 
-    /// Check if this event canr release the press state of a Node.
+    /// Check if this event can release the press state of a Node.
     pub fn is_released(&self) -> bool {
-        matches!(&self, Self::Click | Self::PointerUp | Self::TouchEnd)
+        matches!(&self, Self::Click | Self::PointerUp)
     }
 }

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -245,9 +245,6 @@ impl EventName {
 
     /// Check if this event canr release the press state of a Node.
     pub fn is_released(&self) -> bool {
-        matches!(
-            &self,
-            Self::Click | Self::PointerUp | Self::TouchEnd
-        )
+        matches!(&self, Self::Click | Self::PointerUp | Self::TouchEnd)
     }
 }

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -245,6 +245,9 @@ impl EventName {
 
     /// Check if this event canr release the press state of a Node.
     pub fn is_released(&self) -> bool {
-        matches!(&self, Self::Click | Self::PointerUp | Self::TouchEnd | Self::MouseUp)
+        matches!(
+            &self,
+            Self::Click | Self::PointerUp | Self::TouchEnd | Self::MouseUp
+        )
     }
 }

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -200,8 +200,8 @@ impl EventName {
         )
     }
 
-    /// Check if the event means the cursor was moved
-    pub fn was_cursor_moved(&self) -> bool {
+    /// Check if the event means the cursor was moved.
+    pub fn is_moved(&self) -> bool {
         matches!(
             &self,
             Self::MouseMove | Self::MouseEnter | Self::PointerEnter | Self::PointerOver
@@ -231,34 +231,20 @@ impl EventName {
     }
 
     /// Check if this event can change the hover state of a Node.
-    pub fn can_change_hover_state(&self) -> bool {
+    pub fn is_hovered(&self) -> bool {
         matches!(
             self,
             Self::MouseMove | Self::MouseEnter | Self::PointerOver | Self::PointerEnter
         )
     }
 
-    /// Check if this event can change the press state of a Node.
-    pub fn can_change_press_state(&self) -> bool {
+    /// Check if this event can press state of a Node.
+    pub fn is_pressed(&self) -> bool {
         matches!(self, Self::MouseDown | Self::TouchStart | Self::PointerDown)
     }
 
-    /// Check if the event means the cursor started or released a click
-    pub fn was_cursor_pressed_or_released(&self) -> bool {
-        matches!(
-            &self,
-            Self::MouseDown
-                | Self::PointerDown
-                | Self::MouseUp
-                | Self::Click
-                | Self::PointerUp
-                | Self::TouchStart
-                | Self::TouchEnd
-        )
-    }
-
-    /// Check if the event was pressed
-    pub fn is_pressed(&self) -> bool {
-        matches!(&self, Self::Click)
+    /// Check if this event canr release the press state of a Node.
+    pub fn is_released(&self) -> bool {
+        matches!(&self, Self::Click | Self::PointerUp | Self::TouchEnd | Self::MouseUp)
     }
 }


### PR DESCRIPTION
Only those nodes previously marked as `pressed` (mousedown, pointerdown, etc) are allowed to have emitted `release` (click, pointerup, etc) events on them.