### PR TITLE
fix: Only update devtools on repaint or relayout, but not both

### DIFF
--- a/crates/winit/src/devtools.rs
+++ b/crates/winit/src/devtools.rs
@@ -55,8 +55,8 @@ impl Devtools {
             }
 
             if !devtools_found && root_found {
-                let has_layout = layout.get(node.id()).is_some();
-                if has_layout {
+                let layout_node = layout.get(node.id()).cloned();
+                if let Some(layout_node) = layout_node {
                     let node_type = node.node_type();
                     new_nodes.push(NodeInfo {
                         id: node.id(),
@@ -69,7 +69,7 @@ impl Devtools {
                         tag: *node_type.tag().unwrap(),
                         height: node.height(),
                         state: get_node_state(&node),
-                        layout_node: layout.get(node.id()).unwrap().clone(),
+                        layout_node,
                     });
                 }
             }


### PR DESCRIPTION
This fixes a small bug where the devtools nodes vec was empty on certain updates where there was a repaint and relayout, the fact that where was a relayout but the layout had not been remeasured yet means that the nodes were not in sync yet