### PR TITLE
fix: Only create global events based on the platform derived events

### DIFF
--- a/crates/core/src/events/events_measurer.rs
+++ b/crates/core/src/events/events_measurer.rs
@@ -232,7 +232,11 @@ fn measure_dom_events(
     let layout = fdom.layout();
 
     for (event_name, event_nodes) in potential_events {
-        let derived_events = event_name.get_derived_events();
+        // Get the derived events, but exclude globals like some file events
+        let derived_events = event_name
+            .get_derived_events()
+            .into_iter()
+            .filter(|event| !event.is_global());
 
         // Iterate over the derived events (including the source)
         'event: for derived_event in derived_events {

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -176,7 +176,6 @@ impl EventName {
                 events.extend([Self::Click, Self::PointerUp])
             }
             Self::MouseLeave => events.push(Self::PointerLeave),
-            Self::GlobalFileHover | Self::GlobalFileHoverCancelled => events.clear(),
             _ => {}
         }
 


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/1167

It doesnt make sense to create global events based on dom events, as these might or not happen, neither it makes sense to also consider collateral events as there is no collateral event that also has a global variant, for global events, instead it is as easy as using the platform events and their derived events to create global events