### PR TITLE
fix: Avoid overflow on keyboard navigation in empty lines of text

### DIFF
--- a/crates/hooks/src/text_editor.rs
+++ b/crates/hooks/src/text_editor.rs
@@ -154,7 +154,7 @@ pub trait TextEditor {
                 let new_row = old_row + 1;
                 let new_row_char = self.char_to_utf16_cu(self.line_to_char(new_row));
                 let new_row_len = self.line(new_row).unwrap().utf16_len();
-                let new_col = old_col.min(new_row_len - 1);
+                let new_col = old_col.min(new_row_len.saturating_sub(1));
                 self.cursor_mut().set(new_row_char + new_col);
 
                 true
@@ -188,7 +188,7 @@ pub trait TextEditor {
                 let new_row = old_row - 1;
                 let new_row_char = self.char_to_utf16_cu(self.line_to_char(new_row));
                 let new_row_len = self.line(new_row).unwrap().utf16_len();
-                let new_col = old_col.min(new_row_len - 1);
+                let new_col = old_col.min(new_row_len.saturating_sub(1));
                 self.cursor_mut().set(new_row_char + new_col);
             }
 


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/1177