### PR TITLE
fix: remove unnecessary empty section at the end of VirtualScrollView component

### DIFF
--- a/crates/components/src/scroll_views/virtual_scroll_view.rs
+++ b/crates/components/src/scroll_views/virtual_scroll_view.rs
@@ -5,15 +5,35 @@ use std::ops::Range;
 use dioxus::prelude::*;
 use freya_elements::{
     self as dioxus_elements,
-    events::{keyboard::Key, KeyboardEvent, MouseEvent, WheelEvent},
+    events::{
+        keyboard::Key,
+        KeyboardEvent,
+        MouseEvent,
+        WheelEvent,
+    },
 };
-use freya_hooks::{use_applied_theme, use_focus, use_node, ScrollBarThemeWith};
+use freya_hooks::{
+    use_applied_theme,
+    use_focus,
+    use_node,
+    ScrollBarThemeWith,
+};
 
 use crate::{
-    get_container_sizes, get_corrected_scroll_position, get_scroll_position_from_cursor,
-    get_scroll_position_from_wheel, get_scrollbar_pos_and_size, is_scrollbar_visible,
-    manage_key_event, scroll_views::use_scroll_controller, Axis, ScrollBar, ScrollConfig,
-    ScrollController, ScrollThumb, SCROLL_SPEED_MULTIPLIER,
+    get_container_sizes,
+    get_corrected_scroll_position,
+    get_scroll_position_from_cursor,
+    get_scroll_position_from_wheel,
+    get_scrollbar_pos_and_size,
+    is_scrollbar_visible,
+    manage_key_event,
+    scroll_views::use_scroll_controller,
+    Axis,
+    ScrollBar,
+    ScrollConfig,
+    ScrollController,
+    ScrollThumb,
+    SCROLL_SPEED_MULTIPLIER,
 };
 
 /// Properties for the [`VirtualScrollView`] component.

--- a/crates/components/src/scroll_views/virtual_scroll_view.rs
+++ b/crates/components/src/scroll_views/virtual_scroll_view.rs
@@ -678,9 +678,9 @@ mod test {
         utils.wait_for_update().await;
 
         let content = root.get(0).get(0).get(0);
-        assert_eq!(content.children_ids().len(), 9);
+        assert_eq!(content.children_ids().len(), 10);
 
-        for (n, i) in (21..30).enumerate() {
+        for (n, i) in (20..30).enumerate() {
             let child = content.get(n);
             assert_eq!(
                 child.get(0).text(),

--- a/crates/components/src/scroll_views/virtual_scroll_view.rs
+++ b/crates/components/src/scroll_views/virtual_scroll_view.rs
@@ -5,35 +5,15 @@ use std::ops::Range;
 use dioxus::prelude::*;
 use freya_elements::{
     self as dioxus_elements,
-    events::{
-        keyboard::Key,
-        KeyboardEvent,
-        MouseEvent,
-        WheelEvent,
-    },
+    events::{keyboard::Key, KeyboardEvent, MouseEvent, WheelEvent},
 };
-use freya_hooks::{
-    use_applied_theme,
-    use_focus,
-    use_node,
-    ScrollBarThemeWith,
-};
+use freya_hooks::{use_applied_theme, use_focus, use_node, ScrollBarThemeWith};
 
 use crate::{
-    get_container_sizes,
-    get_corrected_scroll_position,
-    get_scroll_position_from_cursor,
-    get_scroll_position_from_wheel,
-    get_scrollbar_pos_and_size,
-    is_scrollbar_visible,
-    manage_key_event,
-    scroll_views::use_scroll_controller,
-    Axis,
-    ScrollBar,
-    ScrollConfig,
-    ScrollController,
-    ScrollThumb,
-    SCROLL_SPEED_MULTIPLIER,
+    get_container_sizes, get_corrected_scroll_position, get_scroll_position_from_cursor,
+    get_scroll_position_from_wheel, get_scrollbar_pos_and_size, is_scrollbar_visible,
+    manage_key_event, scroll_views::use_scroll_controller, Axis, ScrollBar, ScrollConfig,
+    ScrollController, ScrollThumb, SCROLL_SPEED_MULTIPLIER,
 };
 
 /// Properties for the [`VirtualScrollView`] component.
@@ -222,7 +202,7 @@ pub fn VirtualScrollView<
     let mut focus = use_focus();
     let applied_scrollbar_theme = use_applied_theme!(&scrollbar_theme, scroll_bar);
 
-    let inner_size = item_size + (item_size * length as f32);
+    let inner_size = item_size * length as f32;
 
     scroll_controller.use_apply(inner_size, inner_size);
 


### PR DESCRIPTION
Removes the empty bit at the end of a `VirtualScrollView` component to match with a regular `ScrollView` component.

Video showing the empty bit:

https://github.com/user-attachments/assets/29efdfb3-54c2-4a5b-bc09-3c9b0f09cfd8

The changes related to imports are caused by the code formatter in my code editor.

