### PR TITLE
HEX transparency

### DIFF
--- a/crates/core/src/values/color.rs
+++ b/crates/core/src/values/color.rs
@@ -2,7 +2,10 @@ use std::fmt;
 
 use freya_engine::prelude::*;
 
-use crate::parsing::{Parse, ParseError};
+use crate::parsing::{
+    Parse,
+    ParseError,
+};
 
 pub trait DisplayColor {
     fn fmt_rgb(&self, f: &mut fmt::Formatter) -> fmt::Result;

--- a/crates/core/src/values/color.rs
+++ b/crates/core/src/values/color.rs
@@ -2,10 +2,7 @@ use std::fmt;
 
 use freya_engine::prelude::*;
 
-use crate::parsing::{
-    Parse,
-    ParseError,
-};
+use crate::parsing::{Parse, ParseError};
 
 pub trait DisplayColor {
     fn fmt_rgb(&self, f: &mut fmt::Formatter) -> fmt::Result;
@@ -193,12 +190,20 @@ fn parse_hsl(color: &str) -> Result<Color, ParseError> {
 }
 
 fn parse_hex_color(color: &str) -> Result<Color, ParseError> {
-    if color.len() == 7 {
-        let r = u8::from_str_radix(&color[1..3], 16).map_err(|_| ParseError)?;
-        let g = u8::from_str_radix(&color[3..5], 16).map_err(|_| ParseError)?;
-        let b = u8::from_str_radix(&color[5..7], 16).map_err(|_| ParseError)?;
-        Ok(Color::from_rgb(r, g, b))
-    } else {
-        Err(ParseError)
+    match color.len() {
+        7 => {
+            let r = u8::from_str_radix(&color[1..3], 16).map_err(|_| ParseError)?;
+            let g = u8::from_str_radix(&color[3..5], 16).map_err(|_| ParseError)?;
+            let b = u8::from_str_radix(&color[5..7], 16).map_err(|_| ParseError)?;
+            Ok(Color::from_rgb(r, g, b))
+        }
+        9 => {
+            let r = u8::from_str_radix(&color[1..3], 16).map_err(|_| ParseError)?;
+            let g = u8::from_str_radix(&color[3..5], 16).map_err(|_| ParseError)?;
+            let b = u8::from_str_radix(&color[5..7], 16).map_err(|_| ParseError)?;
+            let a = u8::from_str_radix(&color[7..9], 16).map_err(|_| ParseError)?;
+            Ok(Color::from_rgb(r, g, b).with_a(a))
+        }
+        _ => Err(ParseError),
     }
 }

--- a/crates/core/tests/parse_color.rs
+++ b/crates/core/tests/parse_color.rs
@@ -37,6 +37,12 @@ fn parse_hex_color() {
 }
 
 #[test]
+fn parse_hex_transparent_color() {
+    let color = Color::parse("#5b7b3980");
+    assert_eq!(color, Ok(Color::from_argb(128, 91, 123, 57)));
+}
+
+#[test]
 fn invalid_colors() {
     let incorrect_name = Color::parse("wow(0, 0, 0)");
     let extra_lparen = Color::parse("rgb((0, 0, 0)");


### PR DESCRIPTION
* [x] Add support to HEX transparent colors

Example code:
```rust
#![cfg_attr(
    all(not(debug_assertions), target_os = "windows"),
    windows_subsystem = "windows"
)]

use freya::prelude::*;

const CUSTOM_THEME: Theme = Theme {
    button: ButtonTheme {
        // Black HEX color with transparency
        background: Cow::Borrowed("#0000003C"),
        hover_background: Cow::Borrowed("#00000000"),
        border_fill: Cow::Borrowed("#00000000"),
        focus_border_fill: Cow::Borrowed("#00000000"),
        font_theme: FontTheme {
            color: Cow::Borrowed("#000000"),
        },
        ..LIGHT_THEME.button
    },
    ..LIGHT_THEME
};

fn main() {
    launch(app);
}

fn app() -> Element {
    rsx!(
        ThemeProvider {
            theme: CUSTOM_THEME,
            rect {
                width: "100%",
                height: "100%",
                main_align: "center",
                cross_align: "center",
                Button {
                    label {
                        "Cancel"
                    }
                }
            }
        }
    )
}
```

Result:
![image](https://github.com/user-attachments/assets/f9ccf237-1b91-40e3-83d4-b730cc787926)
