### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.toml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I thought having a `.editorconfig` file in the project would be a good idea.

- Ensures consistent code formatting across editors
- Reduces formatting-related diffs in version control
- Prevents accidental whitespace and line ending issues
- Complements formatters like `rustfmt`
- Other goodies if configured correctly
