### PR TITLE
feat: `UsePlatform::sender`

### DIFF
--- a/crates/components/src/native_container.rs
+++ b/crates/components/src/native_container.rs
@@ -23,9 +23,9 @@ pub fn NativeContainer(children: Element) -> Element {
         let allowed_to_navigate = native_platform.navigation_mark.peek().allowed();
         if e.key == Key::Tab && allowed_to_navigate {
             if e.modifiers.contains(Modifiers::SHIFT) {
-                platform.focus(AccessibilityFocusStrategy::Backward);
+                platform.request_focus(AccessibilityFocusStrategy::Backward);
             } else {
-                platform.focus(AccessibilityFocusStrategy::Forward);
+                platform.request_focus(AccessibilityFocusStrategy::Forward);
             }
         } else {
             native_platform.navigation_mark.write().set_allowed(true)

--- a/crates/hooks/src/use_focus.rs
+++ b/crates/hooks/src/use_focus.rs
@@ -65,7 +65,7 @@ impl UseFocus {
     pub fn request_focus(&mut self) {
         if !*self.is_focused.peek() {
             self.platform
-                .focus(AccessibilityFocusStrategy::Node(self.id));
+                .request_focus(AccessibilityFocusStrategy::Node(self.id));
         }
     }
 
@@ -80,7 +80,7 @@ impl UseFocus {
 
     /// Focus a given [AccessibilityId].
     pub fn focus_id(id: AccessibilityId) {
-        UsePlatform::current().focus(AccessibilityFocusStrategy::Node(id));
+        UsePlatform::current().request_focus(AccessibilityFocusStrategy::Node(id));
     }
 
     /// Get [AccessibilityId] of this accessibility node.

--- a/crates/hooks/src/use_platform.rs
+++ b/crates/hooks/src/use_platform.rs
@@ -43,6 +43,7 @@ pub enum UsePlatformError {
 }
 
 impl UsePlatform {
+    /// Get the current [UsePlatform].
     pub fn current() -> Self {
         match try_consume_context() {
             Some(p) => p,
@@ -63,6 +64,7 @@ impl UsePlatform {
         }
     }
 
+    /// You most likely dont want to use this method. Check the other methods in [UsePlatform].
     pub fn send(&self, event: EventLoopMessage) -> Result<(), UsePlatformError> {
         if let Some(event_loop_proxy) = &*self.event_loop_proxy.peek() {
             event_loop_proxy
@@ -76,10 +78,12 @@ impl UsePlatform {
         Ok(())
     }
 
+    /// Update the [CursorIcon].
     pub fn set_cursor(&self, cursor_icon: CursorIcon) {
         self.send(EventLoopMessage::SetCursorIcon(cursor_icon)).ok();
     }
 
+    /// Update the title of the app/window.
     pub fn set_title(&self, title: impl Into<String>) {
         let title = title.into();
         self.with_window(move |window| {
@@ -87,47 +91,53 @@ impl UsePlatform {
         });
     }
 
+    /// Send a callback that will be called with the [Window] once this is available to get read.
+    ///
+    /// For a `Sync` + `Send` version of this method you can use [UsePlatform::sender].
     pub fn with_window(&self, cb: impl FnOnce(&Window) + 'static + Send + Sync) {
         self.send(EventLoopMessage::WithWindow(Box::new(cb))).ok();
     }
 
+    /// Shortcut for [Window::drag_window].
     pub fn drag_window(&self) {
         self.with_window(|window| {
             window.drag_window().ok();
         });
     }
 
+    /// Shortcut for [Window::set_maximized].
     pub fn set_maximize_window(&self, maximize: bool) {
         self.with_window(move |window| {
             window.set_maximized(maximize);
         });
     }
 
+    /// Shortcut for [Window::set_maximized].
+    ///
+    /// Toggles the maximized state of the [Window].
     pub fn toggle_maximize_window(&self) {
         self.with_window(|window| {
             window.set_maximized(!window.is_maximized());
         });
     }
 
+    /// Shortcut for [Window::set_minimized].
     pub fn set_minimize_window(&self, minimize: bool) {
         self.with_window(move |window| {
             window.set_minimized(minimize);
         });
     }
 
+    /// Shortcut for [Window::set_minimized].
+    ///
+    /// Toggles the minimized state of the [Window].
     pub fn toggle_minimize_window(&self) {
         self.with_window(|window| {
             window.set_minimized(window.is_minimized().map(|v| !v).unwrap_or_default());
         });
     }
 
-    pub fn toggle_fullscreen_window(&self) {
-        self.with_window(|window| match window.fullscreen() {
-            Some(_) => window.set_fullscreen(None),
-            None => window.set_fullscreen(Some(Fullscreen::Borderless(None))),
-        });
-    }
-
+    /// Shortcut for [Window::set_fullscreen].
     pub fn set_fullscreen_window(&self, fullscreen: bool) {
         self.with_window(move |window| {
             if fullscreen {
@@ -138,19 +148,39 @@ impl UsePlatform {
         });
     }
 
+    /// Shortcut for [Window::set_fullscreen].
+    ///
+    /// Toggles the fullscreen state of the [Window].
+    pub fn toggle_fullscreen_window(&self) {
+        self.with_window(|window| match window.fullscreen() {
+            Some(_) => window.set_fullscreen(None),
+            None => window.set_fullscreen(Some(Fullscreen::Borderless(None))),
+        });
+    }
+
+    /// Invalidates a drawing area.
+    ///
+    /// You most likely dont want to use this unless you are dealing with advanced images/canvas rendering.
     pub fn invalidate_drawing_area(&self, area: Area) {
         self.send(EventLoopMessage::InvalidateArea(area)).ok();
     }
 
+    /// Requests a new animation frame.
+    ///
+    /// You most likely dont want to use this unless you are dealing animations or canvas rendering.
     pub fn request_animation_frame(&self) {
         self.send(EventLoopMessage::RequestRerender).ok();
     }
 
-    pub fn focus(&self, strategy: AccessibilityFocusStrategy) {
+    /// Request focus with a given [AccessibilityFocusStrategy].
+    pub fn request_focus(&self, strategy: AccessibilityFocusStrategy) {
         self.send(EventLoopMessage::FocusAccessibilityNode(strategy))
             .ok();
     }
 
+    /// Create a new frame [Ticker].
+    ///
+    /// You most likely dont want to use this unless you are dealing animations or canvas rendering.
     pub fn new_ticker(&self) -> Ticker {
         Ticker {
             inner: self.ticker.peek().resubscribe(),
@@ -160,6 +190,40 @@ impl UsePlatform {
     /// Closes the whole app.
     pub fn exit(&self) {
         self.send(EventLoopMessage::ExitApp).ok();
+    }
+
+    /// Get a [PlatformSender] that you can use to send events from other threads.
+    pub fn sender(&self) -> PlatformSender {
+        PlatformSender {
+            event_loop_proxy: self.event_loop_proxy.read().clone(),
+            platform_emitter: self.platform_emitter.read().clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PlatformSender {
+    event_loop_proxy: Option<EventLoopProxy<EventLoopMessage>>,
+    platform_emitter: Option<UnboundedSender<EventLoopMessage>>,
+}
+
+impl PlatformSender {
+    pub fn send(&self, event: EventLoopMessage) -> Result<(), UsePlatformError> {
+        if let Some(event_loop_proxy) = &self.event_loop_proxy {
+            event_loop_proxy
+                .send_event(event)
+                .map_err(|_| UsePlatformError::EventLoopProxyFailed)?;
+        } else if let Some(platform_emitter) = &self.platform_emitter {
+            platform_emitter
+                .send(event)
+                .map_err(|_| UsePlatformError::PlatformEmitterFailed)?;
+        }
+        Ok(())
+    }
+
+    /// Send a callback that will be called with the [Window] once this is available to get read.
+    pub fn with_window(&self, cb: impl FnOnce(&Window) + 'static + Send + Sync) {
+        self.send(EventLoopMessage::WithWindow(Box::new(cb))).ok();
     }
 }
 

--- a/examples/delegated_focus.rs
+++ b/examples/delegated_focus.rs
@@ -32,7 +32,7 @@ fn app() -> Element {
     };
 
     use_effect(move || {
-        platform.focus(AccessibilityFocusStrategy::Node(nodes[current()]));
+        platform.request_focus(AccessibilityFocusStrategy::Node(nodes[current()]));
     });
 
     rsx!(


### PR DESCRIPTION
`PlatformSender` makes it possible to send events from other threads

Added because of https://github.com/marc2332/freya/discussions/1237

Example:

```rust
fn app() -> Element {
    let platform = use_platform();

    use_hook(|| {
        let sender = platform.sender();
        std::thread::spawn(move || loop {
            std::thread::sleep(Duration::from_millis(500));
            sender.with_window(|window| {
                println!("{:?}", window.is_minimized());
            });
        });
    });

    rsx!(
        rect { }
    )
}
```