### PR TITLE
feat: Add `AnimationClock` to universally slow down or speed up animations

### DIFF
--- a/crates/core/src/animation_clock.rs
+++ b/crates/core/src/animation_clock.rs
@@ -1,0 +1,57 @@
+use std::{
+    sync::{
+        atomic::{
+            AtomicU32,
+            Ordering,
+        },
+        Arc,
+    },
+    time::Duration,
+};
+
+use tracing::info;
+
+#[derive(Clone)]
+pub struct AnimationClock(Arc<AtomicU32>); // Stores f32 as bits
+
+impl Default for AnimationClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AnimationClock {
+    const DEFAULT_SPEED: f32 = 1.0;
+    const MIN_SPEED: f32 = 0.1;
+    const MAX_SPEED: f32 = 10.0;
+
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicU32::new(Self::DEFAULT_SPEED.to_bits())))
+    }
+
+    pub fn speed(&self) -> f32 {
+        let bits = self.0.load(Ordering::Relaxed);
+        (f32::from_bits(bits).clamp(Self::MIN_SPEED, Self::MAX_SPEED) * 100.0).round() / 100.0
+    }
+
+    pub(crate) fn set_speed(&self, speed: f32) {
+        let speed = speed.clamp(Self::MIN_SPEED, Self::MAX_SPEED);
+        self.0.store(speed.to_bits(), Ordering::Relaxed);
+        info!("Animation clock speed changed to {:.2}x", speed);
+    }
+
+    pub fn increase_by(&self, factor: f32) {
+        let current = self.speed();
+        self.set_speed(current + factor);
+    }
+
+    pub fn decrease_by(&self, factor: f32) {
+        let current = self.speed();
+        self.set_speed(current - factor);
+    }
+
+    pub fn correct_elapsed_duration(&self, elapsed: Duration) -> Duration {
+        let scaled_secs = elapsed.as_secs_f32() * self.speed();
+        Duration::from_secs_f32(scaled_secs)
+    }
+}

--- a/crates/core/src/dom/doms.rs
+++ b/crates/core/src/dom/doms.rs
@@ -39,6 +39,7 @@ use crate::{
         AccessibilityDirtyNodes,
         AccessibilityGenerator,
     },
+    animation_clock::AnimationClock,
     custom_attributes::CustomAttributeValues,
     elements::ParagraphElement,
     event_loop_messages::TextGroupMeasurement,
@@ -141,6 +142,7 @@ pub struct FreyaDOM {
     accessibility_dirty_nodes: Arc<Mutex<AccessibilityDirtyNodes>>,
     accessibility_generator: Arc<AccessibilityGenerator>,
     images_cache: Arc<Mutex<ImagesCache>>,
+    animation_clock: AnimationClock,
 }
 
 impl Default for FreyaDOM {
@@ -171,6 +173,7 @@ impl Default for FreyaDOM {
             accessibility_dirty_nodes: Arc::default(),
             accessibility_generator: Arc::default(),
             images_cache: Arc::default(),
+            animation_clock: AnimationClock::default(),
         }
     }
 }
@@ -210,6 +213,10 @@ impl FreyaDOM {
 
     pub fn images_cache(&self) -> MutexGuard<ImagesCache> {
         self.images_cache.lock().unwrap()
+    }
+
+    pub fn animation_clock(&self) -> &AnimationClock {
+        &self.animation_clock
     }
 
     /// Create the initial DOM from the given Mutations

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod accessibility;
+pub mod animation_clock;
 pub mod custom_attributes;
 pub mod dom;
 pub mod elements;

--- a/crates/freya/src/lib.rs
+++ b/crates/freya/src/lib.rs
@@ -54,6 +54,7 @@
 //! - `custom-tokio-rt`: disables the default Tokio runtime created by Freya.
 //! - `performance-overlay`: enables the performance overlay plugin.
 //! - `disable-zoom-shortcuts`: disables the default zoom shortcuts.
+//! - `disable-animation-shortcuts`: disables the default animation clock shortcuts.
 
 /// Freya docs.
 #[cfg(doc)]

--- a/crates/freya/src/plugins/performance_overlay.rs
+++ b/crates/freya/src/plugins/performance_overlay.rs
@@ -69,6 +69,7 @@ impl FreyaPlugin for PerformanceOverlayPlugin {
 
                 let rdom = freya_dom.rdom();
                 let layout = freya_dom.layout();
+                let animation_clock = freya_dom.animation_clock();
 
                 let now = Instant::now();
 
@@ -143,6 +144,13 @@ impl FreyaPlugin for PerformanceOverlayPlugin {
                     14.0,
                 );
 
+                // Animation clock speed
+                add_text(
+                    &mut paragraph_builder,
+                    format!("Animation clock speed: {}x \n", animation_clock.speed()),
+                    14.0,
+                );
+
                 let mut paragraph = paragraph_builder.build();
                 paragraph.layout(f32::MAX);
                 paragraph.paint(canvas, (5.0, 0.0));
@@ -156,9 +164,9 @@ impl FreyaPlugin for PerformanceOverlayPlugin {
                     .max_fps
                     .max(self.fps_historic.iter().max().copied().unwrap_or_default());
                 let start_x = 5.0;
-                let start_y = 170.0 + self.max_fps.max(60) as f32;
+                let start_y = 250.0 + self.max_fps.max(60) as f32;
 
-                canvas.draw_rect(Rect::new(5., 150., 200., start_y), &paint);
+                canvas.draw_rect(Rect::new(5., 200., 200., start_y), &paint);
 
                 for (i, fps) in self.fps_historic.iter().enumerate() {
                     let mut paint = Paint::default();

--- a/crates/testing/src/test_handler.rs
+++ b/crates/testing/src/test_handler.rs
@@ -116,6 +116,9 @@ impl<T: 'static + Clone> TestingHandler<T> {
         self.vdom.insert_any_root_context(Box::new(
             self.utils.sdom.get_mut().accessibility_generator().clone(),
         ));
+        self.vdom.insert_any_root_context(Box::new(
+            self.utils.sdom.get_mut().animation_clock().clone(),
+        ));
 
         let sdom = self.utils.sdom();
         let mut fdom = sdom.get_mut();

--- a/crates/winit/Cargo.toml
+++ b/crates/winit/Cargo.toml
@@ -17,6 +17,7 @@ features = ["freya-engine/mocked-engine"]
 [features]
 skia-engine = ["freya-engine/skia-engine"]
 disable-zoom-shortcuts = []
+disable-animation-shortcuts = []
 
 [dependencies]
 freya-elements = { workspace = true }

--- a/crates/winit/src/app.rs
+++ b/crates/winit/src/app.rs
@@ -195,6 +195,8 @@ impl Application {
             .insert_any_root_context(Box::new(Arc::new(self.ticker_sender.subscribe())));
         self.vdom
             .insert_any_root_context(Box::new(self.sdom.get().accessibility_generator().clone()));
+        self.vdom
+            .insert_any_root_context(Box::new(self.sdom.get().animation_clock().clone()));
 
         // Init the RealDOM
         self.sdom.get_mut().init_dom(&mut self.vdom, scale_factor);

--- a/crates/winit/src/renderer.rs
+++ b/crates/winit/src/renderer.rs
@@ -371,34 +371,57 @@ impl<State: Clone> ApplicationHandler<EventLoopMessage> for WinitRenderer<'_, St
                     return;
                 }
 
-                #[cfg(not(feature = "disable-zoom-shortcuts"))]
-                {
-                    let is_control_pressed = {
-                        if cfg!(target_os = "macos") {
-                            self.modifiers_state.super_key()
-                        } else {
-                            self.modifiers_state.control_key()
-                        }
+                #[allow(dead_code)]
+                let is_control_pressed = {
+                    if cfg!(target_os = "macos") {
+                        self.modifiers_state.super_key()
+                    } else {
+                        self.modifiers_state.control_key()
+                    }
+                };
+
+                #[allow(dead_code)]
+                let change_animation_clock = is_control_pressed
+                    && self.modifiers_state.alt_key()
+                    && state == ElementState::Pressed;
+
+                #[cfg(not(feature = "disable-animation-shortcuts"))]
+                if change_animation_clock {
+                    let ch = logical_key.to_text();
+                    let render = if ch == Some("+") {
+                        app.sdom.get().animation_clock().increase_by(0.2);
+                        true
+                    } else if ch == Some("-") {
+                        app.sdom.get().animation_clock().decrease_by(0.2);
+                        true
+                    } else {
+                        false
                     };
 
-                    if is_control_pressed && state == ElementState::Pressed {
-                        let ch = logical_key.to_text();
-                        let render_with_new_scale_factor = if ch == Some("+") {
-                            self.custom_scale_factor =
-                                (self.custom_scale_factor + 0.10).clamp(-1.0, 5.0);
-                            true
-                        } else if ch == Some("-") {
-                            self.custom_scale_factor =
-                                (self.custom_scale_factor - 0.10).clamp(-1.0, 5.0);
-                            true
-                        } else {
-                            false
-                        };
+                    if render {
+                        app.resize(window);
+                        window.request_redraw();
+                    }
+                }
 
-                        if render_with_new_scale_factor {
-                            app.resize(window);
-                            window.request_redraw();
-                        }
+                #[cfg(not(feature = "disable-zoom-shortcuts"))]
+                if !change_animation_clock && is_control_pressed && state == ElementState::Pressed {
+                    let ch = logical_key.to_text();
+                    let render = if ch == Some("+") {
+                        self.custom_scale_factor =
+                            (self.custom_scale_factor + 0.10).clamp(-1.0, 5.0);
+                        true
+                    } else if ch == Some("-") {
+                        self.custom_scale_factor =
+                            (self.custom_scale_factor - 0.10).clamp(-1.0, 5.0);
+                        true
+                    } else {
+                        false
+                    };
+
+                    if render {
+                        app.resize(window);
+                        window.request_redraw();
                     }
                 }
 

--- a/crates/winit/src/renderer.rs
+++ b/crates/winit/src/renderer.rs
@@ -385,7 +385,7 @@ impl<State: Clone> ApplicationHandler<EventLoopMessage> for WinitRenderer<'_, St
                     && self.modifiers_state.alt_key()
                     && state == ElementState::Pressed;
 
-                #[cfg(not(feature = "disable-animation-shortcuts"))]
+                #[cfg(debug_assertions)]
                 if change_animation_clock {
                     let ch = logical_key.to_text();
                     let render = if ch == Some("+") {


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/940

Adds a new debug-only shortcut to slow down or speed up animations

- Slow down: Linux/Windows = `Ctrl Alt -`, Mac = `Super Alt -`
- Speed up: Linux/Windows = `Ctrl Alt +`, Mac = `Super Alt +`