### PR TITLE
fix: Only discard cancelled events in the same run

### DIFF
--- a/crates/components/src/resizable_container.rs
+++ b/crates/components/src/resizable_container.rs
@@ -316,7 +316,6 @@ pub fn ResizableHandle(
             if changed_panels {
                 allow_resizing.set(false);
             }
-            println!("prevented");
             e.prevent_default();
         }
     };

--- a/crates/components/src/resizable_container.rs
+++ b/crates/components/src/resizable_container.rs
@@ -213,7 +213,7 @@ pub fn ResizableHandle(
         platform.set_cursor(cursor);
     };
 
-    let onmousemove = move |e: MouseEvent| {
+    let oncaptureglobalmousemove = move |e: MouseEvent| {
         if clicking() {
             if !allow_resizing() {
                 return;
@@ -316,6 +316,8 @@ pub fn ResizableHandle(
             if changed_panels {
                 allow_resizing.set(false);
             }
+            println!("prevented");
+            e.prevent_default();
         }
     };
 
@@ -352,7 +354,7 @@ pub fn ResizableHandle(
         onmousedown,
         onglobalclick: onclick,
         onmouseenter,
-        onglobalmousemove: onmousemove,
+        oncaptureglobalmousemove,
         onmouseleave,
     })
 }
@@ -427,6 +429,7 @@ mod test {
             cursor: (100.0, 250.0).into(),
             button: Some(MouseButton::Left),
         });
+        utils.wait_for_update().await;
         utils.push_event(TestEvent::Mouse {
             name: MouseEventName::MouseMove,
             cursor: (100.0, 200.0).into(),
@@ -448,6 +451,7 @@ mod test {
             cursor: (167.0, 300.0).into(),
             button: Some(MouseButton::Left),
         });
+        utils.wait_for_update().await;
         utils.push_event(TestEvent::Mouse {
             name: MouseEventName::MouseMove,
             cursor: (187.0, 300.0).into(),

--- a/crates/components/src/scroll_views/scroll_view.rs
+++ b/crates/components/src/scroll_views/scroll_view.rs
@@ -365,7 +365,7 @@ pub fn ScrollView(
     };
 
     // Unmark any scrollbar
-    let onglobalclick = move |_: MouseEvent| {
+    let onglobalpointerup = move |_| {
         if clicking_scrollbar.peek().is_some() {
             *clicking_scrollbar.write() = None;
         }
@@ -395,7 +395,7 @@ pub fn ScrollView(
             min_height: min_height.map(|x| x.to_string()),
             max_width: max_width.map(|x| x.to_string()),
             max_height: max_height.map(|x| x.to_string()),
-            onglobalclick,
+            onglobalpointerup,
             oncaptureglobalmousemove,
             onglobalkeydown,
             onglobalkeyup,

--- a/crates/core/src/events/events_measurer.rs
+++ b/crates/core/src/events/events_measurer.rs
@@ -24,6 +24,7 @@ use crate::{
         ElementUtils,
         ElementUtilsResolver,
     },
+    events::ProcessedEvents,
     states::{
         StyleState,
         ViewportState,
@@ -55,7 +56,7 @@ pub fn process_events(
     // Get potential collateral events, e.g. mousemove -> mouseenter
     let collateral_dom_events = nodes_state.retain_states(fdom, &dom_events, events, scale_factor);
     nodes_state.filter_dom_events(&mut dom_events);
-    nodes_state.create_states(fdom, &potential_events);
+    let nodes_states_update = nodes_state.create_update(fdom, &potential_events);
 
     // Get the global events
     measure_platform_global_events(fdom, events, &mut dom_events, scale_factor);
@@ -68,7 +69,11 @@ pub fn process_events(
 
     // Send all the events
     event_emitter
-        .send((dom_events, flattened_potential_events))
+        .send(ProcessedEvents {
+            dom_events,
+            flattened_potential_events,
+            nodes_states_update,
+        })
         .unwrap();
 
     // Clear the events queue

--- a/crates/core/src/events/handler.rs
+++ b/crates/core/src/events/handler.rs
@@ -65,9 +65,10 @@ pub fn handle_processed_events(
             // Remove the rest of dom events that are cancellable
             dom_events.retain(|event| !cancellable_events.contains(&event.name));
 
-            // Discarda the potential events that dont find a matching dom event
-            // So for instance, a cancelled mousemove event wont be discarded if a mousenter was processed just before
-            // At the same time, a cancelled mouse event that actually gets discarded will only discard this node state update
+            // Discard the potential events that dont find a matching dom event
+            // So for instance, a cancelled potential mousemove event wont be discarded if a dom mousenter was processed before
+            // At the same time, a cancelled potential mousemove event that actually gets discarded will only discard the node state
+            // made in this run, but will not change what was already before this run
             // So if the affected node was already being hovered from the last events run, it will continue to be as so
             for potential_event in &flattened_potential_events {
                 let is_cancellable = cancellable_events.contains(&potential_event.name);

--- a/crates/core/src/events/nodes_state.rs
+++ b/crates/core/src/events/nodes_state.rs
@@ -72,9 +72,9 @@ impl NodesState {
         // Hovered Nodes
         self.hovered_nodes.retain(|node_id| {
             // Check if a DOM event that moves the cursor in this Node will get emitted
-            let dom_movement_event = dom_events
-                .iter()
-                .any(|event| event.name.is_moved() && &event.node_id == node_id);
+            let dom_movement_event = dom_events.iter().any(|event| {
+                (event.name.is_moved() || event.name.is_enter()) && &event.node_id == node_id
+            });
 
             if !dom_movement_event {
                 // If there has been a mouse movement but a DOM event was not emitted to this node, then we safely assume

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -15,9 +15,9 @@ use tokio::sync::{
 
 use crate::{
     events::{
-        DomEvent,
         PlatformEvent,
         PotentialEvent,
+        ProcessedEvents,
     },
     platform_state::NativePlatformState,
 };
@@ -29,10 +29,10 @@ pub type NativePlatformSender = watch::Sender<NativePlatformState>;
 pub type NativePlatformReceiver = watch::Receiver<NativePlatformState>;
 
 /// Emit events to the VirtualDOM
-pub type EventEmitter = UnboundedSender<(Vec<DomEvent>, FlattenedPotentialEvents)>;
+pub type EventEmitter = UnboundedSender<ProcessedEvents>;
 
 /// Receive events to be emitted to the VirtualDOM
-pub type EventReceiver = UnboundedReceiver<(Vec<DomEvent>, FlattenedPotentialEvents)>;
+pub type EventReceiver = UnboundedReceiver<ProcessedEvents>;
 
 /// Queued list of events to be processed by Freya.
 pub type EventsQueue = SmallVec<[PlatformEvent; 2]>;

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -300,7 +300,11 @@ impl EventName {
     /// - Global events
     /// - Capture events
     pub fn does_bubble(&self) -> bool {
-        !self.is_moved() && !self.is_left() && !self.is_global() && !self.is_capture()
+        !self.is_moved()
+            && !self.is_enter()
+            && !self.is_left()
+            && !self.is_global()
+            && !self.is_capture()
     }
 
     /// Only let events that do not move the mouse, go through solid nodes

--- a/crates/native-core/src/events.rs
+++ b/crates/native-core/src/events.rs
@@ -217,13 +217,12 @@ impl EventName {
             Self::PointerOver => events.extend([Self::MouseMove, Self::GlobalMouseMove]),
 
             Self::PointerEnter => events.extend([Self::MouseEnter]),
-            Self::PointerLeave => events.extend([Self::MouseLeave]),
 
             Self::CaptureGlobalMouseMove => events.extend([
                 Self::MouseMove,
                 Self::MouseEnter,
-                Self::MouseLeave,
                 Self::GlobalMouseMove,
+                Self::PointerEnter,
             ]),
             _ => {}
         }
@@ -287,10 +286,7 @@ impl EventName {
 
     /// Check if the event means the cursor was moved.
     pub fn is_moved(&self) -> bool {
-        matches!(
-            &self,
-            Self::MouseMove | Self::MouseEnter | Self::PointerEnter | Self::PointerOver
-        )
+        matches!(&self, Self::MouseMove | Self::PointerEnter)
     }
 
     /// Check if the event means the cursor has left.
@@ -310,14 +306,6 @@ impl EventName {
     /// Only let events that do not move the mouse, go through solid nodes
     pub fn does_go_through_solid(&self) -> bool {
         matches!(self, Self::GlobalKeyDown | Self::GlobalKeyUp)
-    }
-
-    /// Check if this event can change the hover state of a Node.
-    pub fn is_hovered(&self) -> bool {
-        matches!(
-            self,
-            Self::MouseMove | Self::MouseEnter | Self::PointerOver | Self::PointerEnter
-        )
     }
 
     /// Check if this event can press state of a Node.

--- a/crates/testing/src/test_handler.rs
+++ b/crates/testing/src/test_handler.rs
@@ -184,14 +184,13 @@ impl<T: 'static + Clone> TestingHandler<T> {
                 }
             }
 
-            if let Ok((dom_events, flattened_potential_events)) = vdom_events {
+            if let Ok(processed_events) = vdom_events {
                 let sdom = self.utils.sdom();
                 handle_processed_events(
                     sdom,
                     &mut self.vdom,
                     &mut self.nodes_state,
-                    dom_events,
-                    flattened_potential_events,
+                    processed_events,
                 )
             }
         }

--- a/crates/winit/src/app.rs
+++ b/crates/winit/src/app.rs
@@ -228,8 +228,8 @@ impl Application {
         {
             let fut = std::pin::pin!(async {
                 select! {
-                    Some((dom_events, flattened_potential_events)) = self.event_receiver.recv() => {
-                        handle_processed_events(&self.sdom, &mut self.vdom, &mut self.nodes_state, dom_events, flattened_potential_events)
+                    Some(processed_events) = self.event_receiver.recv() => {
+                        handle_processed_events(&self.sdom, &mut self.vdom, &mut self.nodes_state, processed_events)
                     },
                     _ = self.vdom.wait_for_work() => {},
                 }


### PR DESCRIPTION
Continues the work of https://github.com/marc2332/freya/pull/1215