### PR TITLE
refactor: Make `freya-native-core`'s NodeId a wrapper type rather than type alias

### DIFF
--- a/crates/devtools/src/lib.rs
+++ b/crates/devtools/src/lib.rs
@@ -308,20 +308,3 @@ fn LayoutForDOMInspector() -> Element {
 fn DOMInspector() -> Element {
     Ok(VNode::placeholder())
 }
-
-pub trait NodeIdSerializer {
-    fn serialize(&self) -> String;
-
-    fn deserialize(node_id: &str) -> Self;
-}
-
-impl NodeIdSerializer for NodeId {
-    fn serialize(&self) -> String {
-        format!("{}-{}", self.index(), self.gen())
-    }
-
-    fn deserialize(node_id: &str) -> Self {
-        let (index, gen) = node_id.split_once('-').unwrap();
-        NodeId::new_from_index_and_gen(index.parse().unwrap(), gen.parse().unwrap())
-    }
-}

--- a/crates/devtools/src/tabs/layout.rs
+++ b/crates/devtools/src/tabs/layout.rs
@@ -3,10 +3,7 @@ use freya_components::*;
 use freya_elements as dioxus_elements;
 use freya_native_core::NodeId;
 
-use crate::{
-    hooks::use_node_info,
-    NodeIdSerializer,
-};
+use crate::hooks::use_node_info;
 
 #[allow(non_snake_case)]
 #[component]

--- a/crates/devtools/src/tabs/style.rs
+++ b/crates/devtools/src/tabs/style.rs
@@ -19,7 +19,6 @@ use crate::{
         ShadowProperty,
         TextShadowProperty,
     },
-    NodeIdSerializer,
 };
 
 #[allow(non_snake_case)]

--- a/crates/devtools/src/tabs/tree.rs
+++ b/crates/devtools/src/tabs/tree.rs
@@ -12,7 +12,6 @@ use freya_router::prelude::{
 use crate::{
     node::NodeElement,
     state::DevtoolsChannel,
-    NodeIdSerializer,
     Route,
 };
 

--- a/crates/native-core-macro/src/lib.rs
+++ b/crates/native-core-macro/src/lib.rs
@@ -207,7 +207,7 @@ pub fn partial_derive_state(_: TokenStream, input: TokenStream) -> TokenStream {
                 .collect::<Vec<_>>();
             quote! {
                 let raw_node: (#(*const #node_dependencies,)*) = {
-                    let (#(#temps,)*) = (#(&#node_view,)*).get(id).unwrap_or_else(|err| panic!("Failed to get node view {:?}", err));
+                    let (#(#temps,)*) = (#(&#node_view,)*).get(id.into()).unwrap_or_else(|err| panic!("Failed to get node view {:?}", err));
                     (#(#temps as *const _,)*)
                 };
             }
@@ -241,7 +241,7 @@ pub fn partial_derive_state(_: TokenStream, input: TokenStream) -> TokenStream {
                 .collect::<Vec<_>>();
             quote! {
                 let raw_parent = tree.parent_id_advanced(id, Self::TRAVERSE_SHADOW_DOM).and_then(|parent_id| {
-                    let raw_parent: Option<(#(*const #parent_dependencies,)*)> = (#(&#parent_view,)*).get(parent_id).ok().map(|c| {
+                    let raw_parent: Option<(#(*const #parent_dependencies,)*)> = (#(&#parent_view,)*).get(parent_id.into()).ok().map(|c| {
                         let (#(#temps,)*) = c;
                         (#(#temps as *const _,)*)
                     });
@@ -278,7 +278,7 @@ pub fn partial_derive_state(_: TokenStream, input: TokenStream) -> TokenStream {
                 .collect::<Vec<_>>();
             quote! {
                 let raw_children: Vec<_> = tree.children_ids_advanced(id, Self::TRAVERSE_SHADOW_DOM).into_iter().filter_map(|id| {
-                    let raw_children: Option<(#(*const #child_dependencies,)*)> = (#(&#child_view,)*).get(id).ok().map(|c| {
+                    let raw_children: Option<(#(*const #child_dependencies,)*)> = (#(&#child_view,)*).get(id.into()).ok().map(|c| {
                         let (#(#temps,)*) = c;
                         (#(#temps as *const _,)*)
                     });
@@ -346,14 +346,14 @@ pub fn partial_derive_state(_: TokenStream, input: TokenStream) -> TokenStream {
                     let tree = run_view.tree.clone();
                     let node_types = run_view.node_type.clone();
                     freya_native_core::prelude::run_pass(type_id, &dependants, pass_direction, run_view, |id, context, height| {
-                        let node_data: &NodeType<_> = node_types.get(id).unwrap_or_else(|err| panic!("Failed to get node type {:?}", err));
+                        let node_data: &NodeType<_> = node_types.get(id.into()).unwrap_or_else(|err| panic!("Failed to get node type {:?}", err));
                         if !Self::allow_node(node_data) {
                             return false;
                         }
                         // get all of the states from the tree view
                         // Safety: No node has itself as a parent or child.
                         let raw_myself: Option<*mut Self> = (&mut #this_view)
-                            .get(id)
+                            .get(id.into())
                             .ok()
                             .map(|mut c| {
                                 let mut_ref: &mut Self = &mut *c;
@@ -369,14 +369,14 @@ pub fn partial_derive_state(_: TokenStream, input: TokenStream) -> TokenStream {
                         #deref_parent_view
                         #deref_child_view
 
-                        let view = NodeView::new(id, node_data, &node_mask, height);
+                        let view = NodeView::new(id.into(), node_data, &node_mask, height);
                         if let Some(myself) = myself {
                             myself
                                 .update(view, node, parent, children, context)
                         }
                         else {
                             (&mut #this_view).add_component_unchecked(
-                                id,
+                                id.into(),
                                 Self::create(view, node, parent, children, context));
                             true
                         }

--- a/crates/native-core/Cargo.toml
+++ b/crates/native-core/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["gui"]
 
 [dependencies]
 dioxus-core = { workspace = true}
+torin = { workspace = true }
 
 smallvec = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/native-core/src/lib.rs
+++ b/crates/native-core/src/lib.rs
@@ -9,14 +9,15 @@ pub mod attributes;
 pub mod dioxus;
 pub mod events;
 pub mod node;
+pub mod node_id;
 pub mod node_ref;
 mod passes;
 pub mod real_dom;
 pub mod tags;
 pub mod tree;
 
+pub use node_id::NodeId;
 use rustc_hash::FxHashMap;
-pub use shipyard::EntityId as NodeId;
 
 pub mod exports {
     //! Important dependencies that are used by the rest of the library

--- a/crates/native-core/src/node_id.rs
+++ b/crates/native-core/src/node_id.rs
@@ -1,0 +1,40 @@
+use std::ops::Deref;
+
+#[derive(Clone, Copy, PartialEq, Debug, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct NodeId(shipyard::EntityId);
+
+impl Deref for NodeId {
+    type Target = shipyard::EntityId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<NodeId> for shipyard::EntityId {
+    fn from(value: NodeId) -> Self {
+        value.0
+    }
+}
+
+impl From<shipyard::EntityId> for NodeId {
+    fn from(value: shipyard::EntityId) -> Self {
+        NodeId(value)
+    }
+}
+
+impl NodeId {
+    pub fn serialize(&self) -> String {
+        format!("{}-{}", self.index(), self.gen())
+    }
+
+    pub fn deserialize(node_id: &str) -> Self {
+        let (index, gen) = node_id.split_once('-').unwrap();
+        Self(shipyard::EntityId::new_from_index_and_gen(
+            index.parse().unwrap(),
+            gen.parse().unwrap(),
+        ))
+    }
+}
+
+impl torin::prelude::NodeKey for NodeId {}

--- a/crates/torin/Cargo.toml
+++ b/crates/torin/Cargo.toml
@@ -11,15 +11,10 @@ repository = "https://github.com/marc2332/freya"
 keywords = ["gui", "ui", "desktop", "skia", "dioxus"]
 categories = ["gui", "caching"]
 
-[features]
-dioxus = ["dep:freya-native-core"]
-default = ["dioxus"]
-
 [dependencies]
 tracing = { workspace = true }
 euclid = { workspace = true }
 rustc-hash = { workspace = true }
-freya-native-core = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -29,4 +24,4 @@ bench = false
 
 [[bench]]
 name = "bench"
-harness = false 
+harness = false

--- a/crates/torin/src/dom_adapter.rs
+++ b/crates/torin/src/dom_adapter.rs
@@ -47,9 +47,6 @@ pub trait NodeKey: Clone + PartialEq + Eq + std::hash::Hash + Copy + std::fmt::D
 
 impl NodeKey for usize {}
 
-#[cfg(feature = "dioxus")]
-impl NodeKey for freya_native_core::NodeId {}
-
 pub trait DOMAdapter<Key: NodeKey> {
     fn root_id(&self) -> Key;
 


### PR DESCRIPTION
Make `freya-native-core`'s NodeId a wrapper type rather than type alias