### PR TITLE
fix: Give the cursor some buffer to click when dropping elements

### DIFF
--- a/crates/components/src/drag_drop.rs
+++ b/crates/components/src/drag_drop.rs
@@ -89,6 +89,10 @@ pub fn DragZone<T: 'static + Clone + PartialEq>(
         }
     };
 
+    // Extend by 1. so that the cursor click can reach the drop zone
+    let x = pos.read().x + 1.;
+    let y = pos.read().y + 1.;
+
     rsx!(
         rect {
             reference: node_reference,
@@ -100,8 +104,8 @@ pub fn DragZone<T: 'static + Clone + PartialEq>(
                     position: "absolute",
                     width: "0",
                     height: "0",
-                    offset_x: "{pos.read().x + 1.}",
-                    offset_y: "{pos.read().y + 1.}",
+                    offset_x: "{x}",
+                    offset_y: "{y}",
                     {drag_element}
                 }
             }


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/1281

This way the cursor can actually click