### PR TITLE
fix: Mark a whole element area as invalidated if using blur

### DIFF
--- a/crates/core/src/elements/utils.rs
+++ b/crates/core/src/elements/utils.rs
@@ -162,7 +162,11 @@ pub trait ElementUtils {
     }
 
     #[inline]
-    fn needs_render(&self, _transform_state: &TransformState, _node_style: &StyleState) -> bool {
+    fn needs_explicit_render(
+        &self,
+        _transform_state: &TransformState,
+        _node_style: &StyleState,
+    ) -> bool {
         false
     }
 }
@@ -361,7 +365,11 @@ impl ElementUtils for ElementWithUtils {
         }
     }
 
-    fn needs_render(&self, node_transform: &TransformState, node_style: &StyleState) -> bool {
+    fn needs_explicit_render(
+        &self,
+        node_transform: &TransformState,
+        node_style: &StyleState,
+    ) -> bool {
         match self {
             Self::Rect(el) => el.has_blur(node_transform, node_style),
             _ => false,

--- a/crates/core/src/elements/utils.rs
+++ b/crates/core/src/elements/utils.rs
@@ -160,6 +160,11 @@ pub trait ElementUtils {
 
         element_check || rotate_effect || scales_effect
     }
+
+    #[inline]
+    fn needs_render(&self, _transform_state: &TransformState, _node_style: &StyleState) -> bool {
+        false
+    }
 }
 
 pub trait ElementUtilsResolver {
@@ -353,6 +358,13 @@ impl ElementUtils for ElementWithUtils {
             Self::Paragraph(el) => el.needs_cached_area(node_ref, transform_state, style_state),
             Self::Image(el) => el.needs_cached_area(node_ref, transform_state, style_state),
             Self::Label(el) => el.needs_cached_area(node_ref, transform_state, style_state),
+        }
+    }
+
+    fn needs_render(&self, node_transform: &TransformState, node_style: &StyleState) -> bool {
+        match self {
+            Self::Rect(el) => el.has_blur(node_transform, node_style),
+            _ => false,
         }
     }
 }

--- a/crates/core/src/render/compositor.rs
+++ b/crates/core/src/render/compositor.rs
@@ -248,11 +248,15 @@ impl Compositor {
                                 };
 
                                 let is_dirty = dirty_nodes.remove(&viewport.node_id);
+                                let needs_render = utils.needs_render(transform_state, style_state);
 
                                 // Use the cached area to invalidate the previous frame area if necessary
                                 let mut invalidated_cache_area =
                                     cache.get(&viewport.node_id).and_then(|cached_area| {
-                                        if is_dirty || dirty_area.intersects(cached_area) {
+                                        if is_dirty
+                                            || needs_render
+                                            || dirty_area.intersects(cached_area)
+                                        {
                                             Some(*cached_area)
                                         } else {
                                             None
@@ -260,6 +264,7 @@ impl Compositor {
                                     });
 
                                 let is_invalidated = is_dirty
+                                    || needs_render
                                     || invalidated_cache_area.is_some()
                                     || dirty_area.intersects(&area);
 
@@ -277,7 +282,7 @@ impl Compositor {
                                         cache.insert(viewport.node_id, area);
                                     }
 
-                                    if is_dirty {
+                                    if is_dirty || needs_render {
                                         // Expand the dirty area with the cached area
                                         if let Some(invalidated_cache_area) =
                                             invalidated_cache_area.take()

--- a/crates/core/src/render/compositor.rs
+++ b/crates/core/src/render/compositor.rs
@@ -248,13 +248,14 @@ impl Compositor {
                                 };
 
                                 let is_dirty = dirty_nodes.remove(&viewport.node_id);
-                                let needs_render = utils.needs_render(transform_state, style_state);
+                                let needs_explicit_render =
+                                    utils.needs_explicit_render(transform_state, style_state);
 
                                 // Use the cached area to invalidate the previous frame area if necessary
                                 let mut invalidated_cache_area =
                                     cache.get(&viewport.node_id).and_then(|cached_area| {
                                         if is_dirty
-                                            || needs_render
+                                            || needs_explicit_render
                                             || dirty_area.intersects(cached_area)
                                         {
                                             Some(*cached_area)
@@ -264,7 +265,7 @@ impl Compositor {
                                     });
 
                                 let is_invalidated = is_dirty
-                                    || needs_render
+                                    || needs_explicit_render
                                     || invalidated_cache_area.is_some()
                                     || dirty_area.intersects(&area);
 
@@ -282,7 +283,7 @@ impl Compositor {
                                         cache.insert(viewport.node_id, area);
                                     }
 
-                                    if is_dirty || needs_render {
+                                    if is_dirty || needs_explicit_render {
                                         // Expand the dirty area with the cached area
                                         if let Some(invalidated_cache_area) =
                                             invalidated_cache_area.take()


### PR DESCRIPTION
 Mark a whole element area as invalidated in the compositor if it uses blur, as skia blur does not work well when the canvas clip is smaller than blurred area