### PR TITLE
docs: Split editor example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ rfd = "0.15.3"
 bytes = "1.5.0"
 dioxus-clipboard = { workspace = true }
 winit = { workspace = true }
+dioxus-radio = "0.6.0"
 
 [profile.release]
 lto = true

--- a/crates/components/src/scroll_views/virtual_scroll_view.rs
+++ b/crates/components/src/scroll_views/virtual_scroll_view.rs
@@ -458,6 +458,7 @@ pub fn VirtualScrollView<
             onglobalkeydown,
             onglobalkeyup,
             a11y_id,
+            a11y_focusable: "false",
             rect {
                 direction: "vertical",
                 width: "{container_width}",

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -25,7 +25,7 @@ freya-core = { workspace = true }
 freya-components = { workspace = true }
 freya-engine = { workspace = true }
 torin = { workspace = true }
-dioxus-radio = "0.5"
+dioxus-radio = "0.6"
 serde_json = "1.0.107"
 accesskit = { workspace = true }
 

--- a/examples/split_editors.rs
+++ b/examples/split_editors.rs
@@ -1,0 +1,197 @@
+use dioxus_clipboard::hooks::use_clipboard;
+use dioxus_radio::hooks::{
+    use_init_radio_station,
+    use_radio,
+    RadioChannel,
+};
+use freya::{
+    events::MouseEvent,
+    prelude::*,
+};
+
+fn main() {
+    launch_cfg(
+        app,
+        LaunchConfig::<()>::new()
+            .with_size(900.0, 500.0)
+            .with_decorations(true)
+            .with_transparency(false)
+            .with_title("Editor"),
+    );
+}
+
+fn app() -> Element {
+    let platform = use_platform();
+    let clipboard = use_clipboard();
+    use_init_radio_station::<State, Channel>(|| State {
+        editors: vec![UseEditable::new_in_hook(
+            clipboard,
+            platform,
+            EditableConfig::new("Hello, World!".to_string()),
+            EditableMode::SingleLineMultipleEditors,
+        )],
+    });
+    use_init_theme(|| DARK_THEME);
+    let mut radio = use_radio(Channel::Editors);
+
+    let split = move |_| {
+        radio.write().editors.push(UseEditable::new_in_hook(
+            clipboard,
+            platform,
+            EditableConfig::new("Hello, World!".to_string()),
+            EditableMode::SingleLineMultipleEditors,
+        ));
+    };
+
+    rsx!(
+        Body {
+            rect {
+                cross_align: "center",
+                width: "fill",
+                Button {
+                    onpress: split,
+                    label {
+                        "Split"
+                    }
+                }
+            }
+            rect {
+                direction: "horizontal",
+                content: "flex",
+                for (editor_id, _) in radio.read().editors.iter().enumerate() {
+                    Editor {
+                        key: "{editor_id}",
+                        editor_id
+                    }
+                }
+            }
+        }
+    )
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Copy, Hash)]
+enum Channel {
+    Editors,
+    UpdatedEditor(usize),
+}
+
+impl RadioChannel<State> for Channel {}
+
+struct State {
+    editors: Vec<UseEditable>,
+}
+
+#[component]
+fn Editor(editor_id: usize) -> Element {
+    let mut focus = use_focus();
+    let mut radio = use_radio(Channel::UpdatedEditor(editor_id));
+
+    let editable = radio.read().editors[editor_id];
+    let editor = editable.editor();
+
+    let onclick = move |_: MouseEvent| {
+        focus.request_focus();
+        radio.write().editors[editor_id].process_event(&EditableEvent::Click);
+    };
+
+    let onkeydown = move |e: KeyboardEvent| {
+        radio.write().editors[editor_id].process_event(&EditableEvent::KeyDown(e.data));
+    };
+
+    let onglobalkeyup = move |e: KeyboardEvent| {
+        radio.write().editors[editor_id].process_event(&EditableEvent::KeyUp(e.data));
+    };
+
+    let border = if focus.is_focused() {
+        "2 inner rgb(100, 100, 100)"
+    } else {
+        "none"
+    };
+
+    rsx!(
+        rect {
+            border,
+            a11y_id: focus.attribute(),
+            width: "flex(1)",
+            height: "fill",
+            padding: "10",
+            onkeydown,
+            onglobalkeyup,
+            onclick,
+            VirtualScrollView {
+                length: editor.read().len_lines(),
+                item_size: 35.0,
+                scroll_with_arrows: false,
+                cache_elements: false,
+                builder: move |line_index, _: &Option<()>| {
+                    let editor = editable.editor().read();
+                    let line = editor.line(line_index).unwrap();
+
+                    let is_line_selected = editor.cursor_row() == line_index;
+
+                    // Only show the cursor in the active line
+                    let character_index = if is_line_selected {
+                        editor.cursor_col().to_string()
+                    } else {
+                        "none".to_string()
+                    };
+
+                    // Only highlight the active line
+                    let line_background = if is_line_selected {
+                        "rgb(37, 37, 37)"
+                    } else {
+                        "none"
+                    };
+
+                    let onmousedown = move |e: MouseEvent| {
+                        radio.write().editors[editor_id].process_event(&EditableEvent::MouseDown(e.data, line_index));
+                    };
+
+                    let onmousemove = move |e: MouseEvent| {
+                        radio.write().editors[editor_id].process_event(&EditableEvent::MouseMove(e.data, line_index));
+                    };
+
+                    let highlights = editable.highlights_attr(line_index);
+
+                    rsx! {
+                        rect {
+                            key: "{line_index}",
+                            width: "100%",
+                            height: "35",
+                            direction: "horizontal",
+                            background: "{line_background}",
+                            label {
+                                main_align: "center",
+                                width: "30",
+                                height: "100%",
+                                text_align: "center",
+                                font_size: "15",
+                                color: "rgb(200, 200, 200)",
+                                "{line_index + 1} "
+                            }
+                            paragraph {
+                                cursor_reference: editable.cursor_attr(),
+                                main_align: "center",
+                                height: "100%",
+                                width: "100%",
+                                cursor_index: "{character_index}",
+                                cursor_color: "white",
+                                cursor_mode: "editable",
+                                cursor_id: "{line_index}",
+                                max_lines: "1",
+                                onmousedown,
+                                onmousemove,
+                                highlights,
+                                text {
+                                    color: "rgb(240, 240, 240)",
+                                    font_size: "15",
+                                    "{line}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    )
+}


### PR DESCRIPTION
Showcases how to manage N amount of editors, all stored in the same global state and yet be able to make granular updates and subscriptions.