### PR TITLE
fix: Remove nodes from their old layer when their layer changes

### DIFF
--- a/crates/core/src/layers.rs
+++ b/crates/core/src/layers.rs
@@ -24,11 +24,13 @@ impl Layers {
 
     /// Remove the [NodeId] from the given layer. Will remove the entry of the layer if it becomes empty.
     pub fn remove_node_from_layer(&mut self, node_id: NodeId, layer_n: i16) {
-        let layer = self.0.get_mut(&layer_n).unwrap();
-        layer.retain(|id| *id != node_id);
+        let layer = self.0.get_mut(&layer_n);
+        if let Some(layer) = layer {
+            layer.retain(|id| *id != node_id);
 
-        if layer.is_empty() {
-            self.0.remove(&layer_n);
+            if layer.is_empty() {
+                self.0.remove(&layer_n);
+            }
         }
     }
 }

--- a/crates/core/src/states/layer.rs
+++ b/crates/core/src/states/layer.rs
@@ -110,6 +110,10 @@ impl State<CustomAttributeValues> for LayerState {
             layers
                 .lock()
                 .unwrap()
+                .remove_node_from_layer(node_view.node_id(), self.layer);
+            layers
+                .lock()
+                .unwrap()
                 .insert_node_in_layer(node_view.node_id(), layer_state.layer);
         }
 


### PR DESCRIPTION
Nodes ids were being duplicated across multiple players if their layer changed