### PR TITLE
chore(edit): Refactor `freya-edit` to use a selection-based cursor

### DIFF
--- a/crates/freya-components/src/input.rs
+++ b/crates/freya-components/src/input.rs
@@ -252,7 +252,7 @@ impl Render for Input {
                         // If it is not valid then undo the latest change and discard all the redos
                         let undo_result = editor.undo();
                         if let Some(idx) = undo_result {
-                            editor.set_cursor_pos(idx);
+                            editor.move_cursor_to(idx);
                         }
                         editor.editor_history().clear_redos();
                     }

--- a/crates/freya-edit/src/event.rs
+++ b/crates/freya-edit/src/event.rs
@@ -8,6 +8,7 @@ use torin::prelude::CursorPoint;
 
 use crate::{
     EditableConfig,
+    TextSelection,
     rope_editor::RopeEditor,
     text_editor::{
         TextEditor,
@@ -55,61 +56,68 @@ impl EditableEvent<'_> {
                     scale_factor,
                 } = holder.as_ref().unwrap();
 
-                dragging
-                    .write()
-                    .set_cursor_coords(location.mul(*scale_factor));
-
                 let mut text_editor = editor.write();
-                text_editor.clear_selection();
+
+                if dragging.peek().shift || dragging.peek().clicked {
+                    text_editor.selection_mut().set_as_range();
+                } else {
+                    text_editor.clear_selection();
+                }
+
+                dragging.write().clicked = true;
 
                 match EventsCombos::pressed(location) {
                     PressEventType::Triple => {
+                        let current_selection = text_editor.selection().clone();
+
                         let char_position = paragraph.get_glyph_position_at_coordinate(
                             location.mul(*scale_factor).to_i32().to_tuple(),
                         );
-                        let new_cursor = text_editor
-                            .measure_new_cursor(char_position.position as usize, editor_id);
+                        let press_selection = text_editor
+                            .measure_selection(char_position.position as usize, editor_id);
 
                         // Get the line start char and its length
-                        let line = text_editor.rope().char_to_line(new_cursor.pos());
+                        let line = text_editor.rope().char_to_line(press_selection.pos());
                         let line_char = text_editor.rope().line_to_char(line);
                         let line_len = text_editor.rope().line(line).len_utf16_cu();
+                        let new_selection =
+                            TextSelection::new_range((line_char, line_char + line_len));
 
                         // Select the whole line
-                        text_editor.set_selection((line_char, line_char + line_len));
+                        if current_selection != new_selection {
+                            *text_editor.selection_mut() = new_selection;
+                        }
                     }
                     PressEventType::Double => {
+                        let current_selection = text_editor.selection().clone();
+
                         let char_position = paragraph.get_glyph_position_at_coordinate(
                             location.mul(*scale_factor).to_i32().to_tuple(),
                         );
-                        let new_cursor = text_editor
-                            .measure_new_cursor(char_position.position as usize, editor_id);
+                        let press_selection = text_editor
+                            .measure_selection(char_position.position as usize, editor_id);
 
                         // Find word boundaries
-                        let selection = text_editor.find_word_boundaries(new_cursor.pos());
+                        let range = text_editor.find_word_boundaries(press_selection.pos());
+                        let new_selection = TextSelection::new_range(range);
 
-                        // Set cursor to end of word and select the word
-                        *text_editor.cursor_mut() = new_cursor.clone();
-                        text_editor.set_selection(selection);
+                        // Select the word
+                        if current_selection != new_selection {
+                            *text_editor.selection_mut() = new_selection;
+                        }
                     }
                     PressEventType::Single => {
+                        let current_selection = text_editor.selection().clone();
+
                         let char_position = paragraph.get_glyph_position_at_coordinate(
                             location.mul(*scale_factor).to_i32().to_tuple(),
                         );
-                        let new_cursor = text_editor
-                            .measure_new_cursor(char_position.position as usize, editor_id);
+                        let new_selection = text_editor
+                            .measure_selection(char_position.position as usize, editor_id);
 
-                        // Only update and clear the selection if the cursor has changed
-                        if *text_editor.cursor() != new_cursor {
-                            *text_editor.cursor_mut() = new_cursor;
-                            if let TextDragging::FromCursorToPoint { cursor: from, .. } =
-                                &*dragging.peek()
-                            {
-                                let to = text_editor.cursor_pos();
-                                text_editor.set_selection((*from, to));
-                            } else {
-                                text_editor.clear_selection();
-                            }
+                        // Move the cursor
+                        if current_selection != new_selection {
+                            *text_editor.selection_mut() = new_selection;
                         }
                     }
                 }
@@ -119,88 +127,48 @@ impl EditableEvent<'_> {
                 editor_id,
                 holder,
             } => {
-                if let Some(origin) = dragging.peek().get_cursor_coords() {
+                if dragging.peek().clicked {
                     let paragraph = holder.0.borrow();
                     let ParagraphHolderInner {
                         paragraph,
                         scale_factor,
                     } = paragraph.as_ref().unwrap();
 
-                    let origin_position = origin;
                     let dist_position = location.mul(*scale_factor);
 
-                    // Calculate the start of the highlighting
-                    let origin_char = paragraph
-                        .get_glyph_position_at_coordinate(origin_position.to_i32().to_tuple());
                     // Calculate the end of the highlighting
                     let dist_char = paragraph
                         .get_glyph_position_at_coordinate(dist_position.to_i32().to_tuple());
-                    let from = origin_char.position as usize;
                     let to = dist_char.position as usize;
 
-                    let current_cursor = editor.peek().cursor().clone();
-                    let current_selection = editor.peek().get_selection();
-
-                    let maybe_new_cursor = editor.peek().measure_new_cursor(to, editor_id);
-                    let maybe_new_selection =
-                        editor.peek().measure_new_selection(from, to, editor_id);
-
-                    // Update the text selection if it has changed
-                    if let Some(current_selection) = current_selection {
-                        if current_selection != maybe_new_selection {
-                            let mut text_editor = editor.write();
-                            text_editor.set_selection(maybe_new_selection);
-                        }
-                    } else {
-                        let mut text_editor = editor.write();
-                        text_editor.set_selection(maybe_new_selection);
+                    if !editor.peek().selection.is_range() {
+                        editor.write().selection_mut().set_as_range();
                     }
 
+                    let current_selection = editor.peek().selection().clone();
+
+                    let new_selection = editor.peek().measure_selection(to, editor_id);
+
                     // Update the cursor if it has changed
-                    if current_cursor != maybe_new_cursor {
+                    if current_selection != new_selection {
                         let mut text_editor = editor.write();
-                        *text_editor.cursor_mut() = maybe_new_cursor;
+                        *text_editor.selection_mut() = new_selection;
                     }
                 }
             }
             EditableEvent::Release => {
-                let dragging = &mut *dragging.write();
-                match dragging {
-                    TextDragging::FromCursorToPoint { shift, clicked, .. } if *shift => {
-                        *clicked = false;
-                    }
-                    _ => {
-                        *dragging = TextDragging::None;
-                    }
-                }
+                dragging.write().clicked = false;
             }
             EditableEvent::KeyDown { key, modifiers } => {
                 match key {
                     // Handle dragging
                     Key::Shift => {
-                        let dragging = &mut *dragging.write();
-                        match dragging {
-                            TextDragging::FromCursorToPoint {
-                                shift: shift_pressed,
-                                ..
-                            } => {
-                                *shift_pressed = true;
-                            }
-                            TextDragging::None => {
-                                *dragging = TextDragging::FromCursorToPoint {
-                                    shift: true,
-                                    clicked: false,
-                                    cursor: editor.peek().cursor_pos(),
-                                    dist: None,
-                                }
-                            }
-                            _ => {}
-                        }
+                        dragging.write().shift = true;
                     }
                     // Handle editing
                     _ => {
-                        editor.write_if(|mut ditor| {
-                            let event = ditor.process_key(
+                        editor.write_if(|mut editor| {
+                            let event = editor.process_key(
                                 key,
                                 &modifiers,
                                 config.allow_tabs,
@@ -208,71 +176,24 @@ impl EditableEvent<'_> {
                                 config.allow_clipboard,
                             );
                             if event.contains(TextEvent::TEXT_CHANGED) {
-                                *dragging.write() = TextDragging::None;
+                                *dragging.write() = TextDragging::default();
                             }
                             !event.is_empty()
                         });
                     }
                 }
             }
-            EditableEvent::KeyUp { key } => {
+            EditableEvent::KeyUp { key, .. } => {
                 if *key == Key::Shift {
-                    if let TextDragging::FromCursorToPoint { shift, .. } = &mut *dragging.write() {
-                        *shift = false;
-                    }
-                } else {
-                    *dragging.write() = TextDragging::None;
+                    dragging.write().shift = false;
                 }
             }
         };
     }
 }
 
-/// Indicates the type of text dragging being done.
-#[derive(Debug, PartialEq, Clone)]
-pub enum TextDragging {
-    None,
-    FromPointToPoint {
-        src: CursorPoint,
-    },
-    FromCursorToPoint {
-        shift: bool,
-        clicked: bool,
-        cursor: usize,
-        dist: Option<CursorPoint>,
-    },
-}
-
-impl TextDragging {
-    pub fn has_cursor_coords(&self) -> bool {
-        match self {
-            Self::None => false,
-            Self::FromPointToPoint { .. } => true,
-            Self::FromCursorToPoint { dist, .. } => dist.is_some(),
-        }
-    }
-
-    pub fn set_cursor_coords(&mut self, cursor: CursorPoint) {
-        match self {
-            Self::FromPointToPoint { src } => *src = cursor,
-            Self::FromCursorToPoint {
-                dist, shift: true, ..
-            } => *dist = Some(cursor),
-            _ => *self = Self::FromPointToPoint { src: cursor },
-        }
-    }
-
-    pub fn get_cursor_coords(&self) -> Option<CursorPoint> {
-        match self {
-            Self::None => None,
-            Self::FromPointToPoint { src } => Some(*src),
-            Self::FromCursorToPoint { dist, clicked, .. } => {
-                if *clicked {
-                    *dist
-                } else {
-                    None
-                }
-            }
-        }
-    }
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct TextDragging {
+    pub shift: bool,
+    pub clicked: bool,
 }

--- a/crates/freya-edit/src/use_editable.rs
+++ b/crates/freya-edit/src/use_editable.rs
@@ -9,7 +9,7 @@ use crate::{
     TextDragging,
     editor_history::EditorHistory,
     rope_editor::RopeEditor,
-    text_editor::TextCursor,
+    text_editor::TextSelection,
 };
 
 /// Manage an editable text.
@@ -25,12 +25,12 @@ impl UseEditable {
     pub fn create(content: String, config: EditableConfig, mode: EditableMode) -> Self {
         let editor = State::create(RopeEditor::new(
             content,
-            TextCursor::default(),
+            TextSelection::new_cursor(0),
             config.identation,
             mode,
             EditorHistory::new(Duration::from_millis(10)),
         ));
-        let dragging = State::create(TextDragging::None);
+        let dragging = State::create(TextDragging::default());
 
         UseEditable {
             editor,

--- a/examples/text_editing.rs
+++ b/examples/text_editing.rs
@@ -1,5 +1,4 @@
 use freya::{
-    helpers::from_fn,
     prelude::*,
     text_edit::*,
 };
@@ -9,65 +8,50 @@ fn main() {
 }
 
 fn app() -> impl IntoElement {
+    let holder = use_state(ParagraphHolder::default);
     let mut editable = use_editable(
-        || "Hello Rustaceans\nHello World".to_string(),
+        || "Hello, World!".to_string(),
         EditableConfig::new,
-        EditableMode::SingleLineMultipleEditors,
+        EditableMode::MultipleLinesSingleEditor,
     );
+    let focus = use_focus();
 
-    let editor = editable.editor().read();
-
-    let on_global_key_down = move |e: Event<KeyboardEventData>| {
-        editable.process_event(EditableEvent::KeyDown {
-            key: &e.key,
-            modifiers: e.modifiers,
-        });
-    };
-
-    rect()
-        .font_family("NotoSans")
-        .width(Size::fill())
-        .height(Size::fill())
-        .background((255, 255, 255))
-        .on_global_key_down(on_global_key_down)
-        .children_iter(editor.lines().enumerate().map(move |(i, line)| {
-            let line = line.text.to_string();
-            from_fn((), line, move |line| {
-                let holder = use_state(ParagraphHolder::default);
-                let editor = editable.editor().read();
-
-                let is_selected = editor.cursor_row() == i;
-                let cursor_index = if is_selected {
-                    Some(editor.cursor_col())
-                } else {
-                    None
-                };
-
-                let on_mouse_down = move |e: Event<MouseEventData>| {
-                    editable.process_event(EditableEvent::Down {
-                        location: e.element_location,
-                        editor_id: i,
-                        holder: &holder.read(),
-                    });
-                };
-
-                paragraph()
-                    .holder(holder.read().clone())
-                    .width(Size::fill())
-                    .height(Size::px(30.0))
-                    .max_lines(1)
-                    .cursor_index(cursor_index)
-                    .cursor_color((0, 0, 0))
-                    .on_mouse_down(on_mouse_down)
-                    .highlights(editor.get_visible_selection(i).map(|h| vec![h]))
-                    .span(Span::new(line.clone()))
-                    .into()
-            })
-        }))
-        .child(
-            label()
-                .color((0, 0, 0))
-                .height(Size::percent(50.0))
-                .text(format!("{}:{}", editor.cursor_row(), editor.cursor_col())),
+    paragraph()
+        .a11y_id(focus.a11y_id())
+        .cursor_index(editable.editor().read().cursor_pos())
+        .highlights(
+            editable
+                .editor()
+                .read()
+                .get_selection()
+                .map(|selection| vec![selection])
+                .unwrap_or_default(),
         )
+        .on_mouse_down(move |e: Event<MouseEventData>| {
+            focus.request_focus();
+            editable.process_event(EditableEvent::Down {
+                location: e.element_location,
+                editor_id: 0,
+                holder: &holder.read(),
+            });
+        })
+        .on_mouse_move(move |e: Event<MouseEventData>| {
+            editable.process_event(EditableEvent::Move {
+                location: e.element_location,
+                editor_id: 0,
+                holder: &holder.read(),
+            });
+        })
+        .on_global_mouse_up(move |_| editable.process_event(EditableEvent::Release))
+        .on_key_down(move |e: Event<KeyboardEventData>| {
+            editable.process_event(EditableEvent::KeyDown {
+                key: &e.key,
+                modifiers: e.modifiers,
+            });
+        })
+        .on_key_up(move |e: Event<KeyboardEventData>| {
+            editable.process_event(EditableEvent::KeyUp { key: &e.key });
+        })
+        .span(editable.editor().read().to_string())
+        .holder(holder.read().clone())
 }


### PR DESCRIPTION
Simplifies the internal data structures to avoid maintaining the cursor and the selected text separately, instead only 1 exists at a time.