### PR TITLE
fix: Dont enable vulkan feature when checking mocked skia bindings

### DIFF
--- a/crates/freya-engine/src/mocked.rs
+++ b/crates/freya-engine/src/mocked.rs
@@ -423,7 +423,7 @@ pub enum TextAlign {
     End = 5,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct TextStyle;
 
 impl TextStyle {

--- a/crates/freya-terminal/Cargo.toml
+++ b/crates/freya-terminal/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/marc2332/freya"
 keywords = ["gui", "ui", "desktop", "terminal", "pty"]
 categories = ["gui"]
 
+[package.metadata.docs.rs]
+features = ["freya-engine/mocked-engine"]
+
 [features]
 skia-engine = ["freya-core/skia-engine"]
 

--- a/crates/freya-webview/Cargo.toml
+++ b/crates/freya-webview/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/marc2332/freya"
 keywords = ["gui", "ui", "desktop", "webview"]
 categories = ["gui"]
 
+[package.metadata.docs.rs]
+features = ["freya-engine/mocked-engine"]
+
 [features]
 skia-engine = ["freya-core/skia-engine"]
 

--- a/crates/freya/Cargo.toml
+++ b/crates/freya/Cargo.toml
@@ -47,6 +47,12 @@ all-publish = [
   "dep:freya-testing",
   "dep:freya-plotters-backend",
 ]
+all-bindings = [
+  "all",
+  "performance",
+  "dep:freya-testing",
+  "dep:freya-plotters-backend",
+]
 all-debug = [
   "all",
   "performance",

--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ ba:
     cargo build --all-targets --all-features
 
 bindings:
-    cargo build --package freya --package freya-testing --features "mocked-engine, all-debug" --no-default-features
+    cargo build --package freya --package freya-testing --features "mocked-engine, all-bindings" --no-default-features
 
 dev-app:
     cargo run --package freya-devtools-app


### PR DESCRIPTION
the check was wrong, so the release docs were not working properly.

https://docs.rs/crate/freya/0.4.0-rc.4/builds/2840200