### PR TITLE
fix(freya): Proper reexport of `freya-router`

### DIFF
--- a/crates/freya-router/src/lib.rs
+++ b/crates/freya-router/src/lib.rs
@@ -10,8 +10,10 @@
 //! for a runnable demo.
 //!
 //! ```rust
-//! use freya::prelude::*;
-//! use freya_router::prelude::*;
+//! use freya::{
+//!     prelude::*,
+//!     router::prelude::*,
+//! };
 //!
 //! fn app() -> impl IntoElement {
 //!     router::<Route>(|| RouterConfig::default().with_initial_path(Route::Home))

--- a/crates/freya/src/lib.rs
+++ b/crates/freya/src/lib.rs
@@ -105,6 +105,9 @@ pub mod prelude {
         freya_winit::launch(launch_config)
     }
 
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "router")))]
+    #[cfg(feature = "router")]
+    pub use freya_router;
     pub use torin::{
         alignment::Alignment,
         content::Content,

--- a/examples/animation_router.rs
+++ b/examples/animation_router.rs
@@ -6,8 +6,8 @@
 use freya::{
     animation::*,
     prelude::*,
+    router::prelude::*,
 };
-use freya_router::prelude::*;
 
 fn main() {
     launch(LaunchConfig::new().with_window(WindowConfig::new(app).with_title("Animated Router")))

--- a/examples/component_floating_tab.rs
+++ b/examples/component_floating_tab.rs
@@ -3,8 +3,10 @@
     windows_subsystem = "windows"
 )]
 
-use freya::prelude::*;
-use freya_router::prelude::*;
+use freya::{
+    prelude::*,
+    router::prelude::*,
+};
 
 fn main() {
     launch(LaunchConfig::new().with_window(WindowConfig::new(app)))

--- a/examples/component_sidebar.rs
+++ b/examples/component_sidebar.rs
@@ -3,8 +3,10 @@
     windows_subsystem = "windows"
 )]
 
-use freya::prelude::*;
-use freya_router::prelude::*;
+use freya::{
+    prelude::*,
+    router::prelude::*,
+};
 
 fn main() {
     launch(LaunchConfig::new().with_window(WindowConfig::new(app)))

--- a/examples/feature_router.rs
+++ b/examples/feature_router.rs
@@ -3,13 +3,15 @@
     windows_subsystem = "windows"
 )]
 
-use freya::prelude::*;
-use freya_router::prelude::{
-    Routable,
-    RouterConfig,
-    RouterContext,
-    outlet,
-    router,
+use freya::{
+    prelude::*,
+    router::prelude::{
+        Routable,
+        RouterConfig,
+        RouterContext,
+        outlet,
+        router,
+    },
 };
 
 fn main() {


### PR DESCRIPTION
This way the Routable macro works even if the user doesnt have freya-router as a dependency.