### PR TITLE
fix(core): Make `label` and `GifViewer` use the visible area when rendering, as this includes padding and margins

### DIFF
--- a/crates/freya-components/src/gif_viewer.rs
+++ b/crates/freya-components/src/gif_viewer.rs
@@ -633,12 +633,9 @@ impl ElementExt for GifElement {
             SamplingMode::CatmullRom => SamplingOptions::from(CubicResampler::catmull_rom()),
         };
 
-        let rect = SkRect::new(
-            context.layout_node.area.min_x(),
-            context.layout_node.area.min_y(),
-            context.layout_node.area.max_x(),
-            context.layout_node.area.max_y(),
-        );
+        let area = context.layout_node.visible_area();
+
+        let rect = SkRect::new(area.min_x(), area.min_y(), area.max_x(), area.max_y());
 
         let current_frame = &self.frames.frames[self.frame_idx];
 

--- a/crates/freya-core/src/elements/label.rs
+++ b/crates/freya-core/src/elements/label.rs
@@ -288,7 +288,10 @@ impl ElementExt for LabelElement {
         let layout_data = context.layout_node.data.as_ref().unwrap();
         let paragraph = layout_data.downcast_ref::<SkParagraph>().unwrap();
 
-        paragraph.paint(context.canvas, context.layout_node.area.origin.to_tuple());
+        paragraph.paint(
+            context.canvas,
+            context.layout_node.visible_area().origin.to_tuple(),
+        );
     }
 }
 


### PR DESCRIPTION
Make `label` and `GifViewer` use the visible area when rendering, as this includes padding and margins