### PR TITLE
fix(core): Run effect cascade in new nodes with no data but with parents with effects

### DIFF
--- a/crates/freya-core/src/tree.rs
+++ b/crates/freya-core/src/tree.rs
@@ -411,7 +411,7 @@ impl Tree {
                     if !run_cascade
                         && !self.effect_state.contains_key(&node_id)
                         && let Some(parent) = self.parents.get(&node_id)
-                        && self.effect_state.contains_key(&parent)
+                        && self.effect_state.contains_key(parent)
                     {
                         run_cascade = true;
                     }


### PR DESCRIPTION
Run effect cascade in new nodes with no data but with parents with effects

to do: test