### PR TITLE
chore(core): Add getter for events prevent default flag

### DIFF
--- a/crates/freya-core/src/events/data.rs
+++ b/crates/freya-core/src/events/data.rs
@@ -106,6 +106,10 @@ impl<D> Event<D> {
     pub fn prevent_default(&self) {
         *self.default.borrow_mut() = false;
     }
+
+    pub fn get_prevent_default(&self) -> Rc<RefCell<bool>> {
+        self.default.clone()
+    }
 }
 
 /// Data of a Sized event.


### PR DESCRIPTION
Useful to for event handlers that call other event handlers.