### PR TITLE
fix(core): Apply tree mutations under root scope context

### DIFF
--- a/crates/freya-core/src/runner.rs
+++ b/crates/freya-core/src/runner.rs
@@ -691,6 +691,19 @@ impl Runner {
         mutations
     }
 
+    pub fn run_in<T>(&self, run: impl FnOnce() -> T) -> T {
+        CurrentContext::run(
+            CurrentContext {
+                scope_id: ScopeId::ROOT,
+                scopes_storages: self.scopes_storages.clone(),
+                tasks: self.tasks.clone(),
+                task_id_counter: self.task_id_counter.clone(),
+                sender: self.sender.clone(),
+            },
+            run,
+        )
+    }
+
     #[cfg_attr(feature = "hotpath", hotpath::measure)]
     fn run_scope(
         &mut self,

--- a/crates/freya-testing/src/lib.rs
+++ b/crates/freya-testing/src/lib.rs
@@ -338,7 +338,9 @@ impl TestingRunner {
         }
 
         let mutations = self.runner.sync_and_update();
-        self.tree.borrow_mut().apply_mutations(mutations);
+        self.runner.run_in(|| {
+            self.tree.borrow_mut().apply_mutations(mutations);
+        });
         self.tree.borrow_mut().measure_layout(
             self.size,
             &self.font_collection,

--- a/crates/freya-winit/src/renderer.rs
+++ b/crates/freya-winit/src/renderer.rs
@@ -433,7 +433,7 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                                 PluginHandle::new(&self.proxy),
                             );
                             let mutations = app.runner.sync_and_update();
-                            let result = app.tree.apply_mutations(mutations);
+                            let result = app.runner.run_in(|| app.tree.apply_mutations(mutations));
                             if result.needs_render {
                                 app.process_layout_on_next_render = true;
                                 app.window.request_redraw();


### PR DESCRIPTION
 Apply tree mutations under root scope context so that element-owned (like values captured in event handlers) scope values can access the context api on custom Drop impls