### PR TITLE
feat(torin): Spacing support for wrapped content

### DIFF
--- a/crates/freya-core/src/elements/extensions.rs
+++ b/crates/freya-core/src/elements/extensions.rs
@@ -182,6 +182,7 @@ pub trait ContentExt {
     fn fit() -> Content;
     fn flex() -> Content;
     fn wrap() -> Content;
+    fn wrap_spacing(spacing: f32) -> Content;
 }
 
 impl ContentExt for Content {
@@ -198,7 +199,13 @@ impl ContentExt for Content {
     }
 
     fn wrap() -> Content {
-        Content::Wrap
+        Content::Wrap { wrap_spacing: None }
+    }
+
+    fn wrap_spacing(spacing: f32) -> Content {
+        Content::Wrap {
+            wrap_spacing: Some(spacing),
+        }
     }
 }
 

--- a/crates/torin/src/measure.rs
+++ b/crates/torin/src/measure.rs
@@ -17,6 +17,7 @@ use crate::{
         AreaOf,
         Available,
         AvailableAreaModel,
+        Content,
         Direction,
         Inner,
         LayoutMetadata,
@@ -695,11 +696,11 @@ where
                 }
             }
 
-            if parent_node.content.is_wrap() {
+            if let Content::Wrap { wrap_spacing } = parent_node.content {
                 let initial_phase_size = initial_phase_sizes.get(&child_id);
-                // Wrap this child
                 Self::wrap_child(
-                    parent_node,
+                    wrap_spacing.unwrap_or_default(),
+                    parent_node.direction,
                     initial_phase_size,
                     &initial_available_area,
                     parent_area,
@@ -746,8 +747,10 @@ where
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn wrap_child(
-        parent_node: &Node,
+        wrap_spacing: f32,
+        direction: Direction,
         initial_phase_size: Option<&Size2D>,
         initial_available_area: &AreaOf<Available>,
         parent_area: &mut AreaOf<Parent>,
@@ -756,27 +759,29 @@ where
         inner_sizes: Size2D,
     ) {
         if let Some(initial_phase_size) = initial_phase_size {
-            match parent_node.direction {
+            match direction {
                 Direction::Vertical => {
                     if adapted_available_area.height() - initial_phase_size.height < 0. {
+                        let advance = inner_sizes.width + wrap_spacing;
                         available_area.origin.y = initial_available_area.origin.y;
                         available_area.size.height = initial_available_area.size.height;
-                        available_area.origin.x += inner_sizes.width;
+                        available_area.origin.x += advance;
                         adapted_available_area.origin.y = initial_available_area.origin.y;
                         adapted_available_area.size.height = initial_available_area.size.height;
-                        adapted_available_area.origin.x += inner_sizes.width;
-                        parent_area.size.width += inner_sizes.width;
+                        adapted_available_area.origin.x += advance;
+                        parent_area.size.width += advance;
                     }
                 }
                 Direction::Horizontal => {
                     if adapted_available_area.width() - initial_phase_size.width < 0. {
+                        let advance = inner_sizes.height + wrap_spacing;
                         available_area.origin.x = initial_available_area.origin.x;
                         available_area.size.width = initial_available_area.size.width;
-                        available_area.origin.y += inner_sizes.height;
+                        available_area.origin.y += advance;
                         adapted_available_area.origin.x = initial_available_area.origin.x;
                         adapted_available_area.size.width = initial_available_area.size.width;
-                        adapted_available_area.origin.y += inner_sizes.height;
-                        parent_area.size.height += inner_sizes.height;
+                        adapted_available_area.origin.y += advance;
+                        parent_area.size.height += advance;
                     }
                 }
             }

--- a/crates/torin/src/values/content.rs
+++ b/crates/torin/src/values/content.rs
@@ -1,11 +1,14 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(PartialEq, Eq, Clone, Debug, Default)]
+#[derive(PartialEq, Clone, Debug, Default)]
 pub enum Content {
     #[default]
     Normal,
     Fit,
     Flex,
-    Wrap,
+    /// Wraps children to the next line/column, with an optional gap between wrapped lines.
+    Wrap {
+        wrap_spacing: Option<f32>,
+    },
 }
 
 impl Content {
@@ -18,7 +21,7 @@ impl Content {
     }
 
     pub fn is_wrap(&self) -> bool {
-        self == &Self::Wrap
+        matches!(self, Self::Wrap { .. })
     }
 
     pub fn allows_alignments(&self) -> bool {
@@ -32,7 +35,7 @@ impl Content {
             Self::Normal => "normal".to_owned(),
             Self::Fit => "fit".to_owned(),
             Self::Flex => "flex".to_owned(),
-            Self::Wrap => "wrap".to_owned(),
+            Self::Wrap { .. } => "wrap".to_owned(),
         }
     }
 }

--- a/crates/torin/tests/wrap.rs
+++ b/crates/torin/tests/wrap.rs
@@ -14,7 +14,7 @@ pub fn content_wrap_horizontal() {
         Size::Pixels(Length::new(200.0)),
         Direction::Horizontal,
     );
-    root.content = Content::Wrap;
+    root.content = Content::Wrap { wrap_spacing: None };
 
     mocked_tree.add(0, None, vec![1, 2, 3], root);
 
@@ -85,7 +85,7 @@ pub fn content_wrap_vertical() {
         Node::from_size_and_content(
             Size::Pixels(Length::new(200.0)),
             Size::Pixels(Length::new(200.0)),
-            Content::Wrap,
+            Content::Wrap { wrap_spacing: None },
         ),
     );
 
@@ -125,5 +125,76 @@ pub fn content_wrap_vertical() {
     assert_eq!(
         layout.get(&2).unwrap().area,
         Rect::new(Point2D::new(100.0, 0.0), Size2D::new(100.0, 150.0)),
+    );
+}
+
+#[test]
+pub fn content_wrap_horizontal_with_spacing() {
+    let (mut layout, mut measurer) = test_utils();
+
+    let mut mocked_tree = TestingTree::default();
+    let mut root = Node::from_size_and_direction(
+        Size::Pixels(Length::new(300.0)),
+        Size::Pixels(Length::new(200.0)),
+        Direction::Horizontal,
+    );
+    root.content = Content::Wrap {
+        wrap_spacing: Some(10.0),
+    };
+
+    mocked_tree.add(0, None, vec![1, 2, 3], root);
+
+    mocked_tree.add(
+        1,
+        Some(0),
+        vec![],
+        Node::from_size_and_direction(
+            Size::Pixels(Length::new(150.0)),
+            Size::Pixels(Length::new(20.0)),
+            Direction::Vertical,
+        ),
+    );
+    mocked_tree.add(
+        2,
+        Some(0),
+        vec![],
+        Node::from_size_and_direction(
+            Size::Pixels(Length::new(150.0)),
+            Size::Pixels(Length::new(20.0)),
+            Direction::Vertical,
+        ),
+    );
+    mocked_tree.add(
+        3,
+        Some(0),
+        vec![],
+        Node::from_size_and_direction(
+            Size::Pixels(Length::new(150.0)),
+            Size::Pixels(Length::new(20.0)),
+            Direction::Vertical,
+        ),
+    );
+
+    layout.measure(
+        0,
+        Rect::new(Point2D::new(0.0, 0.0), Size2D::new(1000.0, 1000.0)),
+        &mut measurer,
+        &mut mocked_tree,
+    );
+
+    assert_eq!(
+        layout.get(&1).unwrap().area,
+        Rect::new(Point2D::new(0.0, 0.0), Size2D::new(150.0, 20.0)),
+    );
+
+    assert_eq!(
+        layout.get(&2).unwrap().area,
+        Rect::new(Point2D::new(150.0, 0.0), Size2D::new(150.0, 20.0)),
+    );
+
+    // Third child wraps to y=20+10=30 due to wrap_spacing of 10.0
+    assert_eq!(
+        layout.get(&3).unwrap().area,
+        Rect::new(Point2D::new(0.0, 30.0), Size2D::new(150.0, 20.0)),
     );
 }

--- a/examples/layout_content_wrap.rs
+++ b/examples/layout_content_wrap.rs
@@ -45,7 +45,8 @@ fn app() -> impl IntoElement {
         .content(Content::Flex)
         .child(
             rect()
-                .content(Content::Wrap)
+                .content(Content::wrap_spacing(10.))
+                .spacing(10.)
                 .width(Size::fill())
                 .height(Size::flex(1.))
                 .horizontal()
@@ -53,7 +54,7 @@ fn app() -> impl IntoElement {
         )
         .child(
             rect()
-                .content(Content::Wrap)
+                .content(Content::wrap())
                 .width(Size::fill())
                 .height(Size::flex(1.))
                 .children(cards()),


### PR DESCRIPTION
```rust
rect()
	.content(Content::wrap_spacing(10.))
	.spacing(10.)
```