### PR TITLE
fix(core): Drop removed tasks before scope gets dropped

### DIFF
--- a/crates/freya-core/src/runner.rs
+++ b/crates/freya-core/src/runner.rs
@@ -180,6 +180,7 @@ impl Drop for Runner {
                             true
                         }
                     });
+                    drop(_removed_tasks);
                     let _scope = self.scopes_storages.borrow_mut().remove(&scope_id);
                 },
             );
@@ -1095,6 +1096,7 @@ impl Runner {
                             true
                         }
                     });
+                    drop(_removed_tasks);
                     // This is very important, the scope storage must be dropped after the borrow in `scopes_storages` has been released
                     let _scope = self.scopes_storages.borrow_mut().remove(&scope.id);
                 },


### PR DESCRIPTION
Oopsie from https://github.com/marc2332/freya/pull/1600

This way the tasks are droped before the scope. 

The error otherwise would **sometimes** (after closing feature_terminal.rs) be:
```
thread 'main' panicked at /home/marc/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/generational-box-0.7.3/src/unsync.rs:228:51:
RefCell already borrowed
```