### PR TITLE
fix(core): Expose `ScopeId`

### DIFF
--- a/crates/freya-core/src/lib.rs
+++ b/crates/freya-core/src/lib.rs
@@ -124,6 +124,7 @@ pub mod prelude {
         platform::*,
         reactive_context::ReactiveContext,
         rendering_ticker::RenderingTicker,
+        scope_id::ScopeId,
         style::{
             border::*,
             color::*,


### PR DESCRIPTION
This way `provide_context_for_scope_id` can be used without depending directly on `freya-core`