### PR TITLE
feat(terminal): More keys supported in `freya-terminal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,7 +671,7 @@ fn app() -> impl IntoElement {
         let mut cmd = CommandBuilder::new("bash");
         cmd.env("TERM", "xterm-256color");
         cmd.env("COLORTERM", "truecolor");
-        TerminalHandle::new(cmd).ok()
+        TerminalHandle::new(TerminalId::new(), cmd, None).ok()
     });
 
     rect()
@@ -684,28 +684,7 @@ fn app() -> impl IntoElement {
             Terminal::new(handle.clone())
                 .a11y_id(focus.a11y_id())
                 .on_key_down(move |e: Event<KeyboardEventData>| {
-                    if e.modifiers.contains(Modifiers::CONTROL)
-                        && matches!(&e.key, Key::Character(ch) if ch.len() == 1)
-                    {
-                        if let Key::Character(ch) = &e.key {
-                            let _ = handle.write(&[ch.as_bytes()[0] & 0x1f]);
-                        }
-                    } else if let Some(ch) = e.try_as_str() {
-                        let _ = handle.write(ch.as_bytes());
-                    } else {
-                        let _ = handle.write(match &e.key {
-                            Key::Named(NamedKey::Enter) => b"\r",
-                            Key::Named(NamedKey::Backspace) => &[0x7f],
-                            Key::Named(NamedKey::Delete) => b"\x1b[3~",
-                            Key::Named(NamedKey::Tab) => b"\t",
-                            Key::Named(NamedKey::Escape) => &[0x1b],
-                            Key::Named(NamedKey::ArrowUp) => b"\x1b[A",
-                            Key::Named(NamedKey::ArrowDown) => b"\x1b[B",
-                            Key::Named(NamedKey::ArrowLeft) => b"\x1b[D",
-                            Key::Named(NamedKey::ArrowRight) => b"\x1b[C",
-                            _ => return,
-                        });
-                    };
+                    let _ = handle.write_key(&e.key, e.modifiers);
                 })
         } else {
             "Terminal exited".into_element()

--- a/crates/freya-terminal/src/handle.rs
+++ b/crates/freya-terminal/src/handle.rs
@@ -18,7 +18,11 @@ use freya_core::{
         UserEvent,
     },
 };
-use keyboard_types::Modifiers;
+use keyboard_types::{
+    Key,
+    Modifiers,
+    NamedKey,
+};
 use portable_pty::{
     MasterPty,
     PtySize,
@@ -194,6 +198,107 @@ impl TerminalHandle {
         *self.last_write_time.borrow_mut() = Instant::now();
         self.scroll_to_bottom();
         Ok(())
+    }
+
+    /// Process a key event and write the corresponding terminal escape sequence to the PTY.
+    ///
+    /// Handles standard terminal keys (Enter, Backspace, Tab, Escape, arrows, Delete),
+    /// Ctrl+letter control codes, modified Enter (Shift/Ctrl via CSI u encoding),
+    /// regular character input, and shift state tracking for mouse selection.
+    ///
+    /// Returns `Ok(true)` if the key was handled, `Ok(false)` if not recognized.
+    ///
+    /// Application-level shortcuts like clipboard copy/paste should be handled
+    /// by the caller before calling this method.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use freya_terminal::prelude::*;
+    /// # use keyboard_types::{Key, Modifiers};
+    /// # let handle: TerminalHandle = unimplemented!();
+    /// # let key = Key::Character("a".into());
+    /// # let modifiers = Modifiers::empty();
+    /// let _ = handle.write_key(&key, modifiers);
+    /// ```
+    pub fn write_key(&self, key: &Key, modifiers: Modifiers) -> Result<bool, TerminalError> {
+        let shift = modifiers.contains(Modifiers::SHIFT);
+        let ctrl = modifiers.contains(Modifiers::CONTROL);
+        let alt = modifiers.contains(Modifiers::ALT);
+
+        match key {
+            Key::Character(ch) if ctrl && ch.len() == 1 => {
+                self.write(&[ch.as_bytes()[0] & 0x1f])?;
+                Ok(true)
+            }
+            Key::Named(NamedKey::Enter) if shift || ctrl => {
+                if self.parser.borrow().screen().alternate_screen() {
+                    let m = 1 + shift as u8 + (alt as u8) * 2 + (ctrl as u8) * 4;
+                    let seq = format!("\x1b[13;{m}u");
+                    self.write(seq.as_bytes())?;
+                } else {
+                    self.write(b"\r")?;
+                }
+                Ok(true)
+            }
+            Key::Named(NamedKey::Enter) => {
+                self.write(b"\r")?;
+                Ok(true)
+            }
+            Key::Named(NamedKey::Backspace) => {
+                self.write(&[0x7f])?;
+                Ok(true)
+            }
+            Key::Named(NamedKey::Delete) if alt || ctrl || shift => {
+                let m = 1 + shift as u8 + (alt as u8) * 2 + (ctrl as u8) * 4;
+                let seq = format!("\x1b[3;{m}~");
+                self.write(seq.as_bytes())?;
+                Ok(true)
+            }
+            Key::Named(NamedKey::Delete) => {
+                self.write(b"\x1b[3~")?;
+                Ok(true)
+            }
+            Key::Named(NamedKey::Shift) => {
+                self.shift_pressed(true);
+                Ok(true)
+            }
+            Key::Named(NamedKey::Tab) => {
+                self.write(b"\t")?;
+                Ok(true)
+            }
+            Key::Named(NamedKey::Escape) => {
+                self.write(&[0x1b])?;
+                Ok(true)
+            }
+            Key::Named(
+                dir @ (NamedKey::ArrowUp
+                | NamedKey::ArrowDown
+                | NamedKey::ArrowLeft
+                | NamedKey::ArrowRight),
+            ) => {
+                let ch = match dir {
+                    NamedKey::ArrowUp => 'A',
+                    NamedKey::ArrowDown => 'B',
+                    NamedKey::ArrowRight => 'C',
+                    NamedKey::ArrowLeft => 'D',
+                    _ => unreachable!(),
+                };
+                if shift || ctrl {
+                    let m = 1 + shift as u8 + (alt as u8) * 2 + (ctrl as u8) * 4;
+                    let seq = format!("\x1b[1;{m}{ch}");
+                    self.write(seq.as_bytes())?;
+                } else {
+                    self.write(&[0x1b, b'[', ch as u8])?;
+                }
+                Ok(true)
+            }
+            Key::Character(ch) => {
+                self.write(ch.as_bytes())?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
     }
 
     /// Write text to the PTY as a paste operation.

--- a/crates/freya-terminal/src/lib.rs
+++ b/crates/freya-terminal/src/lib.rs
@@ -41,20 +41,7 @@
 //!                         .a11y_id(focus.a11y_id())
 //!                         .on_mouse_down(move |_| focus.request_focus())
 //!                         .on_key_down(move |e: Event<KeyboardEventData>| {
-//!                             if let Some(ch) = e.try_as_str() {
-//!                                 let _ = handle.write(ch.as_bytes());
-//!                             } else {
-//!                                 let _ = handle.write(match &e.key {
-//!                                     Key::Named(NamedKey::Enter) => b"\n",
-//!                                     Key::Named(NamedKey::Backspace) => &[0x7f],
-//!                                     Key::Named(NamedKey::Tab) => b"\t",
-//!                                     Key::Named(NamedKey::ArrowUp) => b"\x1b[A",
-//!                                     Key::Named(NamedKey::ArrowDown) => b"\x1b[B",
-//!                                     Key::Named(NamedKey::ArrowLeft) => b"\x1b[D",
-//!                                     Key::Named(NamedKey::ArrowRight) => b"\x1b[C",
-//!                                     _ => return,
-//!                                 });
-//!                             }
+//!                             let _ = handle.write_key(&e.key, e.modifiers);
 //!                         }),
 //!                 )
 //!                 .expanded()

--- a/examples/feature_terminal.rs
+++ b/examples/feature_terminal.rs
@@ -125,9 +125,8 @@ fn app() -> impl IntoElement {
                             }
                         })
                         .on_key_down(move |e: Event<KeyboardEventData>| {
-                            let mods = e.modifiers;
-                            let ctrl_shift = mods.contains(Modifiers::CONTROL | Modifiers::SHIFT);
-                            let ctrl = mods.contains(Modifiers::CONTROL);
+                            let ctrl_shift =
+                                e.modifiers.contains(Modifiers::CONTROL | Modifiers::SHIFT);
 
                             match &e.key {
                                 Key::Character(ch)
@@ -144,43 +143,8 @@ fn app() -> impl IntoElement {
                                         let _ = handle.paste(&text);
                                     }
                                 }
-                                Key::Character(ch) if ctrl && ch.len() == 1 => {
-                                    let _ = handle.write(&[ch.as_bytes()[0] & 0x1f]);
-                                }
-                                Key::Named(NamedKey::Enter) => {
-                                    let _ = handle.write(b"\r");
-                                }
-                                Key::Named(NamedKey::Backspace) => {
-                                    let _ = handle.write(&[0x7f]);
-                                }
-                                Key::Named(NamedKey::Delete) => {
-                                    let _ = handle.write(b"\x1b[3~");
-                                }
-                                Key::Named(NamedKey::Shift) => {
-                                    handle.shift_pressed(true);
-                                }
-                                Key::Named(NamedKey::Tab) => {
-                                    let _ = handle.write(b"\t");
-                                }
-                                Key::Named(NamedKey::Escape) => {
-                                    let _ = handle.write(&[0x1b]);
-                                }
-                                Key::Named(NamedKey::ArrowUp) => {
-                                    let _ = handle.write(b"\x1b[A");
-                                }
-                                Key::Named(NamedKey::ArrowDown) => {
-                                    let _ = handle.write(b"\x1b[B");
-                                }
-                                Key::Named(NamedKey::ArrowLeft) => {
-                                    let _ = handle.write(b"\x1b[D");
-                                }
-                                Key::Named(NamedKey::ArrowRight) => {
-                                    let _ = handle.write(b"\x1b[C");
-                                }
                                 _ => {
-                                    if let Some(ch) = e.try_as_str() {
-                                        let _ = handle.write(ch.as_bytes());
-                                    }
+                                    let _ = handle.write_key(&e.key, e.modifiers);
                                 }
                             }
                         }),

--- a/examples/feature_terminal_canvas.rs
+++ b/examples/feature_terminal_canvas.rs
@@ -254,10 +254,9 @@ impl Component for TerminalPanel {
                                         }
                                     })
                                     .on_key_down(move |e: Event<KeyboardEventData>| {
-                                        let mods = e.modifiers;
-                                        let ctrl_shift =
-                                            mods.contains(Modifiers::CONTROL | Modifiers::SHIFT);
-                                        let ctrl = mods.contains(Modifiers::CONTROL);
+                                        let ctrl_shift = e
+                                            .modifiers
+                                            .contains(Modifiers::CONTROL | Modifiers::SHIFT);
 
                                         match &e.key {
                                             Key::Character(ch)
@@ -274,43 +273,8 @@ impl Component for TerminalPanel {
                                                     let _ = handle.paste(&text);
                                                 }
                                             }
-                                            Key::Character(ch) if ctrl && ch.len() == 1 => {
-                                                let _ = handle.write(&[ch.as_bytes()[0] & 0x1f]);
-                                            }
-                                            Key::Named(NamedKey::Enter) => {
-                                                let _ = handle.write(b"\r");
-                                            }
-                                            Key::Named(NamedKey::Backspace) => {
-                                                let _ = handle.write(&[0x7f]);
-                                            }
-                                            Key::Named(NamedKey::Delete) => {
-                                                let _ = handle.write(b"\x1b[3~");
-                                            }
-                                            Key::Named(NamedKey::Shift) => {
-                                                handle.shift_pressed(true);
-                                            }
-                                            Key::Named(NamedKey::Tab) => {
-                                                let _ = handle.write(b"\t");
-                                            }
-                                            Key::Named(NamedKey::Escape) => {
-                                                let _ = handle.write(&[0x1b]);
-                                            }
-                                            Key::Named(NamedKey::ArrowUp) => {
-                                                let _ = handle.write(b"\x1b[A");
-                                            }
-                                            Key::Named(NamedKey::ArrowDown) => {
-                                                let _ = handle.write(b"\x1b[B");
-                                            }
-                                            Key::Named(NamedKey::ArrowLeft) => {
-                                                let _ = handle.write(b"\x1b[D");
-                                            }
-                                            Key::Named(NamedKey::ArrowRight) => {
-                                                let _ = handle.write(b"\x1b[C");
-                                            }
                                             _ => {
-                                                if let Some(ch) = e.try_as_str() {
-                                                    let _ = handle.write(ch.as_bytes());
-                                                }
+                                                let _ = handle.write_key(&e.key, e.modifiers);
                                             }
                                         }
                                     }),


### PR DESCRIPTION
- Shift+Enter
- Ctrl+Enter
- Ctrl+Shift+Enter
- Ctrl+Arrow keys
- Shift+Arrow keys
- Ctrl+Shift+Arrow keys
- Alt+Delete
- Ctrl+Delete
- Shift+Delete