### PR TITLE
fix(core): Properly move elements of nested components

### DIFF
--- a/crates/freya-core/src/runner.rs
+++ b/crates/freya-core/src/runner.rs
@@ -904,6 +904,20 @@ impl Runner {
         (parent_node_id, index_inside_parent)
     }
 
+    /// Recursively finds the root element [NodeId] of a scope.
+    /// When a scope's first child is another component (scope), this follows
+    /// the chain until it finds the first actual element.
+    fn find_scope_root_node_id(&self, scope_id: ScopeId) -> NodeId {
+        let scope_rc = self.scopes.get(&scope_id).unwrap();
+        let scope = scope_rc.borrow();
+        let path_node = scope.nodes.get(&[0]).unwrap();
+        if let Some(child_scope_id) = path_node.scope_id {
+            self.find_scope_root_node_id(child_scope_id)
+        } else {
+            path_node.node_id
+        }
+    }
+
     #[cfg_attr(feature = "hotpath", hotpath::measure)]
     fn apply_diff(
         &mut self,
@@ -1228,18 +1242,16 @@ impl Runner {
                 scope.borrow_mut().nodes.insert_entry(&to_path, path_entry);
 
                 if let Some(scope_id) = scope_id {
+                    let scope_root_node_id = self.find_scope_root_node_id(scope_id);
                     let scope_rc = self.scopes.get(&scope_id).cloned().unwrap();
-
                     let scope = scope_rc.borrow();
-
-                    let scope_root_node_id = scope.nodes.get(&[0]).map(|node| node.node_id);
 
                     // Mark the scope root node id as moved
                     mutations
                         .moved
                         .entry(scope.parent_node_id_in_parent)
                         .or_default()
-                        .push((to, scope_root_node_id.unwrap()));
+                        .push((to, scope_root_node_id));
                 } else {
                     // Mark the element as moved
                     mutations

--- a/crates/freya-core/src/tree.rs
+++ b/crates/freya-core/src/tree.rs
@@ -267,15 +267,15 @@ impl Tree {
 
             for (parent_node_id, movements) in mutations.moved {
                 let parent = self.children.get_mut(&parent_node_id).unwrap();
-                for (to, node_id) in movements.iter() {
-                    let from = parent.iter().position(|id| id == node_id).unwrap();
+                for (to, node_id) in movements {
+                    let from = parent.iter().position(|id| *id == node_id).unwrap();
 
-                    if from < *to as usize {
-                        parent.insert(*to as usize, *node_id);
+                    if from < to as usize {
+                        parent.insert(to as usize, node_id);
                         parent.remove(from);
                     } else {
                         parent.remove(from);
-                        parent.insert(*to as usize, *node_id);
+                        parent.insert(to as usize, node_id);
                     }
                 }
                 let mut diff = DiffModifies::empty();

--- a/crates/freya-core/tests/diffing.rs
+++ b/crates/freya-core/tests/diffing.rs
@@ -1612,3 +1612,64 @@ fn ordered_scope_mutations_diffing() {
 
     assert_eq!(tree.elements.len(), runner.node_to_scope.len());
 }
+
+#[test]
+fn deeply_nested_component_move() {
+    fn comp3(_: &()) -> Element {
+        rect().into()
+    }
+
+    fn comp2(_: &()) -> Element {
+        from_fn_standalone_borrowed((), comp3)
+    }
+
+    fn comp1(_: &()) -> Element {
+        from_fn_standalone_borrowed((), comp2)
+    }
+
+    fn app() -> Element {
+        let state = use_consume::<State<bool>>();
+        if state() {
+            rect()
+                .child(from_fn_standalone_borrowed_keyed(1, (), comp1))
+                .child(from_fn_standalone_borrowed_keyed(2, (), comp1))
+                .into()
+        } else {
+            rect()
+                .child(from_fn_standalone_borrowed_keyed(2, (), comp1))
+                .child(from_fn_standalone_borrowed_keyed(1, (), comp1))
+                .into()
+        }
+    }
+
+    let mut runner = Runner::new(app);
+    let mut tree = Tree::default();
+    let mut state = runner.provide_root_context(|| State::create(true));
+
+    let mutations = runner.sync_and_update();
+    tree.apply_mutations(mutations);
+    tree.verify_tree_integrity();
+    assert_eq!(tree.elements.len(), runner.node_to_scope.len());
+
+    // Swap: key=1 moves from position 0 to 1, key=2 moves from position 1 to 0
+    state.set(false);
+    let mutations = runner.sync_and_update();
+    assert!(mutations.added.is_empty());
+    assert!(mutations.modified.is_empty());
+    assert!(mutations.removed.is_empty());
+    assert!(!mutations.moved.is_empty());
+    tree.apply_mutations(mutations);
+    tree.verify_tree_integrity();
+    assert_eq!(tree.elements.len(), runner.node_to_scope.len());
+
+    // Swap back: verify the move is fully reversible
+    state.set(true);
+    let mutations = runner.sync_and_update();
+    assert!(mutations.added.is_empty());
+    assert!(mutations.modified.is_empty());
+    assert!(mutations.removed.is_empty());
+    assert!(!mutations.moved.is_empty());
+    tree.apply_mutations(mutations);
+    tree.verify_tree_integrity();
+    assert_eq!(tree.elements.len(), runner.node_to_scope.len());
+}


### PR DESCRIPTION
When moving a component we need to recursively find its closest non-scope node id for the tree mutations.