### PR TITLE
fix(torin): Add a correction pass for flex-content containers with non-start cross alignments and with auto-sized inner elements

### DIFF
--- a/crates/torin/src/measure.rs
+++ b/crates/torin/src/measure.rs
@@ -590,6 +590,93 @@ where
 
                         acc
                     });
+
+            // Re-measure flex children that have an inner (auto) cross-axis size
+            // with their actual flex-grown main-axis dimensions to get accurate
+            // cross-axis sizes for alignment.
+            //
+            // During the initial phase, Size::Flex resolves to None so flex children
+            // get a near-zero main-axis dimension. This causes inner content
+            // (e.g. text measured by a custom measurer) to wrap differently and
+            // produce an incorrect cross-axis size, which then pollutes both
+            // the per-child alignment sizes and the parent's accumulated cross-axis size.
+            //
+            // See: https://github.com/marc2332/freya/issues/1098
+            if parent_node.cross_alignment.is_not_start() {
+                let cross_axis = AlignAxis::new(&parent_node.direction, AlignmentDirection::Cross);
+
+                for child_id in &children {
+                    let Some(flex_grow) = initial_phase_flex_grows.get(child_id) else {
+                        continue;
+                    };
+                    let Some(child_data) = self.tree_adapter.get_node(child_id) else {
+                        continue;
+                    };
+                    if !child_data.position.is_stacked() {
+                        continue;
+                    }
+
+                    let has_inner_cross = match cross_axis {
+                        AlignAxis::Height => child_data.height.inner_sized(),
+                        AlignAxis::Width => child_data.width.inner_sized(),
+                    };
+                    if !has_inner_cross {
+                        continue;
+                    }
+
+                    let flex_grow_per = flex_grow.get() / flex_grows.get() * 100.;
+                    let mut corrected_available_area = initial_area.as_available();
+
+                    match flex_axis {
+                        AlignAxis::Height => {
+                            corrected_available_area.size.height =
+                                flex_available_height / 100. * flex_grow_per;
+                        }
+                        AlignAxis::Width => {
+                            corrected_available_area.size.width =
+                                flex_available_width / 100. * flex_grow_per;
+                        }
+                    }
+
+                    let (_, mut child_areas) = self.measure_node(
+                        *child_id,
+                        &child_data,
+                        initial_area.as_parent(),
+                        corrected_available_area,
+                        false,
+                        parent_is_dirty,
+                        Phase::Final,
+                    );
+
+                    child_areas.area.adjust_size(&child_data);
+                    initial_phase_sizes.insert(*child_id, child_areas.area.size);
+                }
+
+                // Recompute the parent's cross-axis size from corrected child sizes
+                let max_cross = children
+                    .iter()
+                    .filter_map(|id| initial_phase_sizes.get(id))
+                    .map(|size| match cross_axis {
+                        AlignAxis::Height => size.height,
+                        AlignAxis::Width => size.width,
+                    })
+                    .fold(0.0, f32::max);
+
+                match cross_axis {
+                    AlignAxis::Height if parent_node.height.inner_sized() => {
+                        let gaps = parent_node.padding.vertical() + parent_node.margin.vertical();
+                        initial_phase_parent_area.size.height = max_cross + gaps;
+                        initial_phase_inner_area.size.height = max_cross;
+                    }
+                    AlignAxis::Width if parent_node.width.inner_sized() => {
+                        let gaps =
+                            parent_node.padding.horizontal() + parent_node.margin.horizontal();
+                        initial_phase_parent_area.size.width = max_cross + gaps;
+                        initial_phase_inner_area.size.width = max_cross;
+                    }
+                    _ => {}
+                }
+            }
         }
 
         if needs_initial_phase {

--- a/crates/torin/tests/flex.rs
+++ b/crates/torin/tests/flex.rs
@@ -1,3 +1,8 @@
+use std::{
+    any::Any,
+    rc::Rc,
+};
+
 use euclid::Length;
 use torin::{
     prelude::*,
@@ -494,4 +499,125 @@ pub fn flex_root_candidate_resolution() {
         layout.get(&3).unwrap().area.round(),
         Rect::new(Point2D::new(0.0, 150.0), Size2D::new(100.0, 50.0)),
     );
+}
+
+/// Simulates text wrapping: height grows as available width shrinks.
+struct TextLikeMeasurer {
+    text_nodes: Vec<usize>,
+    text_content_width: f32,
+    line_height: f32,
+}
+
+impl LayoutMeasurer<usize> for TextLikeMeasurer {
+    fn measure(
+        &mut self,
+        node_id: usize,
+        _node: &Node,
+        size: &Size2D,
+    ) -> Option<(Size2D, Rc<dyn Any>)> {
+        if !self.text_nodes.contains(&node_id) {
+            return None;
+        }
+
+        let available_width = size.width.max(1.0);
+        let lines = (self.text_content_width / available_width).ceil();
+        let width = self.text_content_width.min(available_width);
+        let height = lines * self.line_height;
+
+        Some((Size2D::new(width, height), Rc::new(())))
+    }
+
+    fn should_hook_measurement(&mut self, node_id: usize) -> bool {
+        self.text_nodes.contains(&node_id)
+    }
+
+    fn should_measure_inner_children(&mut self, node_id: usize) -> bool {
+        !self.text_nodes.contains(&node_id)
+    }
+}
+
+/// Regression test for https://github.com/marc2332/freya/issues/1098
+#[test]
+pub fn flex_with_cross_align_center_and_text() {
+    let mut layout = Torin::<usize>::new();
+
+    let mut measurer = Some(TextLikeMeasurer {
+        text_nodes: vec![3],
+        text_content_width: 80.0,
+        line_height: 20.0,
+    });
+
+    let mut mocked_tree = TestingTree::default();
+
+    mocked_tree.add(
+        0,
+        None,
+        vec![1],
+        Node::from_size_and_direction(
+            Size::Pixels(Length::new(300.0)),
+            Size::Pixels(Length::new(48.0)),
+            Direction::Vertical,
+        ),
+    );
+
+    mocked_tree.add(1, Some(0), vec![2, 4], {
+        let mut node = Node::from_size_and_alignments_and_direction(
+            Size::Inner,
+            Size::Inner,
+            Alignment::Start,
+            Alignment::Center,
+            Direction::Horizontal,
+        );
+        node.content = Content::Flex;
+        node.spacing = Length::new(8.0);
+        node
+    });
+
+    mocked_tree.add(
+        2,
+        Some(1),
+        vec![3],
+        Node::from_size_and_direction(
+            Size::Flex(Length::new(1.0)),
+            Size::Inner,
+            Direction::Vertical,
+        ),
+    );
+
+    mocked_tree.add(
+        3,
+        Some(2),
+        vec![],
+        Node::from_size_and_direction(Size::Inner, Size::Inner, Direction::Vertical),
+    );
+
+    mocked_tree.add(
+        4,
+        Some(1),
+        vec![],
+        Node::from_size_and_direction(
+            Size::Pixels(Length::new(12.0)),
+            Size::Pixels(Length::new(12.0)),
+            Direction::Vertical,
+        ),
+    );
+
+    layout.measure(
+        0,
+        Rect::new(Point2D::new(0.0, 0.0), Size2D::new(1000.0, 1000.0)),
+        &mut measurer,
+        &mut mocked_tree,
+    );
+
+    let node_2_area = layout.get(&2).unwrap().area;
+    let node_3_area = layout.get(&3).unwrap().area;
+    let node_4_area = layout.get(&4).unwrap().area;
+
+    // Text fits on one line with the flex-grown width
+    assert_eq!(node_3_area.size.height, 20.0);
+    assert_eq!(node_2_area.size.height, 20.0);
+
+    // The 12px rect should be vertically centered: (20 - 12) / 2 = 4px offset
+    assert_eq!(node_4_area.size.height, 12.0);
+    assert_eq!(node_4_area.origin.y, node_2_area.origin.y + 4.0);
 }

--- a/examples/layout_content_flex.rs
+++ b/examples/layout_content_flex.rs
@@ -4,8 +4,6 @@
 )]
 use freya::prelude::*;
 
-// NOTES: Cross align does not use the new height so centering does not work as expected
-
 fn main() {
     launch(LaunchConfig::new().with_window(WindowConfig::new(app)))
 }


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/1098

pain