### PR TITLE
fix(core): Prevent overflow when drawing cursor of paragraph element

### DIFF
--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -512,7 +512,7 @@ impl ElementExt for ParagraphElement {
                     .get_glyph_position_at_coordinate((f32::MAX, f32::MAX))
                     .position as usize;
                 let last_rects = paragraph.get_rects_for_range(
-                    (text_len - 1)..text_len,
+                    text_len.saturating_sub(1)..text_len,
                     RectHeightStyle::Tight,
                     RectWidthStyle::Tight,
                 );
@@ -528,7 +528,7 @@ impl ElementExt for ParagraphElement {
                 let paint_color = self.cursor_style_data.color;
                 match self.cursor_style {
                     CursorStyle::Underline => {
-                        let thickness = 2.0_f32;
+                        let thickness = 2.0;
                         let underline_rect = SkRect::new(
                             cursor_area.min_x() + cursor_rect.left,
                             cursor_area.min_y() + cursor_rect.bottom - thickness


### PR DESCRIPTION
```
thread 'main' (591432) panicked at /home/marc/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/freya-core-0.4.0-rc.14/src/elements/paragraph.rs:515:21:                                              
attempt to subtract with overflow                                                                                                                                                                        
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace      
``