### PR TITLE
chore(core): Change default image sampling mode to Trilinear for higher quality rendering

### DIFF
--- a/crates/freya-core/src/elements/image.rs
+++ b/crates/freya-core/src/elements/image.rs
@@ -99,9 +99,9 @@ pub enum AspectRatio {
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum SamplingMode {
-    #[default]
     Nearest,
     Bilinear,
+    #[default]
     Trilinear,
     Mitchell,
     CatmullRom,

--- a/examples/floating_dock.rs
+++ b/examples/floating_dock.rs
@@ -100,7 +100,6 @@ impl Component for DockIcon {
                 .into()
         } else {
             ImageViewer::new(self.icon_path.clone())
-                .sampling_mode(SamplingMode::Trilinear)
                 .width(Size::px(28.))
                 .height(Size::px(28.))
                 .into()


### PR DESCRIPTION
<img width="1461" height="600" alt="image" src="https://github.com/user-attachments/assets/6ac310ec-eec2-43e3-8308-c0ca6c9525df" />
Nearest vs Trilinear