### PR TITLE
fix(winit): Reset text cache when scale factor changes

### DIFF
--- a/crates/freya-winit/src/renderer.rs
+++ b/crates/freya-winit/src/renderer.rs
@@ -623,6 +623,7 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                     app.window.request_redraw();
                     app.process_layout_on_next_render = true;
                     app.tree.layout.reset();
+                    app.tree.text_cache.reset();
                 }
                 WindowEvent::CloseRequested => {
                     let mut on_close_hook = self


### PR DESCRIPTION
Its not like the text wasn't being invalidated before, it depends on whether its area changed too or not. In any case, this is better,