### PR TITLE
Fixed show_progress for ProgressBar

### DIFF
--- a/crates/freya-components/src/progressbar.rs
+++ b/crates/freya-components/src/progressbar.rs
@@ -126,8 +126,8 @@ impl Component for ProgressBar {
                     .height(Size::fill())
                     .corner_radius(99.)
                     .background(progressbar_theme.progress_background)
-                    .maybe(self.show_progress, |r| {
-                        r.child(
+                    .maybe(self.show_progress, |el| {
+                        el.child(
                             label()
                                 .width(Size::fill())
                                 .color(progressbar_theme.color)


### PR DESCRIPTION
I'm assuming show_progress is supposed to hide the percentage label, from what I've seen the variable itself is not even being used anywhere in the code.