### PR TITLE
fix(core): correct log message in animation clock speed enable method

### DIFF
--- a/crates/freya-core/src/animation_clock.rs
+++ b/crates/freya-core/src/animation_clock.rs
@@ -44,7 +44,7 @@ impl AnimationClock {
     pub fn enable(&self) {
         self.0
             .store(Self::DEFAULT_SPEED.to_bits(), Ordering::Relaxed);
-        info!("Animation clock speed disabled");
+        info!("Animation clock speed enabled");
     }
 
     pub fn disable(&self) {


### PR DESCRIPTION
The enable method previously logged "disabled" by mistake. Changed to
"enabled" to reflect actual behavior.