### PR TITLE
fix(components): Use day index as key rather than day in calendar component

### DIFF
--- a/crates/freya-components/src/calendar.rs
+++ b/crates/freya-components/src/calendar.rs
@@ -309,7 +309,6 @@ impl Component for Calendar {
             };
 
             CalendarDay::new()
-                .key(i)
                 .day(day)
                 .background(bg)
                 .hover_background(hover_bg)


### PR DESCRIPTION
Otherwise the days might get duplicates keys (you might get between 1 and 2 numbers of month days at once sometimes)