### PR TITLE
chore(core): Include `Adwaita Sans` in default fonts of Linux

### DIFF
--- a/crates/freya-core/src/style/default_fonts.rs
+++ b/crates/freya-core/src/style/default_fonts.rs
@@ -9,7 +9,7 @@ pub fn default_fonts() -> Vec<Cow<'static, str>> {
         fonts.insert(0, ".AppleSystemUIFont".into());
     } else if cfg!(target_os = "linux") {
         fonts.insert(0, "Ubuntu".into());
-        fonts.insert(1, "Inter".into());
+        fonts.insert(1, "Adwaita Sans".into());
     } else if cfg!(target_os = "android") {
         fonts.insert(0, "Roboto".into());
     }

--- a/crates/freya-core/src/style/default_fonts.rs
+++ b/crates/freya-core/src/style/default_fonts.rs
@@ -9,6 +9,7 @@ pub fn default_fonts() -> Vec<Cow<'static, str>> {
         fonts.insert(0, ".AppleSystemUIFont".into());
     } else if cfg!(target_os = "linux") {
         fonts.insert(0, "Ubuntu".into());
+        fonts.insert(1, "Inter".into());
     } else if cfg!(target_os = "android") {
         fonts.insert(0, "Roboto".into());
     }


### PR DESCRIPTION
GNOME ships with it.