### PR TITLE
fix(winit): Recreate swapchain if size doesnt match

### DIFF
--- a/crates/freya-winit/src/drivers/vulkan.rs
+++ b/crates/freya-winit/src/drivers/vulkan.rs
@@ -380,6 +380,8 @@ impl VulkanDriver {
 
         let result = unsafe { self.swapchain_fns.queue_present(self.queue, &present_info) };
 
+        println!("result: {result:?}");
+
         drop(surface);
 
         if self.swapchain_suboptimal
@@ -387,6 +389,7 @@ impl VulkanDriver {
         {
             self.swapchain_size = size;
             self.recreate_swapchain();
+            window.request_redraw();
         }
     }
 

--- a/crates/freya-winit/src/drivers/vulkan.rs
+++ b/crates/freya-winit/src/drivers/vulkan.rs
@@ -254,6 +254,12 @@ impl VulkanDriver {
             return;
         }
 
+        if self.swapchain_extent.width != size.width || self.swapchain_extent.height != size.height
+        {
+            self.swapchain_size = size;
+            self.recreate_swapchain();
+        }
+
         let mut surface = unsafe {
             self.device
                 .wait_for_fences(&[self.in_flight_fence], true, u64::MAX)

--- a/crates/freya-winit/src/drivers/vulkan.rs
+++ b/crates/freya-winit/src/drivers/vulkan.rs
@@ -380,8 +380,6 @@ impl VulkanDriver {
 
         let result = unsafe { self.swapchain_fns.queue_present(self.queue, &present_info) };
 
-        println!("result: {result:?}");
-
         drop(surface);
 
         if self.swapchain_suboptimal
@@ -389,6 +387,13 @@ impl VulkanDriver {
         {
             self.swapchain_size = size;
             self.recreate_swapchain();
+            window.request_redraw();
+        }
+
+        let latest_size = window.inner_size();
+        if latest_size.width != self.swapchain_extent.width
+            || latest_size.height != self.swapchain_extent.height
+        {
             window.request_redraw();
         }
     }


### PR DESCRIPTION
This is kinda of failsafe in case the render events are not on sync (seems like it might be the case with windows when double clicking the title bar?)