### PR TITLE
fix(pathgraph): Only shift item if filled on insert

### DIFF
--- a/crates/freya-core/tests/diffing.rs
+++ b/crates/freya-core/tests/diffing.rs
@@ -1842,3 +1842,67 @@ fn moved_element_with_deeply_nested_child_type_change() {
     tree.verify_tree_integrity();
     assert_eq!(tree.elements.len(), runner.node_to_scope.len());
 }
+
+/// Frame 1 reorders A's children inside a moved wrapper and inserts a new
+/// sibling in the middle. The PathGraph `insert` semantics used during move
+/// application and deferred additions leave an empty slot in `scope.nodes`
+/// that shifts `a1` from its tree path `[0,1,2]` to `[0,1,3]`.
+///
+/// Frame 2 adds a new grandchild under `a1` at tree path `[0,1,2,0]`. The
+/// diff emits `added = [[0,1,2,0]]`, which is not deferred (no moves), and
+/// `process_addition` looks up the parent `[0,1,2]` in `scope.nodes` — but
+/// that slot holds the leftover empty entry from frame 1, so `nodes.get`
+/// returns `None` and the unwrap at runner.rs L971 fires.
+#[test]
+fn crash_l971_leftover_empty_slot() {
+    fn app() -> Element {
+        let state = use_consume::<State<u8>>();
+        match state() {
+            0 => rect()
+                .child(rect().key(1).child(rect().key(2)).child(rect().key(3)))
+                .child(rect().key(4))
+                .into(),
+            1 => rect()
+                .child(rect().key(4))
+                .child(
+                    rect()
+                        .key(1)
+                        .child(rect().key(3).child(rect()))
+                        .child(rect())
+                        .child(rect().key(2)),
+                )
+                .into(),
+            _ => rect()
+                .child(rect().key(4))
+                .child(
+                    rect()
+                        .key(1)
+                        .child(rect().key(3).child(rect()))
+                        .child(rect())
+                        .child(rect().key(2).child(rect())),
+                )
+                .into(),
+        }
+    }
+
+    let mut runner = Runner::new(app);
+    let mut tree = Tree::default();
+    let mut state = runner.provide_root_context(|| State::create(0u8));
+
+    let mutations = runner.sync_and_update();
+    tree.apply_mutations(mutations);
+    tree.verify_tree_integrity();
+    assert_eq!(tree.elements.len(), runner.node_to_scope.len());
+
+    state.set(1);
+    let mutations = runner.sync_and_update();
+    tree.apply_mutations(mutations);
+    tree.verify_tree_integrity();
+    assert_eq!(tree.elements.len(), runner.node_to_scope.len());
+
+    state.set(2);
+    let mutations = runner.sync_and_update();
+    tree.apply_mutations(mutations);
+    tree.verify_tree_integrity();
+    assert_eq!(tree.elements.len(), runner.node_to_scope.len());
+}

--- a/crates/pathgraph/src/lib.rs
+++ b/crates/pathgraph/src/lib.rs
@@ -19,19 +19,26 @@ impl<V> PathGraphEntry<V> {
         if path.is_empty() {
             self.value = Some(value);
         } else {
-            if self.items.get(path[0] as usize).is_none() {
-                self.items.resize_with(path[0] as usize + 1, || Self {
-                    value: None,
-                    items: Vec::new(),
-                });
-            } else if path.len() == 1 {
-                self.items.insert(
-                    path[0] as usize,
-                    Self {
+            match self.items.get(path[0] as usize) {
+                None => {
+                    self.items.resize_with(path[0] as usize + 1, || Self {
                         value: None,
                         items: Vec::new(),
-                    },
-                );
+                    });
+                }
+                Some(existing) if path.len() == 1 && existing.value.is_some() => {
+                    // Real sibling already here: shift it right and insert.
+                    self.items.insert(
+                        path[0] as usize,
+                        Self {
+                            value: None,
+                            items: Vec::new(),
+                        },
+                    );
+                }
+                // Empty placeholder (`value: None`) or intermediate entry:
+                // fall through and let the recursive call fill it in place.
+                _ => {}
             }
             self.items[path[0] as usize].insert(&path[1..], value)
         }
@@ -41,19 +48,23 @@ impl<V> PathGraphEntry<V> {
         if path.is_empty() {
             *self = entry;
         } else {
-            if self.items.get(path[0] as usize).is_none() {
-                self.items.resize_with(path[0] as usize + 1, || Self {
-                    value: None,
-                    items: Vec::new(),
-                });
-            } else if path.len() == 1 {
-                self.items.insert(
-                    path[0] as usize,
-                    Self {
+            match self.items.get(path[0] as usize) {
+                None => {
+                    self.items.resize_with(path[0] as usize + 1, || Self {
                         value: None,
                         items: Vec::new(),
-                    },
-                );
+                    });
+                }
+                Some(existing) if path.len() == 1 && existing.value.is_some() => {
+                    self.items.insert(
+                        path[0] as usize,
+                        Self {
+                            value: None,
+                            items: Vec::new(),
+                        },
+                    );
+                }
+                _ => {}
             }
             self.items[path[0] as usize].insert_entry(&path[1..], entry)
         }
@@ -403,5 +414,64 @@ impl<V> PathGraph<V> {
         if let Some(entry) = &self.entry {
             entry.traverse_1_level(target, vec![], &mut traverser);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// When a `remove` + `insert_entry` pair leaves a `None`-valued placeholder
+    /// inside an `items` vec, a subsequent `insert` targeting that same slot
+    /// must fill the placeholder in place instead of shifting it right.
+    /// Otherwise later siblings drift to a higher index than their logical
+    /// position and `get` at the intended path returns `None`.
+    #[test]
+    fn insert_fills_placeholder_left_by_move_sequence() {
+        let mut graph = PathGraph::<u32>::new();
+        graph.insert(&[], 0);
+        graph.insert(&[0], 10);
+        graph.insert(&[0, 0], 100);
+        graph.insert(&[0, 1], 200);
+
+        // Simulate the move sequence (1,0), (0,2) that `apply_diff` performs:
+        let a = graph.remove(&[0, 1]).unwrap();
+        graph.insert_entry(&[0, 0], a);
+        let b = graph.remove(&[0, 1]).unwrap();
+        graph.insert_entry(&[0, 2], b);
+
+        // Now [0,1] should be the empty slot the deferred addition targets.
+        assert_eq!(graph.get(&[0, 0]), Some(&200));
+        assert_eq!(graph.get(&[0, 1]), None);
+        assert_eq!(graph.get(&[0, 2]), Some(&100));
+
+        // Fill the placeholder with a deferred addition.
+        graph.insert(&[0, 1], 999);
+
+        // The deferred value lands at its intended position and the existing
+        // siblings stay put instead of drifting one index to the right.
+        assert_eq!(graph.get(&[0, 0]), Some(&200));
+        assert_eq!(graph.get(&[0, 1]), Some(&999));
+        assert_eq!(graph.get(&[0, 2]), Some(&100));
+        assert_eq!(graph.get(&[0, 3]), None);
+        assert_eq!(graph.len(&[0]), Some(3));
+    }
+
+    /// `insert` must still shift real siblings when inserting between
+    /// occupied positions.
+    #[test]
+    fn insert_still_shifts_occupied_siblings() {
+        let mut graph = PathGraph::<u32>::new();
+        graph.insert(&[], 0);
+        graph.insert(&[0], 10);
+        graph.insert(&[0, 0], 100);
+        graph.insert(&[0, 1], 200);
+
+        graph.insert(&[0, 1], 150);
+
+        assert_eq!(graph.get(&[0, 0]), Some(&100));
+        assert_eq!(graph.get(&[0, 1]), Some(&150));
+        assert_eq!(graph.get(&[0, 2]), Some(&200));
+        assert_eq!(graph.len(&[0]), Some(3));
     }
 }

--- a/crates/pathgraph/src/lib.rs
+++ b/crates/pathgraph/src/lib.rs
@@ -26,8 +26,9 @@ impl<V> PathGraphEntry<V> {
                         items: Vec::new(),
                     });
                 }
+                // Only shift on collision with a real sibling; empty
+                // placeholders from prior moves are filled in place.
                 Some(existing) if path.len() == 1 && existing.value.is_some() => {
-                    // Real sibling already here: shift it right and insert.
                     self.items.insert(
                         path[0] as usize,
                         Self {
@@ -36,8 +37,6 @@ impl<V> PathGraphEntry<V> {
                         },
                     );
                 }
-                // Empty placeholder (`value: None`) or intermediate entry:
-                // fall through and let the recursive call fill it in place.
                 _ => {}
             }
             self.items[path[0] as usize].insert(&path[1..], value)
@@ -421,11 +420,8 @@ impl<V> PathGraph<V> {
 mod tests {
     use super::*;
 
-    /// When a `remove` + `insert_entry` pair leaves a `None`-valued placeholder
-    /// inside an `items` vec, a subsequent `insert` targeting that same slot
-    /// must fill the placeholder in place instead of shifting it right.
-    /// Otherwise later siblings drift to a higher index than their logical
-    /// position and `get` at the intended path returns `None`.
+    /// An `insert` targeting a placeholder left by a prior `remove` +
+    /// `insert_entry` pair must fill it in place instead of shifting siblings.
     #[test]
     fn insert_fills_placeholder_left_by_move_sequence() {
         let mut graph = PathGraph::<u32>::new();
@@ -434,22 +430,17 @@ mod tests {
         graph.insert(&[0, 0], 100);
         graph.insert(&[0, 1], 200);
 
-        // Simulate the move sequence (1,0), (0,2) that `apply_diff` performs:
         let a = graph.remove(&[0, 1]).unwrap();
         graph.insert_entry(&[0, 0], a);
         let b = graph.remove(&[0, 1]).unwrap();
         graph.insert_entry(&[0, 2], b);
 
-        // Now [0,1] should be the empty slot the deferred addition targets.
         assert_eq!(graph.get(&[0, 0]), Some(&200));
         assert_eq!(graph.get(&[0, 1]), None);
         assert_eq!(graph.get(&[0, 2]), Some(&100));
 
-        // Fill the placeholder with a deferred addition.
         graph.insert(&[0, 1], 999);
 
-        // The deferred value lands at its intended position and the existing
-        // siblings stay put instead of drifting one index to the right.
         assert_eq!(graph.get(&[0, 0]), Some(&200));
         assert_eq!(graph.get(&[0, 1]), Some(&999));
         assert_eq!(graph.get(&[0, 2]), Some(&100));
@@ -457,8 +448,7 @@ mod tests {
         assert_eq!(graph.len(&[0]), Some(3));
     }
 
-    /// `insert` must still shift real siblings when inserting between
-    /// occupied positions.
+    /// `insert` still shifts when the target slot holds a real sibling.
     #[test]
     fn insert_still_shifts_occupied_siblings() {
         let mut graph = PathGraph::<u32>::new();


### PR DESCRIPTION
This caused a panic in https://github.com/marc2332/freya/blob/cb8222c29824a9a9873ba78105a76321d5b5488c/crates/freya-core/src/runner.rs#L971 because pathgraph was always shifting items when inserting if len was 1, even if the value was a placeholder (caused by a previous resize). So, instead we only shift if there is an actual value, otherwise we assume its a placeholder (caused by a resize) in which case we simply continue without any shifting.