### PR TITLE
feat: Non-panicking version of queries invalidations

### DIFF
--- a/crates/freya-query/src/query.rs
+++ b/crates/freya-query/src/query.rs
@@ -332,7 +332,7 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     pub async fn invalidate_all() {
         let storage = consume_context::<QueriesStorage<Q>>();
 
-        storage.internal_invalidate_all().await;
+        storage.inner_invalidate_all().await;
     }
 
     /// Non-panicking version of [`QueriesStorage::invalidate_all()`]
@@ -341,10 +341,10 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
             return;
         };
 
-        storage.internal_invalidate_all().await;
+        storage.inner_invalidate_all().await;
     }
 
-    async fn internal_invalidate_all(self) {
+    async fn inner_invalidate_all(self) {
         // Get all the queries
         let matching_queries = self.storage.read().clone().into_iter().collect::<Vec<_>>();
         let matching_queries = matching_queries
@@ -362,7 +362,7 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     pub async fn invalidate_matching(matching_keys: Q::Keys) {
         let storage = consume_context::<QueriesStorage<Q>>();
 
-        storage.internal_invalidate_matching(matching_keys).await;
+        storage.inner_invalidate_matching(matching_keys).await;
     }
 
     /// Non-panicking version of [`QueriesStorage::invalidate_matching()`]
@@ -371,10 +371,10 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
             return;
         };
 
-        storage.internal_invalidate_matching(matching_keys).await;
+        storage.inner_invalidate_matching(matching_keys).await;
     }
 
-    async fn internal_invalidate_matching(self, matching_keys: Q::Keys) {
+    async fn inner_invalidate_matching(self, matching_keys: Q::Keys) {
         // Get those queries that match
         let mut matching_queries = Vec::new();
         for (query, data) in self.storage.read().iter() {

--- a/crates/freya-query/src/query.rs
+++ b/crates/freya-query/src/query.rs
@@ -326,18 +326,27 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
         }
     }
 
+    /// Acquires query storage from context and invalidates all queries
+    ///
+    /// Panics if query storage is not in context
     pub async fn invalidate_all() {
+        let storage = consume_context::<QueriesStorage<Q>>();
+
+        storage.internal_invalidate_all().await;
+    }
+
+    /// Non-panicking version of [`Self::invalidate_all()`]
+    pub async fn try_invalidate_all() {
         let Some(storage) = try_consume_context::<QueriesStorage<Q>>() else {
             return;
         };
 
+        storage.internal_invalidate_all().await;
+    }
+
+    async fn internal_invalidate_all(self) {
         // Get all the queries
-        let matching_queries = storage
-            .storage
-            .read()
-            .clone()
-            .into_iter()
-            .collect::<Vec<_>>();
+        let matching_queries = self.storage.read().clone().into_iter().collect::<Vec<_>>();
         let matching_queries = matching_queries
             .iter()
             .map(|(q, d)| (q, d))
@@ -347,14 +356,28 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
         Self::run_queries(&matching_queries).await
     }
 
+    /// Acquires query storage from context and invalidates matching queries
+    ///
+    /// Panics if query storage is not in context
     pub async fn invalidate_matching(matching_keys: Q::Keys) {
+        let storage = consume_context::<QueriesStorage<Q>>();
+
+        storage.internal_invalidate_matching(matching_keys).await;
+    }
+
+    /// Non-panicking version of [`Self::invalidate_matching()`]
+    pub async fn try_invalidate_matching(matching_keys: Q::Keys) {
         let Some(storage) = try_consume_context::<QueriesStorage<Q>>() else {
             return;
         };
 
+        storage.internal_invalidate_matching(matching_keys).await;
+    }
+
+    async fn internal_invalidate_matching(self, matching_keys: Q::Keys) {
         // Get those queries that match
         let mut matching_queries = Vec::new();
-        for (query, data) in storage.storage.read().iter() {
+        for (query, data) in self.storage.read().iter() {
             if query.query.matches(&matching_keys) {
                 matching_queries.push((query.clone(), data.clone()));
             }

--- a/crates/freya-query/src/query.rs
+++ b/crates/freya-query/src/query.rs
@@ -327,7 +327,9 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     }
 
     pub async fn invalidate_all() {
-        let storage = consume_context::<QueriesStorage<Q>>();
+        let Some(storage) = try_consume_context::<QueriesStorage<Q>>() else {
+            return;
+        };
 
         // Get all the queries
         let matching_queries = storage
@@ -346,7 +348,9 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     }
 
     pub async fn invalidate_matching(matching_keys: Q::Keys) {
-        let storage = consume_context::<QueriesStorage<Q>>();
+        let Some(storage) = try_consume_context::<QueriesStorage<Q>>() else {
+            return;
+        };
 
         // Get those queries that match
         let mut matching_queries = Vec::new();

--- a/crates/freya-query/src/query.rs
+++ b/crates/freya-query/src/query.rs
@@ -335,7 +335,7 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
         storage.internal_invalidate_all().await;
     }
 
-    /// Non-panicking version of [`Self::invalidate_all()`]
+    /// Non-panicking version of [`QueriesStorage::invalidate_all()`]
     pub async fn try_invalidate_all() {
         let Some(storage) = try_consume_context::<QueriesStorage<Q>>() else {
             return;
@@ -365,7 +365,7 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
         storage.internal_invalidate_matching(matching_keys).await;
     }
 
-    /// Non-panicking version of [`Self::invalidate_matching()`]
+    /// Non-panicking version of [`QueriesStorage::invalidate_matching()`]
     pub async fn try_invalidate_matching(matching_keys: Q::Keys) {
         let Some(storage) = try_consume_context::<QueriesStorage<Q>>() else {
             return;


### PR DESCRIPTION
Currently you can crash your application if the query being invalidated doesn't exist in the storage. This doesn't make much sense as some mutations can invalidate multiple queries some of which aren't being used currently and may not be initialized in the context.

I changed that behavior so we just ignore the request if the storage is not in context. 