### PR TITLE
fix(core): avoid accidental removal of old hash and SmallVec spill in LRUCache

### DIFF
--- a/crates/freya-core/src/lru_cache.rs
+++ b/crates/freya-core/src/lru_cache.rs
@@ -40,23 +40,16 @@ impl<V, ID: Hash + Eq> LRUCache<V, ID> {
         let mut hasher = FxHasher::default();
         hash_value.hash(&mut hasher);
         let hash = hasher.finish();
-        let mut value = self.map.get_mut(&hash);
 
-        let cache_value = value.as_ref().map(|v| v.1.clone());
+        let cache_value = self.map.get(&hash).map(|v| v.1.clone());
 
         let hashes = self.users.entry(id).or_default();
 
         // New hashed value
         if !hashes.contains(&hash) {
-            if let Some(value) = &mut value {
-                value.0 += 1;
-                hashes.push(hash);
-            }
-
             let index = match hashes.len() {
                 ..=1 => 0,
-                2 => 1,
-                len => len - 2,
+                len => len - 1,
             };
             // Clean the first current hash
             for old_hash in hashes.drain(0..index) {
@@ -69,6 +62,10 @@ impl<V, ID: Hash + Eq> LRUCache<V, ID> {
                 if entry.0 == 0 {
                     self.map.remove(&old_hash);
                 }
+            }
+            if let Some(value) = self.map.get_mut(&hash) {
+                value.0 += 1;
+                hashes.push(hash);
             }
         }
 
@@ -170,5 +167,56 @@ mod test {
         assert!(cache.get(&70).is_some());
         cache.remove(&2);
         assert!(cache.get(&70).is_none());
+    }
+
+    #[test]
+    fn test_keep_old_hash_when_adding_second_hash() {
+        let mut cache = LRUCache::<i32, u64>::default();
+
+        cache
+            .utilize(1, &50)
+            .unwrap_or_else(|| cache.insert(1, &50, 5000));
+        cache
+            .utilize(2, &60)
+            .unwrap_or_else(|| cache.insert(2, &60, 6000));
+
+        assert_eq!(cache.utilize(1, &50), Some(Rc::new(5000)));
+        assert_eq!(cache.utilize(2, &60), Some(Rc::new(6000)));
+
+        cache
+            .utilize(1, &60)
+            .unwrap_or_else(|| cache.insert(1, &60, 6000));
+
+        assert!(cache.get(&50).is_some());
+        assert!(cache.get(&60).is_some());
+
+        let hashes = cache.users.get(&1).unwrap();
+        assert_eq!(hashes.len(), 2);
+    }
+
+    #[test]
+    fn test_smallvec_no_spill_on_third_hash() {
+        let mut cache = LRUCache::<i32, u64>::default();
+
+        cache
+            .utilize(1, &50)
+            .unwrap_or_else(|| cache.insert(1, &50, 5000));
+        cache
+            .utilize(1, &60)
+            .unwrap_or_else(|| cache.insert(1, &60, 6000));
+
+        let hashes = cache.users.get(&1).unwrap();
+        assert!(!hashes.spilled());
+
+        cache
+            .utilize(2, &70)
+            .unwrap_or_else(|| cache.insert(2, &70, 7000));
+        cache
+            .utilize(1, &70)
+            .unwrap_or_else(|| cache.insert(1, &70, 7000));
+
+        let hashes = cache.users.get(&1).unwrap();
+        assert_eq!(hashes.len(), 2);
+        assert!(!hashes.spilled());
     }
 }


### PR DESCRIPTION
This PR fixes two issues in the LRUCache `utilize` function:

1. **Accidental removal of old hash**: When a user's hash list had exactly 1 entry, calling `utilize` with a new second hash would incorrectly remove the first entry entirely, leaving only 1 hash. This caused the cached value to be evicted prematurely if it was only referenced by that user.

**Reproduction Test Case**:
```rust
#[test]
fn test_keep_old_hash_when_adding_second_hash() {
    let mut cache = LRUCache::<i32, u64>::default();

    cache
        .utilize(1, &50)
        .unwrap_or_else(|| cache.insert(1, &50, 5000));
    cache
        .utilize(2, &60)
        .unwrap_or_else(|| cache.insert(2, &60, 6000));
    assert_eq!(cache.utilize(1, &50), Some(Rc::new(5000)));
    assert_eq!(cache.utilize(2, &60), Some(Rc::new(6000)));

    cache
        .utilize(1, &60)
        .unwrap_or_else(|| cache.insert(1, &60, 6000));

    // ❌ Before fix: hash 50 was accidentally removed
    // ✅ After fix: both 50 and 60 are retained
    assert!(cache.get(&50).is_some());
    assert!(cache.get(&60).is_some());

    let hashes = cache.users.get(&1).unwrap();
    assert_eq!(hashes.len(), 2);
}
```
2. **Unnecessary SmallVec heap spill**: The original code would first push a 3rd hash (triggering a heap spill) and then drain back to 2. Since SmallVec does not automatically unspill, the data remained on the heap permanently.

**Verification Test Case**:
```rust
#[test]
fn test_smallvec_no_spill_on_third_hash() {
    let mut cache = LRUCache::<i32, u64>::default();

    cache
        .utilize(1, &50)
        .unwrap_or_else(|| cache.insert(1, &50, 5000));
    cache
        .utilize(1, &60)
        .unwrap_or_else(|| cache.insert(1, &60, 6000));

    let hashes = cache.users.get(&1).unwrap();
    assert!(!hashes.spilled());

    cache
        .utilize(2, &70)
        .unwrap_or_else(|| cache.insert(2, &70, 7000));
    cache
        .utilize(1, &70)
        .unwrap_or_else(|| cache.insert(1, &70, 7000));

    let hashes = cache.users.get(&1).unwrap();
    assert_eq!(hashes.len(), 2);
    // ✅ After fix: still not spilled, since we clean before pushing
    assert!(!hashes.spilled());
}
```


### Changes made:
- Adjusted the match branch from `len => len - 2` to `len => len - 1` to fix the logic bug
- Reordered operations to clean up old hashes *before* pushing new ones, ensuring the SmallVec length never exceeds 2
- Added two test cases:
  - `test_keep_old_hash_when_adding_second_hash`: Verifies the logic fix
  - `test_smallvec_no_spill_on_third_hash`: Verifies no heap spill occurs