### PR TITLE
Fix package name deprecation warnings in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,10 +55,10 @@
           wayland
 
           # WINIT_UNIX_BACKEND=x11
-          xorg.libXcursor
-          xorg.libXrandr
-          xorg.libXi
-          xorg.libX11
+          libxcursor
+          libxrandr
+          libxi
+          libx11
         ];
 
         mkDevShell =


### PR DESCRIPTION
## Description

Fixes deprecation warnings for xorg packages in the nix flake 

## Motivation

Evaluation warnings showed up when entering the dev shell which is annoying

## Checklist

- [X] I have tested my changes.
- [ ] I used AI assistance (e.g. ChatGPT, Copilot, etc.) to write this code.
- [ ] I have added or updated documentation where relevant.
- [ ] I have added or updated tests where relevant.
