### PR TITLE
docs: add/update `Nix` setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,14 @@ cd freya
 
 ### Required Tools
 
+> **Note:** The repository uses two toolchain files: [`rust-toolchain.toml`](./rust-toolchain.toml) for the stable toolchain and [`rust-toolchain-nightly.toml`](./rust-toolchain-nightly.toml) for the nightly toolchain required for formatting.
+
+#### Nix
+
+A [flake.nix](./flake.nix) is included in the repository. Run `nix develop` to enter a dev shell with all required tools and dependencies (stable toolchain). For the nightly toolchain, use `nix develop .#unstable` instead.
+
+#### Without Nix
+
 You will need the following tools installed:
 
 - [Rust](https://www.rust-lang.org/tools/install) (stable and nightly toolchains)
@@ -20,7 +28,7 @@ You will need the following tools installed:
 - [taplo](https://taplo.tamasfe.dev/) - TOML formatter
 - [cargo-nextest](https://nexte.st/) - Test runner
 
-Install nightly Rust (required for formatting):
+Install the nightly toolchain with the version pinned in [`rust-toolchain-nightly.toml`](./rust-toolchain-nightly.toml):
 ```sh
 rustup toolchain install nightly-2026-03-15
 ```

--- a/crates/freya/src/_docs/development_setup.rs
+++ b/crates/freya/src/_docs/development_setup.rs
@@ -31,9 +31,9 @@
 //! sudo dnf install openssl-devel clang-devel systemd-devel gtk3-devel @development-tools -y
 //! ```
 //!
-//! #### NixOS
+//! #### Nix
 //!
-//! Copy this [flake.nix](https://github.com/kuba375/freya-flake) into your project root. Then you can enter a dev shell by `nix develop`.
+//! A [flake.nix](https://github.com/marc2332/freya/blob/main/flake.nix) is included in the repository. Run `nix develop` to enter a dev shell with all required dependencies.
 //!
 //! Don't hesitate to contribute so other distros can be added here.
 //!


### PR DESCRIPTION
## Description

`README` + [`docs`](https://docs.rs/freya/0.3.4/freya/_docs/development_setup/) have been updated for `Nix` users and to reflect latest changes we got with #1791.

## Motivation

Keep docs up-to-date.

## Checklist

- [ ] I have tested my changes.
- [ ] I used AI assistance (e.g. ChatGPT, Copilot, etc.) to write this code.
- [x] I have added or updated documentation where relevant.
- [ ] I have added or updated tests where relevant.
