### PR TITLE
nix: add `cargo-nextest`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1768805593,
-        "narHash": "sha256-PIIapv/qntJyKws2AlvS/o4EkLOI/oK4q3Ou64K6Tk4=",
+        "lastModified": 1777365644,
+        "narHash": "sha256-Z5Q3KNfZQoTrkUgkdrruwM0wB6jaVdM9i3Q6UgcIV9Q=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d7dc5da8b80e79afd19fcffcca2d01af21b7d3b6",
+        "rev": "996ffd25e71cd97add9458da37cc8ec8f9ec6978",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774701658,
-        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768726954,
-        "narHash": "sha256-sJMJ64vN2LaeMJ8C8daD/rmOzqsrTpwVAaykL/J+BG0=",
+        "lastModified": 1777324474,
+        "narHash": "sha256-CydmOyYXLAw4pAo5UHEnNHHeNHS3GmAugFXk0tsGazQ=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "080e70378c543d26a3a817899cb66934ba76360b",
+        "rev": "c2a4de0fe8e7808f07b2db1ecc87238c16bf09ee",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
           pkgs.python3
           pkgs.just
           pkgs.taplo
+          pkgs.cargo-nextest
           pkgs.alejandra
           pkgs.dioxus-cli
         ];


### PR DESCRIPTION
## Description

`cargo-nextest` is needed to run `just t` (tests). In addition: `nix flake update` to update flake dependencies to their latest versions.

## Motivation

<!-- Why did you make this change? (e.g. I encountered a crash, a weird behavior, a missing feature, or I was reading the source code and spotted an improvement) -->

## Checklist

- [x] I have tested my changes by running tests.
- [ ] I used AI assistance (e.g. ChatGPT, Copilot, etc.) to write this code.
- [ ] I have added or updated documentation where relevant.
- [ ] I have added or updated tests where relevant.
