### PR TITLE
feat(components): Custom Cursor Icon for Button component

### DIFF
--- a/crates/freya-components/src/accordion.rs
+++ b/crates/freya-components/src/accordion.rs
@@ -62,12 +62,25 @@ define_theme! {
 #[cfg_attr(feature = "docs",
     doc = embed_doc_image::embed_image!("accordion", "images/gallery_accordion.png")
 )]
-#[derive(Clone, PartialEq, Default)]
+#[derive(Clone, PartialEq)]
 pub struct Accordion {
     pub(crate) theme: Option<AccordionThemePartial>,
     header: Option<Element>,
     children: Vec<Element>,
+    cursor_icon: CursorIcon,
     key: DiffKey,
+}
+
+impl Default for Accordion {
+    fn default() -> Self {
+        Self {
+            theme: None,
+            header: None,
+            children: Vec::new(),
+            cursor_icon: CursorIcon::Pointer,
+            key: DiffKey::default(),
+        }
+    }
 }
 
 impl KeyExt for Accordion {
@@ -85,6 +98,12 @@ impl Accordion {
         self.header = Some(header.into());
         self
     }
+
+    /// Override the cursor icon shown when hovering over this component.
+    pub fn cursor_icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
+        self.cursor_icon = cursor_icon.into();
+        self
+    }
 }
 
 impl ChildrenExt for Accordion {
@@ -97,6 +116,7 @@ impl Component for Accordion {
     fn render(self: &Accordion) -> impl IntoElement {
         let header = use_focus();
         let accordion_theme = get_theme!(&self.theme, AccordionThemePreference, "accordion");
+        let cursor_icon = self.cursor_icon;
         let mut open = use_state(|| false);
         let mut animation = use_animation(move |_conf| {
             AnimNum::new(0., 100.)
@@ -122,7 +142,7 @@ impl Component for Accordion {
                     .alignment(BorderAlignment::Inner),
             )
             .on_pointer_enter(move |_| {
-                Cursor::set(CursorIcon::Pointer);
+                Cursor::set(cursor_icon);
             })
             .on_pointer_leave(move |_| {
                 Cursor::set(CursorIcon::default());

--- a/crates/freya-components/src/accordion.rs
+++ b/crates/freya-components/src/accordion.rs
@@ -62,25 +62,13 @@ define_theme! {
 #[cfg_attr(feature = "docs",
     doc = embed_doc_image::embed_image!("accordion", "images/gallery_accordion.png")
 )]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Default)]
 pub struct Accordion {
     pub(crate) theme: Option<AccordionThemePartial>,
     header: Option<Element>,
     children: Vec<Element>,
     cursor_icon: CursorIcon,
     key: DiffKey,
-}
-
-impl Default for Accordion {
-    fn default() -> Self {
-        Self {
-            theme: None,
-            header: None,
-            children: Vec::new(),
-            cursor_icon: CursorIcon::Pointer,
-            key: DiffKey::default(),
-        }
-    }
 }
 
 impl KeyExt for Accordion {

--- a/crates/freya-components/src/button.rs
+++ b/crates/freya-components/src/button.rs
@@ -140,6 +140,7 @@ pub struct Button {
     layout_variant: ButtonLayoutVariant,
     enabled: bool,
     focusable: bool,
+    cursor_icon: Option<CursorIcon>,
 }
 
 impl Default for Button {
@@ -173,6 +174,7 @@ impl Button {
             elements: Vec::default(),
             enabled: true,
             focusable: true,
+            cursor_icon: None,
             key: DiffKey::None,
         }
     }
@@ -260,6 +262,12 @@ impl Button {
     pub fn flat(self) -> Self {
         self.style_variant(ButtonStyleVariant::Flat)
     }
+
+    /// Override the cursor icon shown when hovering over the button while enabled.
+    pub fn icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
+        self.cursor_icon = Some(cursor_icon.into());
+        self
+    }
 }
 
 impl CornerRadiusExt for Button {
@@ -275,6 +283,7 @@ impl Component for Button {
         let focus_status = use_focus_status(focus);
 
         let enabled = use_reactive(&self.enabled);
+        let cursor_icon = self.cursor_icon.unwrap_or_default();
         use_drop(move || {
             if hovering() {
                 Cursor::set(CursorIcon::default());
@@ -389,7 +398,7 @@ impl Component for Button {
             })
             .on_pointer_enter(move |_| {
                 if enabled() {
-                    Cursor::set(CursorIcon::Pointer);
+                    Cursor::set(cursor_icon);
                 } else {
                     Cursor::set(CursorIcon::NotAllowed);
                 }

--- a/crates/freya-components/src/button.rs
+++ b/crates/freya-components/src/button.rs
@@ -140,7 +140,7 @@ pub struct Button {
     layout_variant: ButtonLayoutVariant,
     enabled: bool,
     focusable: bool,
-    cursor_icon: Option<CursorIcon>,
+    cursor_icon: CursorIcon,
 }
 
 impl Default for Button {
@@ -174,7 +174,7 @@ impl Button {
             elements: Vec::default(),
             enabled: true,
             focusable: true,
-            cursor_icon: None,
+            cursor_icon: CursorIcon::default(),
             key: DiffKey::None,
         }
     }
@@ -264,8 +264,8 @@ impl Button {
     }
 
     /// Override the cursor icon shown when hovering over the button while enabled.
-    pub fn icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
-        self.cursor_icon = Some(cursor_icon.into());
+    pub fn cursor_icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
+        self.cursor_icon = cursor_icon.into();
         self
     }
 }
@@ -283,7 +283,7 @@ impl Component for Button {
         let focus_status = use_focus_status(focus);
 
         let enabled = use_reactive(&self.enabled);
-        let cursor_icon = self.cursor_icon.unwrap_or_default();
+        let cursor_icon = self.cursor_icon;
         use_drop(move || {
             if hovering() {
                 Cursor::set(CursorIcon::default());

--- a/crates/freya-components/src/card.rs
+++ b/crates/freya-components/src/card.rs
@@ -135,7 +135,7 @@ impl Card {
             on_press: None,
             elements: Vec::default(),
             hoverable: false,
-            cursor_icon: CursorIcon::Pointer,
+            cursor_icon: CursorIcon::default(),
             key: DiffKey::None,
         }
     }

--- a/crates/freya-components/src/card.rs
+++ b/crates/freya-components/src/card.rs
@@ -82,6 +82,7 @@ pub struct Card {
     style_variant: CardStyleVariant,
     layout_variant: CardLayoutVariant,
     hoverable: bool,
+    cursor_icon: CursorIcon,
 }
 
 impl Default for Card {
@@ -134,6 +135,7 @@ impl Card {
             on_press: None,
             elements: Vec::default(),
             hoverable: false,
+            cursor_icon: CursorIcon::Pointer,
             key: DiffKey::None,
         }
     }
@@ -198,6 +200,12 @@ impl Card {
     pub fn compact(self) -> Self {
         self.layout_variant(CardLayoutVariant::Compact)
     }
+
+    /// Override the cursor icon shown when hovering over this component while hoverable.
+    pub fn cursor_icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
+        self.cursor_icon = cursor_icon.into();
+        self
+    }
 }
 
 impl Component for Card {
@@ -207,6 +215,7 @@ impl Component for Card {
         let focus_status = use_focus_status(focus);
 
         let is_hoverable = self.hoverable;
+        let cursor_icon = self.cursor_icon;
 
         use_drop(move || {
             if hovering() && is_hoverable {
@@ -281,7 +290,7 @@ impl Component for Card {
             .maybe(is_hoverable, |rect| {
                 rect.on_pointer_enter(move |_| {
                     hovering.set(true);
-                    Cursor::set(CursorIcon::Pointer);
+                    Cursor::set(cursor_icon);
                 })
                 .on_pointer_leave(move |_| {
                     if hovering() {

--- a/crates/freya-components/src/chip.rs
+++ b/crates/freya-components/src/chip.rs
@@ -71,6 +71,7 @@ pub struct Chip {
     on_press: Option<EventHandler<Event<PressEventData>>>,
     selected: bool,
     enabled: bool,
+    cursor_icon: CursorIcon,
     key: DiffKey,
 }
 
@@ -82,6 +83,7 @@ impl Default for Chip {
             on_press: None,
             selected: false,
             enabled: true,
+            cursor_icon: CursorIcon::Pointer,
             key: DiffKey::None,
         }
     }
@@ -115,6 +117,12 @@ impl Chip {
 
     pub fn on_press(mut self, handler: impl Into<EventHandler<Event<PressEventData>>>) -> Self {
         self.on_press = Some(handler.into());
+        self
+    }
+
+    /// Override the cursor icon shown when hovering over this component while enabled.
+    pub fn cursor_icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
+        self.cursor_icon = cursor_icon.into();
         self
     }
 }
@@ -159,6 +167,7 @@ impl Component for Chip {
         } = theme;
 
         let enabled = use_reactive(&self.enabled);
+        let cursor_icon = self.cursor_icon;
         use_drop(move || {
             if status() == ChipStatus::Hovering && enabled() {
                 Cursor::set(CursorIcon::default());
@@ -176,7 +185,7 @@ impl Component for Chip {
         let on_pointer_enter = move |_| {
             status.set(ChipStatus::Hovering);
             if enabled() {
-                Cursor::set(CursorIcon::Pointer);
+                Cursor::set(cursor_icon);
             } else {
                 Cursor::set(CursorIcon::NotAllowed);
             }

--- a/crates/freya-components/src/chip.rs
+++ b/crates/freya-components/src/chip.rs
@@ -83,7 +83,7 @@ impl Default for Chip {
             on_press: None,
             selected: false,
             enabled: true,
-            cursor_icon: CursorIcon::Pointer,
+            cursor_icon: CursorIcon::default(),
             key: DiffKey::None,
         }
     }

--- a/crates/freya-components/src/segmented_button.rs
+++ b/crates/freya-components/src/segmented_button.rs
@@ -80,6 +80,7 @@ pub struct ButtonSegment {
     on_press: Option<EventHandler<Event<PressEventData>>>,
     selected: bool,
     enabled: bool,
+    cursor_icon: CursorIcon,
     key: DiffKey,
 }
 
@@ -97,6 +98,7 @@ impl ButtonSegment {
             on_press: None,
             selected: false,
             enabled: true,
+            cursor_icon: CursorIcon::default(),
             key: DiffKey::None,
         }
     }
@@ -129,6 +131,12 @@ impl ButtonSegment {
 
     pub fn on_press(mut self, on_press: impl Into<EventHandler<Event<PressEventData>>>) -> Self {
         self.on_press = Some(on_press.into());
+        self
+    }
+
+    /// Override the cursor icon shown when hovering over this component while enabled.
+    pub fn cursor_icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
+        self.cursor_icon = cursor_icon.into();
         self
     }
 }
@@ -167,6 +175,7 @@ impl Component for ButtonSegment {
         } = theme;
 
         let enabled = use_reactive(&self.enabled);
+        let cursor_icon = self.cursor_icon;
         use_drop(move || {
             if status() == ButtonSegmentStatus::Hovering && enabled() {
                 Cursor::set(CursorIcon::default());
@@ -184,7 +193,7 @@ impl Component for ButtonSegment {
         let on_pointer_enter = move |_| {
             status.set(ButtonSegmentStatus::Hovering);
             if enabled() {
-                Cursor::set(CursorIcon::Pointer);
+                Cursor::set(cursor_icon);
             } else {
                 Cursor::set(CursorIcon::NotAllowed);
             }

--- a/crates/freya-components/src/select.rs
+++ b/crates/freya-components/src/select.rs
@@ -76,6 +76,7 @@ pub struct Select {
     pub(crate) theme: Option<SelectThemePartial>,
     selected_item: Option<Element>,
     children: Vec<Element>,
+    cursor_icon: CursorIcon,
     key: DiffKey,
 }
 
@@ -103,6 +104,7 @@ impl Select {
             theme: None,
             selected_item: None,
             children: Vec::new(),
+            cursor_icon: CursorIcon::Pointer,
             key: DiffKey::None,
         }
     }
@@ -114,6 +116,12 @@ impl Select {
 
     pub fn selected_item(mut self, item: impl Into<Element>) -> Self {
         self.selected_item = Some(item.into());
+        self
+    }
+
+    /// Override the cursor icon shown when hovering over this component.
+    pub fn cursor_icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
+        self.cursor_icon = cursor_icon.into();
         self
     }
 }
@@ -156,6 +164,7 @@ impl Component for Select {
             }
         });
 
+        let cursor_icon = self.cursor_icon;
         use_drop(move || {
             if status() == SelectStatus::Hovering {
                 Cursor::set(CursorIcon::default());
@@ -187,7 +196,7 @@ impl Component for Select {
 
         let on_pointer_enter = move |_| {
             *status.write() = SelectStatus::Hovering;
-            Cursor::set(CursorIcon::Pointer);
+            Cursor::set(cursor_icon);
         };
 
         let on_pointer_leave = move |_| {

--- a/crates/freya-components/src/select.rs
+++ b/crates/freya-components/src/select.rs
@@ -104,7 +104,7 @@ impl Select {
             theme: None,
             selected_item: None,
             children: Vec::new(),
-            cursor_icon: CursorIcon::Pointer,
+            cursor_icon: CursorIcon::default(),
             key: DiffKey::None,
         }
     }

--- a/crates/freya-components/src/slider.rs
+++ b/crates/freya-components/src/slider.rs
@@ -68,7 +68,7 @@ impl Slider {
             size: Size::fill(),
             direction: Direction::Horizontal,
             enabled: true,
-            cursor_icon: CursorIcon::Pointer,
+            cursor_icon: CursorIcon::default(),
             key: DiffKey::None,
         }
     }

--- a/crates/freya-components/src/slider.rs
+++ b/crates/freya-components/src/slider.rs
@@ -49,6 +49,7 @@ pub struct Slider {
     size: Size,
     direction: Direction,
     enabled: bool,
+    cursor_icon: CursorIcon,
     key: DiffKey,
 }
 
@@ -67,6 +68,7 @@ impl Slider {
             size: Size::fill(),
             direction: Direction::Horizontal,
             enabled: true,
+            cursor_icon: CursorIcon::Pointer,
             key: DiffKey::None,
         }
     }
@@ -95,6 +97,12 @@ impl Slider {
         self.direction = direction;
         self
     }
+
+    /// Override the cursor icon shown when hovering over this component while enabled.
+    pub fn cursor_icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
+        self.cursor_icon = cursor_icon.into();
+        self
+    }
 }
 
 impl Component for Slider {
@@ -107,6 +115,7 @@ impl Component for Slider {
         let mut size = use_state(Area::default);
 
         let enabled = use_reactive(&self.enabled);
+        let cursor_icon = self.cursor_icon;
         use_drop(move || {
             if hovering() {
                 Cursor::set(CursorIcon::default());
@@ -143,7 +152,7 @@ impl Component for Slider {
         let on_pointer_enter = move |_| {
             hovering.set(true);
             if enabled() {
-                Cursor::set(CursorIcon::Pointer);
+                Cursor::set(cursor_icon);
             } else {
                 Cursor::set(CursorIcon::NotAllowed);
             }

--- a/crates/freya-components/src/switch.rs
+++ b/crates/freya-components/src/switch.rs
@@ -99,6 +99,7 @@ pub struct Switch {
     toggled: Readable<bool>,
     on_toggle: Option<EventHandler<()>>,
     enabled: bool,
+    cursor_icon: CursorIcon,
     key: DiffKey,
 }
 
@@ -123,6 +124,7 @@ impl Switch {
             theme_layout: None,
             layout_variant: SwitchLayoutVariant::Normal,
             enabled: true,
+            cursor_icon: CursorIcon::Pointer,
             key: DiffKey::None,
         }
     }
@@ -160,6 +162,12 @@ impl Switch {
     /// Shortcut for [Self::layout_variant] and [SwitchLayoutVariant::Expanded].
     pub fn expanded(self) -> Self {
         self.layout_variant(SwitchLayoutVariant::Expanded)
+    }
+
+    /// Override the cursor icon shown when hovering over this component while enabled.
+    pub fn cursor_icon(mut self, cursor_icon: impl Into<CursorIcon>) -> Self {
+        self.cursor_icon = cursor_icon.into();
+        self
     }
 }
 
@@ -241,6 +249,7 @@ impl Component for Switch {
         let press_size = anim_press.get().value();
 
         let enabled = use_reactive(&self.enabled);
+        let cursor_icon = self.cursor_icon;
         use_drop(move || {
             if hovering() && enabled() {
                 Cursor::set(CursorIcon::default());
@@ -290,7 +299,7 @@ impl Component for Switch {
             .on_pointer_enter(move |_| {
                 hovering.set(true);
                 if enabled() {
-                    Cursor::set(CursorIcon::Pointer);
+                    Cursor::set(cursor_icon);
                 } else {
                     Cursor::set(CursorIcon::NotAllowed);
                 }

--- a/crates/freya-components/src/switch.rs
+++ b/crates/freya-components/src/switch.rs
@@ -124,7 +124,7 @@ impl Switch {
             theme_layout: None,
             layout_variant: SwitchLayoutVariant::Normal,
             enabled: true,
-            cursor_icon: CursorIcon::Pointer,
+            cursor_icon: CursorIcon::default(),
             key: DiffKey::None,
         }
     }


### PR DESCRIPTION
## Description

This PR sets the usual mouse icon as a default for buttons and allows overriding the icon for components setting a cursor icon on mouse overs.

## Motivation
I noticed that buttons currently do not allow changing the icon and the existing `CursorArea` component does not allow changing the icon of a button. See #1833 

## Checklist

- [X] I have tested my changes.
- [X] I used AI assistance (e.g. ChatGPT, Copilot, etc.) to write this code.
- [X] I have added or updated documentation where relevant.
- [ ] I have added or updated tests where relevant.
