### PR TITLE
feat(menu): close on `Escape`

### DIFF
--- a/crates/freya-components/src/menu.rs
+++ b/crates/freya-components/src/menu.rs
@@ -131,9 +131,21 @@ impl ComponentOwned for Menu {
         // Provide the menus ID generator
         use_provide_context(|| State::create(ROOT_MENU.0));
         // Provide the menus stack
-        use_provide_context::<State<Vec<MenuId>>>(|| State::create(vec![ROOT_MENU]));
+        let mut menus =
+            use_provide_context::<State<Vec<MenuId>>>(|| State::create(vec![ROOT_MENU]));
         // Provide this the ROOT Menu ID
         use_provide_context(|| ROOT_MENU);
+
+        let on_close = self.on_close.clone();
+        let on_global_key_down = move |e: Event<KeyboardEventData>| {
+            if e.key == Key::Named(NamedKey::Escape) {
+                if menus.read().len() > 1 {
+                    menus.write().pop();
+                } else if let Some(on_close) = &on_close {
+                    on_close.call(());
+                }
+            }
+        };
 
         rect()
             .layer(Layer::Overlay)
@@ -146,6 +158,7 @@ impl ComponentOwned for Menu {
                     on_close.call(());
                 }
             })
+            .on_global_key_down(on_global_key_down)
             .child(MenuContainer::new().children(self.children))
     }
     fn render_key(&self) -> DiffKey {

--- a/examples/feature_material_design.rs
+++ b/examples/feature_material_design.rs
@@ -43,11 +43,11 @@ fn app() -> impl IntoElement {
         .padding(16.)
         .child(
             Button::new()
-                .on_press(|_| {
+                .on_press(|e: Event<PressEventData>| {
                     if ContextMenu::is_open() {
                         ContextMenu::close();
                     } else {
-                        ContextMenu::open(context_menu());
+                        ContextMenu::open_from_event(&e, context_menu());
                     }
                 })
                 .flat()


### PR DESCRIPTION
## Description

- Close menu/submenu on `ESC`. One at time.
-  Fix `examples/feature_material_design` example: menu requires two clicks/escapes to close (instead of one)

## Motivation

Similar to other desktops apps, e.g. Firefox.

## Checklist

- [x] I have tested my changes.
- [x] I used AI assistance (CLAUDE)
