### PR TITLE
fix(nix): pin `rust-src`/`rust-analyzer`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.94.1"
 profile = "default"
+components = ["rust-src", "rust-analyzer"]


### PR DESCRIPTION
in `rust-toolchain` to ensure to use a version-matched binary instead of a globally installed one (e.g. via Home Manager). 

### Before
```sh
which rustc cargo rustfmt clippy-driver rust-analyzer

/nix/store/mqrmgxyg3i91hmfdp6mmjfk4b73w10sj-rust-1.94.1/bin/rustc
/nix/store/mqrmgxyg3i91hmfdp6mmjfk4b73w10sj-rust-1.94.1/bin/cargo
/nix/store/mqrmgxyg3i91hmfdp6mmjfk4b73w10sj-rust-1.94.1/bin/rustfmt
/nix/store/mqrmgxyg3i91hmfdp6mmjfk4b73w10sj-rust-1.94.1/bin/clippy-driver
/home/{..}/.nix-profile/bin/rust-analyzer   <---- global + another version
```

### Fixed

```sh
which rustc cargo rustfmt clippy-driver rust-analyzer

/nix/store/3lqpvzn26cd2lw6d23jzhmaavmin3r8n-rust-1.94.1/bin/rustc
/nix/store/3lqpvzn26cd2lw6d23jzhmaavmin3r8n-rust-1.94.1/bin/cargo
/nix/store/3lqpvzn26cd2lw6d23jzhmaavmin3r8n-rust-1.94.1/bin/rustfmt
/nix/store/3lqpvzn26cd2lw6d23jzhmaavmin3r8n-rust-1.94.1/bin/clippy-driver
/nix/store/3lqpvzn26cd2lw6d23jzhmaavmin3r8n-rust-1.94.1/bin/rust-analyzer   <---- fixed
```

## Motivation

In other case editors (e.g. Zed in my case) can't run `rust-analyzer` properly.

## Checklist

- [x] I have tested my changes.
