### PR TITLE
feat(components): Remove root theme api and context menu viewer

### DIFF
--- a/crates/freya-components/src/context_menu.rs
+++ b/crates/freya-components/src/context_menu.rs
@@ -16,9 +16,9 @@ pub(crate) enum ContextMenuCloseRequest {
     Pending,
 }
 
-/// Context for managing a global context menu.
+/// Global context menu state.
 ///
-/// Requires a [`ContextMenuViewer`] mounted somewhere in the app tree.
+/// Requires a [`ContextMenuViewer`] in an ancestor scope.
 ///
 /// # Example
 ///
@@ -45,16 +45,12 @@ pub struct ContextMenu {
 }
 
 impl ContextMenu {
-    /// Returns the global [`ContextMenu`] state.
-    ///
     /// # Panics
     ///
-    /// Panics if no [`ContextMenuViewer`] has been mounted in the app tree.
+    /// Panics if no [`ContextMenuViewer`] is mounted in an ancestor scope.
     pub fn get() -> Self {
-        try_consume_root_context().expect(
-            "ContextMenu requires a `ContextMenuViewer` mounted in the app tree. \
-             Add `ContextMenuViewer::new()` somewhere inside your `app` component.",
-        )
+        try_consume_root_context()
+            .expect("ContextMenu requires a `ContextMenuViewer` in an ancestor scope")
     }
 
     pub fn is_open() -> bool {
@@ -97,9 +93,9 @@ impl ContextMenu {
 
 /// Provides the [`ContextMenu`] state and renders the floating menu overlay.
 ///
-/// Mount this component once inside your `app` component to enable [`ContextMenu`].
-/// Placing it inside the app tree (rather than above it) means the rendered menu
-/// inherits any styling applied to the app's root element, e.g. `font_size`.
+/// Mount this as high up in your tree as possible (typically in your `app`
+/// component) so the rendered menu inherits styling like `font_size` from
+/// the app's root element.
 ///
 /// # Example
 ///

--- a/crates/freya-components/src/context_menu.rs
+++ b/crates/freya-components/src/context_menu.rs
@@ -1,8 +1,12 @@
 use freya_core::{
     integration::ScopeId,
+    layers::Layer,
     prelude::*,
 };
-use torin::prelude::CursorPoint;
+use torin::prelude::{
+    CursorPoint,
+    Position,
+};
 
 use crate::menu::Menu;
 
@@ -14,19 +18,23 @@ pub(crate) enum ContextMenuCloseRequest {
 
 /// Context for managing a global context menu.
 ///
+/// Requires a [`ContextMenuViewer`] mounted somewhere in the app tree.
+///
 /// # Example
 ///
 /// ```rust
 /// # use freya::prelude::*;
 /// fn app() -> impl IntoElement {
-///     rect()
-///         .on_secondary_down(move |e: Event<PressEventData>| {
-///             ContextMenu::open_from_event(
-///                 &e,
-///                 Menu::new().child(MenuButton::new().child("Option 1")),
-///             );
-///         })
-///         .child("Right click to open menu")
+///     rect().child(ContextMenuViewer::new()).child(
+///         rect()
+///             .on_secondary_down(move |e: Event<PressEventData>| {
+///                 ContextMenu::open_from_event(
+///                     &e,
+///                     Menu::new().child(MenuButton::new().child("Option 1")),
+///                 );
+///             })
+///             .child("Right click to open menu"),
+///     )
 /// }
 /// ```
 #[derive(Clone, Copy, PartialEq)]
@@ -37,26 +45,20 @@ pub struct ContextMenu {
 }
 
 impl ContextMenu {
+    /// Returns the global [`ContextMenu`] state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no [`ContextMenuViewer`] has been mounted in the app tree.
     pub fn get() -> Self {
-        match try_consume_root_context() {
-            Some(rt) => rt,
-            None => {
-                let context_menu_state = ContextMenu {
-                    location: State::create_in_scope(CursorPoint::default(), ScopeId::ROOT),
-                    menu: State::create_in_scope(None, ScopeId::ROOT),
-                    close_request: State::create_in_scope(
-                        ContextMenuCloseRequest::None,
-                        ScopeId::ROOT,
-                    ),
-                };
-                provide_context_for_scope_id(context_menu_state, ScopeId::ROOT);
-                context_menu_state
-            }
-        }
+        try_consume_root_context().expect(
+            "ContextMenu requires a `ContextMenuViewer` mounted in the app tree. \
+             Add `ContextMenuViewer::new()` somewhere inside your `app` component.",
+        )
     }
 
     pub fn is_open() -> bool {
-        Self::get().menu.read().is_some()
+        try_consume_root_context::<Self>().is_some_and(|c| c.menu.read().is_some())
     }
 
     /// Open the context menu with the given menu.
@@ -87,6 +89,85 @@ impl ContextMenu {
     }
 
     pub fn close() {
-        Self::get().menu.set(None);
+        if let Some(mut this) = try_consume_root_context::<Self>() {
+            this.menu.set(None);
+        }
+    }
+}
+
+/// Provides the [`ContextMenu`] state and renders the floating menu overlay.
+///
+/// Mount this component once inside your `app` component to enable [`ContextMenu`].
+/// Placing it inside the app tree (rather than above it) means the rendered menu
+/// inherits any styling applied to the app's root element, e.g. `font_size`.
+///
+/// # Example
+///
+/// ```rust
+/// # use freya::prelude::*;
+/// fn app() -> impl IntoElement {
+///     rect()
+///         .font_size(18.)
+///         .child(ContextMenuViewer::new())
+///         .child("Your app content here")
+/// }
+/// ```
+#[derive(Default, Clone, PartialEq)]
+pub struct ContextMenuViewer {
+    key: DiffKey,
+}
+
+impl KeyExt for ContextMenuViewer {
+    fn write_key(&mut self) -> &mut DiffKey {
+        &mut self.key
+    }
+}
+
+impl ContextMenuViewer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ComponentOwned for ContextMenuViewer {
+    fn render(self) -> impl IntoElement {
+        let mut context = use_hook(|| {
+            try_consume_root_context::<ContextMenu>().unwrap_or_else(|| {
+                let state = ContextMenu {
+                    location: State::create_in_scope(CursorPoint::default(), ScopeId::ROOT),
+                    menu: State::create_in_scope(None, ScopeId::ROOT),
+                    close_request: State::create_in_scope(
+                        ContextMenuCloseRequest::None,
+                        ScopeId::ROOT,
+                    ),
+                };
+                provide_context_for_scope_id(state, ScopeId::ROOT);
+                state
+            })
+        });
+
+        rect()
+            .on_global_pointer_move(move |e: Event<PointerEventData>| {
+                context.location.set(e.global_location());
+            })
+            .maybe_child(context.menu.read().clone().map(|(location, menu)| {
+                let location = location.to_f32();
+                rect()
+                    .layer(Layer::Overlay)
+                    .position(Position::new_global().left(location.x).top(location.y))
+                    .child(menu.on_close(move |_| match (context.close_request)() {
+                        ContextMenuCloseRequest::None => {
+                            context.close_request.set(ContextMenuCloseRequest::Pending);
+                        }
+                        ContextMenuCloseRequest::Pending => {
+                            context.menu.set(None);
+                            context.close_request.set(ContextMenuCloseRequest::None);
+                        }
+                    }))
+            }))
+    }
+
+    fn render_key(&self) -> DiffKey {
+        self.key.clone().or(self.default_key())
     }
 }

--- a/crates/freya-components/src/integration.rs
+++ b/crates/freya-components/src/integration.rs
@@ -1,18 +1,10 @@
 use freya_core::{
     integration::AppComponent,
-    layers::Layer,
     prelude::*,
-};
-use torin::prelude::Position;
-
-use crate::context_menu::{
-    ContextMenu,
-    ContextMenuCloseRequest,
 };
 
 pub fn integration(app: AppComponent) -> impl IntoElement {
     let platform = use_hook(Platform::get);
-    let mut context = use_hook(ContextMenu::get);
 
     let on_global_key_down = move |e: Event<KeyboardEventData>| match e.key {
         Key::Named(NamedKey::Tab) if e.modifiers == Modifiers::SHIFT => {
@@ -38,27 +30,5 @@ pub fn integration(app: AppComponent) -> impl IntoElement {
         _ => {}
     };
 
-    let on_global_pointer_move = move |e: Event<PointerEventData>| {
-        context.location.set(e.global_location());
-    };
-
-    rect()
-        .on_global_pointer_move(on_global_pointer_move)
-        .on_global_key_down(on_global_key_down)
-        .child(app)
-        .maybe_child(context.menu.read().clone().map(|(location, menu)| {
-            let location = location.to_f32();
-            rect()
-                .layer(Layer::Overlay)
-                .position(Position::new_global().left(location.x).top(location.y))
-                .child(menu.on_close(move |_| match (context.close_request)() {
-                    ContextMenuCloseRequest::None => {
-                        context.close_request.set(ContextMenuCloseRequest::Pending);
-                    }
-                    ContextMenuCloseRequest::Pending => {
-                        context.menu.set(None);
-                        context.close_request.set(ContextMenuCloseRequest::None);
-                    }
-                }))
-        }))
+    rect().on_global_key_down(on_global_key_down).child(app)
 }

--- a/crates/freya-components/src/theming/hooks.rs
+++ b/crates/freya-components/src/theming/hooks.rs
@@ -1,15 +1,11 @@
-use freya_core::{
-    prelude::{
-        Readable,
-        State,
-        WritableUtils,
-        provide_context,
-        provide_context_for_scope_id,
-        try_consume_context,
-        use_consume,
-        use_hook,
-    },
-    scope_id::ScopeId,
+use freya_core::prelude::{
+    Readable,
+    State,
+    WritableUtils,
+    provide_context,
+    try_consume_context,
+    use_consume,
+    use_hook,
 };
 
 use crate::theming::component_themes::Theme;
@@ -24,20 +20,6 @@ pub fn use_init_theme(theme_cb: impl FnOnce() -> Theme) -> State<Theme> {
         } else {
             let state = State::create(theme_cb());
             provide_context(state);
-            state
-        }
-    })
-}
-
-/// Provides a custom [`Theme`] at the root scope.
-/// If a [`Theme`] context already exists at the root, it reuses it instead of creating a new one.
-pub fn use_init_root_theme(theme_cb: impl FnOnce() -> Theme) -> State<Theme> {
-    use_hook(|| {
-        if let Some(existing) = try_consume_context::<State<Theme>>() {
-            existing
-        } else {
-            let state = State::create_in_scope(theme_cb(), ScopeId::ROOT);
-            provide_context_for_scope_id(state, ScopeId::ROOT);
             state
         }
     })

--- a/crates/freya-devtools-app/src/main.rs
+++ b/crates/freya-devtools-app/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
 }
 
 pub fn app() -> impl IntoElement {
-    use_init_root_theme(dark_theme);
+    use_init_theme(dark_theme);
     use_init_radio_station::<DevtoolsState, DevtoolsChannel>(|| DevtoolsState {
         nodes: HashMap::new(),
         expanded_nodes: HashSet::default(),
@@ -115,6 +115,7 @@ pub fn app() -> impl IntoElement {
         .height(Size::fill())
         .color(Color::WHITE)
         .background((15, 15, 15))
+        .child(ContextMenuViewer::new())
         .child(Router::new(|| {
             RouterConfig::<Route>::default().with_initial_path(Route::TreeInspector {})
         }))

--- a/examples/component_context_menu.rs
+++ b/examples/component_context_menu.rs
@@ -30,17 +30,22 @@ fn context_menu() -> Menu {
 }
 
 fn app() -> impl IntoElement {
-    use_init_root_theme(dark_theme);
+    use_init_theme(dark_theme);
 
-    rect().theme_background().center().expanded().child(
-        Button::new()
-            .on_press(move |e: Event<PressEventData>| {
-                if ContextMenu::is_open() {
-                    ContextMenu::close();
-                } else {
-                    ContextMenu::open_from_event(&e, context_menu())
-                }
-            })
-            .child("Open"),
-    )
+    rect()
+        .theme_background()
+        .center()
+        .expanded()
+        .child(ContextMenuViewer::new())
+        .child(
+            Button::new()
+                .on_press(move |e: Event<PressEventData>| {
+                    if ContextMenu::is_open() {
+                        ContextMenu::close();
+                    } else {
+                        ContextMenu::open_from_event(&e, context_menu())
+                    }
+                })
+                .child("Open"),
+        )
 }

--- a/examples/feature_material_design.rs
+++ b/examples/feature_material_design.rs
@@ -41,6 +41,7 @@ fn app() -> impl IntoElement {
         .expanded()
         .spacing(16.)
         .padding(16.)
+        .child(ContextMenuViewer::new())
         .child(
             Button::new()
                 .on_press(|_| {

--- a/examples/feature_secondary_press.rs
+++ b/examples/feature_secondary_press.rs
@@ -23,9 +23,13 @@ fn app() -> impl IntoElement {
         );
     };
 
-    rect().expanded().center().child(
-        label()
-            .text("Right click to copy")
-            .on_secondary_down(on_secondary_down),
-    )
+    rect()
+        .expanded()
+        .center()
+        .child(ContextMenuViewer::new())
+        .child(
+            label()
+                .text("Right click to copy")
+                .on_secondary_down(on_secondary_down),
+        )
 }

--- a/examples/feature_terminal_canvas.rs
+++ b/examples/feature_terminal_canvas.rs
@@ -36,7 +36,7 @@ fn main() {
 }
 
 fn app() -> impl IntoElement {
-    use_init_root_theme(dark_theme);
+    use_init_theme(dark_theme);
     use_init_radio_station::<AppState, AppChannel>(AppState::default);
     let mut radio = use_radio::<AppState, AppChannel>(AppChannel::Panels);
 

--- a/examples/feature_webview.rs
+++ b/examples/feature_webview.rs
@@ -24,7 +24,7 @@ struct Tab {
 }
 
 fn app() -> impl IntoElement {
-    use_init_root_theme(dark_theme);
+    use_init_theme(dark_theme);
     let mut tabs = use_state(|| {
         vec![Tab {
             id: WebViewId::new(),

--- a/examples/feature_webviews_resizable.rs
+++ b/examples/feature_webviews_resizable.rs
@@ -23,7 +23,7 @@ struct Webview {
 }
 
 fn app() -> impl IntoElement {
-    use_init_root_theme(dark_theme);
+    use_init_theme(dark_theme);
     let mut webviews = use_state(|| {
         vec![Webview {
             id: WebViewId::new(),

--- a/examples/theme_preference.rs
+++ b/examples/theme_preference.rs
@@ -9,7 +9,7 @@ fn main() {
 }
 
 fn app() -> impl IntoElement {
-    let mut theme = use_init_root_theme(|| Platform::get().preferred_theme.read().to_theme());
+    let mut theme = use_init_theme(|| Platform::get().preferred_theme.read().to_theme());
 
     use_side_effect(move || theme.set(Platform::get().preferred_theme.read().to_theme()));
 


### PR DESCRIPTION
- Remove root theme api
- Adds ContextMenuViewer: This way the context menu can be customized using the context theme api or also its text style can be indirectly changed by potential overrides in ancestor elements (e.g app root element)