### PR TITLE
fix(core): Rerun effect cascade if layer changes

### DIFF
--- a/crates/freya-components/src/drag_drop.rs
+++ b/crates/freya-components/src/drag_drop.rs
@@ -124,6 +124,7 @@ impl<T: Clone + PartialEq> Component for DragZone<T> {
                     let (x, y) = position.to_f32().to_tuple();
                     rect()
                         .position(Position::new_global())
+                        .layer(Layer::Overlay)
                         .width(Size::px(0.))
                         .height(Size::px(0.))
                         // Extend by 1. so that the cursor click can reach the drop zone

--- a/crates/freya-core/src/tree.rs
+++ b/crates/freya-core/src/tree.rs
@@ -425,7 +425,7 @@ impl Tree {
                 if flags.intersects(DiffModifies::LAYER) {
                     handle_cascade(&mut layer_cascades);
                 }
-                if flags.intersects(DiffModifies::EFFECT) {
+                if flags.intersects(DiffModifies::EFFECT | DiffModifies::LAYER) {
                     let element = self.elements.get(&node_id).unwrap();
                     // Has data or the parent has state
                     let run_cascade = element.effect().is_some()


### PR DESCRIPTION
this was causing an element with overlay layer to not act like had it.