### PR TITLE
feat: impl IntoReadable for Memo

### DIFF
--- a/crates/freya-core/src/lifecycle/memo.rs
+++ b/crates/freya-core/src/lifecycle/memo.rs
@@ -59,6 +59,12 @@ impl<T: Copy + PartialEq + 'static> Deref for Memo<T> {
     }
 }
 
+impl<T> Memo<T> {
+    pub fn as_state(&self) -> State<T> {
+        self.state
+    }
+}
+
 impl<T: PartialEq> Memo<T> {
     /// Adapted from https://github.com/DioxusLabs/dioxus/blob/a4aef33369894cd6872283d6d7d265303ae63913/packages/signals/src/read.rs#L246
     /// SAFETY: You must call this function directly with `self` as the argument.

--- a/crates/freya-core/src/lifecycle/memo.rs
+++ b/crates/freya-core/src/lifecycle/memo.rs
@@ -31,7 +31,7 @@ pub fn use_memo<T: 'static + PartialEq>(callback: impl FnMut() -> T + 'static) -
 }
 
 pub struct Memo<T> {
-    state: State<T>,
+    pub(crate) state: State<T>,
 }
 
 impl<T: 'static> PartialEq for Memo<T> {
@@ -56,12 +56,6 @@ impl<T: Copy + PartialEq + 'static> Deref for Memo<T> {
 
     fn deref(&self) -> &Self::Target {
         unsafe { Memo::deref_impl(self) }
-    }
-}
-
-impl<T> Memo<T> {
-    pub fn as_state(&self) -> State<T> {
-        self.state
     }
 }
 

--- a/crates/freya-core/src/lifecycle/readable.rs
+++ b/crates/freya-core/src/lifecycle/readable.rs
@@ -137,7 +137,7 @@ impl<T: 'static> IntoReadable<T> for T {
 
 impl<T: 'static> IntoReadable<T> for Memo<T> {
     fn into_readable(self) -> Readable<T> {
-        Readable::from_state(self.as_state())
+        Readable::from_state(self.state)
     }
 }
 

--- a/crates/freya-core/src/lifecycle/readable.rs
+++ b/crates/freya-core/src/lifecycle/readable.rs
@@ -135,8 +135,20 @@ impl<T: 'static> IntoReadable<T> for T {
     }
 }
 
+impl<T: 'static> IntoReadable<T> for Memo<T> {
+    fn into_readable(self) -> Readable<T> {
+        Readable::from_state(self.as_state())
+    }
+}
+
 impl<T> From<State<T>> for Readable<T> {
     fn from(value: State<T>) -> Self {
+        value.into_readable()
+    }
+}
+
+impl<T> From<Memo<T>> for Readable<T> {
+    fn from(value: Memo<T>) -> Self {
         value.into_readable()
     }
 }

--- a/crates/freya/src/_docs/state_management.rs
+++ b/crates/freya/src/_docs/state_management.rs
@@ -402,6 +402,7 @@
 //!
 //! Sources that can be converted to `Readable`:
 //! - [`State<T>`](crate::prelude::State) from `use_state` via [`IntoReadable`](crate::prelude::IntoReadable)
+//! - [`Memo<T>`](crate::prelude::Memo) from `use_memo` via [`IntoReadable`](crate::prelude::IntoReadable)
 //! - [`RadioSlice`](freya_radio::prelude::RadioSlice) from Freya Radio via [`IntoReadable`](crate::prelude::IntoReadable)
 //! - [`Writable<T>`](crate::prelude::Writable) via [`From<Writable<T>>`](crate::prelude::Readable)
 //!


### PR DESCRIPTION
## Description

Adds support for converting `Memo<T>` into a `Readable<T>`, useful for passing down the memoized value to other views.

## Motivation

Currently this must be done manually via the `Readable::new` constructor which adds unnecessary boilerplate.

## Checklist

- [x] I have tested my changes.
- [ ] I used AI assistance (e.g. ChatGPT, Copilot, etc.) to write this code.
- [x] I have added or updated documentation where relevant.
- [ ] I have added or updated tests where relevant.