### PR TITLE
fix(core): Bring back `use_provide_theme` hook

### DIFF
--- a/crates/freya-components/src/theming/hooks.rs
+++ b/crates/freya-components/src/theming/hooks.rs
@@ -25,6 +25,15 @@ pub fn use_init_theme(theme_cb: impl FnOnce() -> Theme) -> State<Theme> {
     })
 }
 
+/// Provides a custom [`Theme`].
+pub fn use_provide_theme(theme_cb: impl FnOnce() -> Theme) -> State<Theme> {
+    use_hook(|| {
+        let state = State::create(theme_cb());
+        provide_context(state);
+        state
+    })
+}
+
 /// Subscribe to [`Theme`] changes.
 pub fn use_theme() -> State<Theme> {
     use_consume::<State<Theme>>()

--- a/examples/website.rs
+++ b/examples/website.rs
@@ -212,7 +212,7 @@ impl Component for Navigation {
 struct Counter;
 impl Component for Counter {
     fn render(&self) -> impl IntoElement {
-        use_init_theme(light_theme);
+        use_provide_theme(light_theme);
         let mut count = use_state(|| 4);
 
         rect()


### PR DESCRIPTION
New name, turns out its useful for e.g website.rs example.