### PR TITLE
chore(components): Allow scroll touch dragging on all platforms

### DIFF
--- a/crates/freya-components/src/scrollviews/scrollview.rs
+++ b/crates/freya-components/src/scrollviews/scrollview.rs
@@ -395,9 +395,9 @@ impl Component for ScrollView {
             }
         };
 
-        let on_touch_start = move |e: Event<TouchEventData>| {
-            if drag_scrolling {
-                drag_origin.set(Some(e.global_location));
+        let on_pointer_down = move |e: Event<PointerEventData>| {
+            if drag_scrolling && matches!(e.data(), PointerEventData::Touch(_)) {
+                drag_origin.set(Some(e.global_location()));
             }
         };
 
@@ -421,7 +421,7 @@ impl Component for ScrollView {
             .on_key_down(on_key_down)
             .on_global_key_up(on_global_key_up)
             .on_global_key_down(on_global_key_down)
-            .on_touch_start(on_touch_start)
+            .on_pointer_down(on_pointer_down)
             .child(
                 rect()
                     .width(container_width)

--- a/crates/freya-components/src/scrollviews/scrollview.rs
+++ b/crates/freya-components/src/scrollviews/scrollview.rs
@@ -96,7 +96,7 @@ impl Default for ScrollView {
             scroll_with_arrows: true,
             scroll_controller: None,
             invert_scroll_wheel: false,
-            drag_scrolling: cfg!(target_os = "android"),
+            drag_scrolling: true,
             key: DiffKey::None,
         }
     }

--- a/crates/freya-components/src/scrollviews/scrollview.rs
+++ b/crates/freya-components/src/scrollviews/scrollview.rs
@@ -395,9 +395,9 @@ impl Component for ScrollView {
             }
         };
 
-        let on_pointer_down = move |e: Event<PointerEventData>| {
+        let on_touch_start = move |e: Event<TouchEventData>| {
             if drag_scrolling {
-                drag_origin.set(Some(e.global_location()));
+                drag_origin.set(Some(e.global_location));
                 a11y_id.request_focus();
                 timeout.reset();
             }
@@ -423,7 +423,7 @@ impl Component for ScrollView {
             .on_key_down(on_key_down)
             .on_global_key_up(on_global_key_up)
             .on_global_key_down(on_global_key_down)
-            .on_pointer_down(on_pointer_down)
+            .on_touch_start(on_touch_start)
             .child(
                 rect()
                     .width(container_width)

--- a/crates/freya-components/src/scrollviews/virtual_scrollview.rs
+++ b/crates/freya-components/src/scrollviews/virtual_scrollview.rs
@@ -146,7 +146,7 @@ impl<B: Fn(usize, &()) -> Element> VirtualScrollView<(), B> {
             scroll_with_arrows: true,
             scroll_controller: Some(scroll_controller),
             invert_scroll_wheel: false,
-            drag_scrolling: cfg!(target_os = "android"),
+            drag_scrolling: true,
             key: DiffKey::None,
         }
     }
@@ -169,7 +169,7 @@ impl<D, B: Fn(usize, &D) -> Element> VirtualScrollView<D, B> {
             scroll_with_arrows: true,
             scroll_controller: None,
             invert_scroll_wheel: false,
-            drag_scrolling: cfg!(target_os = "android"),
+            drag_scrolling: true,
             key: DiffKey::None,
         }
     }
@@ -195,7 +195,7 @@ impl<D, B: Fn(usize, &D) -> Element> VirtualScrollView<D, B> {
             scroll_with_arrows: true,
             scroll_controller: Some(scroll_controller),
             invert_scroll_wheel: false,
-            drag_scrolling: cfg!(target_os = "android"),
+            drag_scrolling: true,
             key: DiffKey::None,
         }
     }
@@ -516,9 +516,9 @@ impl<D: PartialEq + 'static, B: Fn(usize, &D) -> Element + 'static> Component
             }
         };
 
-        let on_pointer_down = move |e: Event<PointerEventData>| {
+        let on_touch_start = move |e: Event<TouchEventData>| {
             if drag_scrolling {
-                drag_origin.set(Some(e.global_location()));
+                drag_origin.set(Some(e.global_location));
                 a11y_id.request_focus();
                 timeout.reset();
             }
@@ -542,7 +542,7 @@ impl<D: PartialEq + 'static, B: Fn(usize, &D) -> Element + 'static> Component
             .on_key_down(on_key_down)
             .on_global_key_up(on_global_key_up)
             .on_global_key_down(on_global_key_down)
-            .on_pointer_down(on_pointer_down)
+            .on_touch_start(on_touch_start)
             .child(
                 rect()
                     .width(container_width)

--- a/crates/freya-components/src/scrollviews/virtual_scrollview.rs
+++ b/crates/freya-components/src/scrollviews/virtual_scrollview.rs
@@ -516,9 +516,9 @@ impl<D: PartialEq + 'static, B: Fn(usize, &D) -> Element + 'static> Component
             }
         };
 
-        let on_touch_start = move |e: Event<TouchEventData>| {
-            if drag_scrolling {
-                drag_origin.set(Some(e.global_location));
+        let on_pointer_down = move |e: Event<PointerEventData>| {
+            if drag_scrolling && matches!(e.data(), PointerEventData::Touch(_)) {
+                drag_origin.set(Some(e.global_location()));
             }
         };
 
@@ -540,7 +540,7 @@ impl<D: PartialEq + 'static, B: Fn(usize, &D) -> Element + 'static> Component
             .on_key_down(on_key_down)
             .on_global_key_up(on_global_key_up)
             .on_global_key_down(on_global_key_down)
-            .on_touch_start(on_touch_start)
+            .on_pointer_down(on_pointer_down)
             .child(
                 rect()
                     .width(container_width)

--- a/crates/freya-components/src/scrollviews/virtual_scrollview.rs
+++ b/crates/freya-components/src/scrollviews/virtual_scrollview.rs
@@ -125,7 +125,7 @@ impl<B: Fn(usize, &()) -> Element> VirtualScrollView<(), B> {
             scroll_with_arrows: true,
             scroll_controller: None,
             invert_scroll_wheel: false,
-            drag_scrolling: cfg!(target_os = "android"),
+            drag_scrolling: true,
             key: DiffKey::None,
         }
     }

--- a/crates/freya-components/tests/scrollview.rs
+++ b/crates/freya-components/tests/scrollview.rs
@@ -178,49 +178,11 @@ pub fn scroll_view_drag_scrolling_release_stops() {
     assert!(content[2].is_visible());
     assert!(!content[3].is_visible());
 
-    // Move cursor further after releasing — should NOT scroll further
+    // Move cursor further after releasing, should NOT scroll further
     test.move_cursor((100., 50.));
     test.sync_and_update();
 
     // Visibility should remain unchanged since drag ended on release
-    assert!(content[0].is_visible());
-    assert!(content[1].is_visible());
-    assert!(content[2].is_visible());
-    assert!(!content[3].is_visible());
-}
-
-#[test]
-pub fn scroll_view_drag_scrolling_disabled_by_default() {
-    fn scroll_view_no_drag_app() -> impl IntoElement {
-        ScrollView::new()
-            .child(rect().height(Size::px(200.)).width(Size::px(200.)))
-            .child(rect().height(Size::px(200.)).width(Size::px(200.)))
-            .child(rect().height(Size::px(200.)).width(Size::px(200.)))
-            .child(rect().height(Size::px(200.)).width(Size::px(200.)))
-    }
-
-    let mut test = launch_test(scroll_view_no_drag_app);
-    let scrollview = test
-        .find(|node, element| {
-            Rect::try_downcast(element)
-                .filter(|rect| rect.accessibility.builder.role() == AccessibilityRole::ScrollView)
-                .map(move |_| node)
-        })
-        .unwrap();
-    let content = scrollview.children()[0].children()[0].children();
-
-    assert!(content[0].is_visible());
-    assert!(!content[3].is_visible());
-
-    // Attempt a drag gesture without drag_scrolling enabled
-    test.press_cursor((100., 400.));
-    test.sync_and_update();
-    test.move_cursor((100., 100.));
-    test.sync_and_update();
-    test.release_cursor((100., 100.));
-    test.sync_and_update();
-
-    // Nothing should have scrolled — visibility unchanged
     assert!(content[0].is_visible());
     assert!(content[1].is_visible());
     assert!(content[2].is_visible());

--- a/crates/freya-components/tests/scrollview.rs
+++ b/crates/freya-components/tests/scrollview.rs
@@ -129,12 +129,9 @@ pub fn scroll_view_drag_scrolling() {
     assert!(!content[3].is_visible());
 
     // Simulate a touch drag: press down on content, drag upward (scroll down)
-    test.press_cursor((100., 400.));
-    test.sync_and_update();
-    test.move_cursor((100., 100.));
-    test.sync_and_update();
-    test.release_cursor((100., 100.));
-    test.sync_and_update();
+    test.press_touch((100., 400.));
+    test.move_touch((100., 100.));
+    test.release_touch((100., 100.));
 
     // After dragging 300px upward, first item should be hidden and last visible
     assert!(!content[0].is_visible());
@@ -165,12 +162,9 @@ pub fn scroll_view_drag_scrolling_release_stops() {
     let content = scrollview.children()[0].children()[0].children();
 
     // Drag down a small amount, then release
-    test.press_cursor((100., 300.));
-    test.sync_and_update();
-    test.move_cursor((100., 200.));
-    test.sync_and_update();
-    test.release_cursor((100., 200.));
-    test.sync_and_update();
+    test.press_touch((100., 300.));
+    test.move_touch((100., 200.));
+    test.release_touch((100., 200.));
 
     // Scrolled 100px: all four items partially in view since content is 800px, viewport 500px
     assert!(content[0].is_visible());
@@ -178,9 +172,8 @@ pub fn scroll_view_drag_scrolling_release_stops() {
     assert!(content[2].is_visible());
     assert!(!content[3].is_visible());
 
-    // Move cursor further after releasing, should NOT scroll further
-    test.move_cursor((100., 50.));
-    test.sync_and_update();
+    // Move touch further after releasing, should NOT scroll further
+    test.move_touch((100., 50.));
 
     // Visibility should remain unchanged since drag ended on release
     assert!(content[0].is_visible());
@@ -218,12 +211,9 @@ pub fn scroll_view_drag_scrolling_horizontal() {
     assert!(!content[3].is_visible());
 
     // Drag left (scroll right) by 300px
-    test.press_cursor((400., 100.));
-    test.sync_and_update();
-    test.move_cursor((100., 100.));
-    test.sync_and_update();
-    test.release_cursor((100., 100.));
-    test.sync_and_update();
+    test.press_touch((400., 100.));
+    test.move_touch((100., 100.));
+    test.release_touch((100., 100.));
 
     // After dragging 300px, first item hidden, last item visible
     assert!(!content[0].is_visible());

--- a/crates/freya-testing/src/lib.rs
+++ b/crates/freya-testing/src/lib.rs
@@ -472,6 +472,39 @@ impl TestingRunner {
         self.sync_and_update();
     }
 
+    pub fn press_touch(&mut self, location: impl Into<CursorPoint>) {
+        self.send_event(PlatformEvent::Touch {
+            name: TouchEventName::TouchStart,
+            location: location.into(),
+            finger_id: 0,
+            phase: TouchPhase::Started,
+            force: None,
+        });
+        self.sync_and_update();
+    }
+
+    pub fn move_touch(&mut self, location: impl Into<CursorPoint>) {
+        self.send_event(PlatformEvent::Touch {
+            name: TouchEventName::TouchMove,
+            location: location.into(),
+            finger_id: 0,
+            phase: TouchPhase::Moved,
+            force: None,
+        });
+        self.sync_and_update();
+    }
+
+    pub fn release_touch(&mut self, location: impl Into<CursorPoint>) {
+        self.send_event(PlatformEvent::Touch {
+            name: TouchEventName::TouchEnd,
+            location: location.into(),
+            finger_id: 0,
+            phase: TouchPhase::Ended,
+            force: None,
+        });
+        self.sync_and_update();
+    }
+
     pub fn scroll(&mut self, cursor: impl Into<CursorPoint>, scroll: impl Into<CursorPoint>) {
         let cursor = cursor.into();
         let scroll = scroll.into();


### PR DESCRIPTION
No reason to only exclude this to Android.