### PR TITLE
feat(core): Cross-platform focus press event

### DIFF
--- a/crates/freya-android/src/lib.rs
+++ b/crates/freya-android/src/lib.rs
@@ -130,16 +130,6 @@ impl Component for AndroidRoot {
             }
         });
 
-        let on_global_pointer_down = move |_: Event<PointerEventData>| {
-            let platform = Platform::get();
-            if let Err(err) = platform.hide_keyboard() {
-                tracing::error!("Failed to hide soft keyboard: {err:?}");
-            }
-        };
-
-        rect()
-            .expanded()
-            .on_global_pointer_down(on_global_pointer_down)
-            .child(self.inner.clone())
+        rect().expanded().child(self.inner.clone())
     }
 }

--- a/crates/freya-android/src/lib.rs
+++ b/crates/freya-android/src/lib.rs
@@ -130,6 +130,6 @@ impl Component for AndroidRoot {
             }
         });
 
-        rect().expanded().child(self.inner.clone())
+        self.inner.clone()
     }
 }

--- a/crates/freya-code-editor/src/editor_line.rs
+++ b/crates/freya-code-editor/src/editor_line.rs
@@ -143,7 +143,7 @@ impl Component for EditorLineUI {
                 paragraph()
                     .holder(holder.read().clone())
                     .on_pointer_move(on_pointer_move)
-                    .on_start_press(on_tap)
+                    .on_focus_press(on_tap)
                     .cursor_color(theme.cursor)
                     .cursor_style(CursorStyle::Block)
                     .cursor_index(cursor_index)

--- a/crates/freya-code-editor/src/editor_line.rs
+++ b/crates/freya-code-editor/src/editor_line.rs
@@ -64,7 +64,7 @@ impl Component for EditorLineUI {
         let on_tap = {
             let mut editor = editor.clone();
             let font_family = font_family.clone();
-            move |e: Event<StartPressEventData>| {
+            move |e: Event<FocusPressEventData>| {
                 let processed = editor.write_if(|mut editor_editor| {
                     editor_editor.process(
                         font_size,

--- a/crates/freya-code-editor/src/editor_line.rs
+++ b/crates/freya-code-editor/src/editor_line.rs
@@ -29,6 +29,7 @@ pub struct EditorLineUI {
     pub(crate) show_whitespace: bool,
     pub(crate) font_family: Cow<'static, str>,
     pub(crate) theme: Readable<EditorTheme>,
+    pub(crate) a11y_id: AccessibilityId,
 }
 
 impl Component for EditorLineUI {
@@ -46,6 +47,7 @@ impl Component for EditorLineUI {
             show_whitespace,
             font_family,
             theme,
+            a11y_id,
         } = self.clone();
 
         let holder = use_state(ParagraphHolder::default);
@@ -59,11 +61,11 @@ impl Component for EditorLineUI {
         let gutter_width = font_size * 5.0;
         let is_line_selected = editor_data.cursor_row() == line_index;
 
-        let on_pointer_down = {
+        let on_tap = {
             let mut editor = editor.clone();
             let font_family = font_family.clone();
-            move |e: Event<PointerEventData>| {
-                editor.write_if(|mut editor_editor| {
+            move |e: Event<StartPressEventData>| {
+                let processed = editor.write_if(|mut editor_editor| {
                     editor_editor.process(
                         font_size,
                         &font_family,
@@ -74,6 +76,9 @@ impl Component for EditorLineUI {
                         },
                     )
                 });
+                if processed {
+                    a11y_id.request_focus();
+                }
             }
         };
 
@@ -137,8 +142,8 @@ impl Component for EditorLineUI {
             .child(
                 paragraph()
                     .holder(holder.read().clone())
-                    .on_pointer_down(on_pointer_down)
                     .on_pointer_move(on_pointer_move)
+                    .on_start_press(on_tap)
                     .cursor_color(theme.cursor)
                     .cursor_style(CursorStyle::Block)
                     .cursor_index(cursor_index)

--- a/crates/freya-code-editor/src/editor_ui.rs
+++ b/crates/freya-code-editor/src/editor_ui.rs
@@ -171,8 +171,6 @@ impl Component for CodeEditor {
         let lines_len = editor_data.metrics.syntax_blocks.len();
 
         let on_pointer_down = move |e: Event<PointerEventData>| {
-            e.prevent_default();
-            e.stop_propagation();
             a11y_id.request_focus();
         };
 

--- a/crates/freya-code-editor/src/editor_ui.rs
+++ b/crates/freya-code-editor/src/editor_ui.rs
@@ -170,10 +170,6 @@ impl Component for CodeEditor {
         let line_height = (font_size * line_height).floor();
         let lines_len = editor_data.metrics.syntax_blocks.len();
 
-        let on_pointer_down = move |_: Event<PointerEventData>| {
-            a11y_id.request_focus();
-        };
-
         let on_key_up = {
             let mut editor = editor.clone();
             let font_family = font_family.clone();
@@ -277,7 +273,6 @@ impl Component for CodeEditor {
                 el.on_key_down(on_key_down).on_key_up(on_key_up)
             })
             .on_global_pointer_press(on_global_pointer_press)
-            .on_pointer_down(on_pointer_down)
             .child(
                 VirtualScrollView::new(move |line_index, _| {
                     EditorLineUI {
@@ -290,6 +285,7 @@ impl Component for CodeEditor {
                         show_whitespace,
                         font_family: font_family.clone(),
                         theme: theme.clone(),
+                        a11y_id,
                     }
                     .into()
                 })

--- a/crates/freya-code-editor/src/editor_ui.rs
+++ b/crates/freya-code-editor/src/editor_ui.rs
@@ -1,13 +1,20 @@
 use std::borrow::Cow;
 
-use freya_components::scrollviews::{ScrollController, ScrollEvent, VirtualScrollView};
+use freya_components::scrollviews::{
+    ScrollController,
+    ScrollEvent,
+    VirtualScrollView,
+};
 use freya_core::prelude::*;
 use freya_edit::EditableEvent;
 
 use crate::{
     editor_data::CodeEditorData,
     editor_line::EditorLineUI,
-    editor_theme::{DEFAULT_EDITOR_THEME, EditorTheme},
+    editor_theme::{
+        DEFAULT_EDITOR_THEME,
+        EditorTheme,
+    },
 };
 
 #[derive(PartialEq, Clone)]

--- a/crates/freya-code-editor/src/editor_ui.rs
+++ b/crates/freya-code-editor/src/editor_ui.rs
@@ -1,20 +1,13 @@
 use std::borrow::Cow;
 
-use freya_components::scrollviews::{
-    ScrollController,
-    ScrollEvent,
-    VirtualScrollView,
-};
+use freya_components::scrollviews::{ScrollController, ScrollEvent, VirtualScrollView};
 use freya_core::prelude::*;
 use freya_edit::EditableEvent;
 
 use crate::{
     editor_data::CodeEditorData,
     editor_line::EditorLineUI,
-    editor_theme::{
-        DEFAULT_EDITOR_THEME,
-        EditorTheme,
-    },
+    editor_theme::{DEFAULT_EDITOR_THEME, EditorTheme},
 };
 
 #[derive(PartialEq, Clone)]
@@ -170,7 +163,7 @@ impl Component for CodeEditor {
         let line_height = (font_size * line_height).floor();
         let lines_len = editor_data.metrics.syntax_blocks.len();
 
-        let on_pointer_down = move |e: Event<PointerEventData>| {
+        let on_pointer_down = move |_: Event<PointerEventData>| {
             a11y_id.request_focus();
         };
 

--- a/crates/freya-components/src/input.rs
+++ b/crates/freya-components/src/input.rs
@@ -454,7 +454,7 @@ impl Component for Input {
             editable.process_event(EditableEvent::KeyUp { key: &e.key });
         };
 
-        let on_input_start_press = move |e: Event<StartPressEventData>| {
+        let on_input_focus_press = move |e: Event<StartPressEventData>| {
             e.stop_propagation();
             e.prevent_default();
             is_dragging.set(true);
@@ -472,7 +472,7 @@ impl Component for Input {
             a11y_id.request_focus();
         };
 
-        let on_start_press = move |e: Event<StartPressEventData>| {
+        let on_focus_press = move |e: Event<StartPressEventData>| {
             e.stop_propagation();
             e.prevent_default();
             is_dragging.set(true);
@@ -608,7 +608,7 @@ impl Component for Input {
             .maybe(self.enabled, |el| {
                 el.on_key_up(on_key_up)
                     .on_key_down(on_key_down)
-                    .on_start_press(on_input_start_press)
+                    .on_focus_press(on_input_focus_press)
                     .on_ime_preedit(on_ime_preedit)
                     .on_pointer_press(on_pointer_press)
                     .on_global_pointer_press(on_global_pointer_press)
@@ -641,7 +641,7 @@ impl Component for Input {
                             .min_width(Size::func(move |context| {
                                 Some(context.parent - theme_layout.inner_margin.horizontal())
                             }))
-                            .maybe(self.enabled, |el| el.on_start_press(on_start_press))
+                            .maybe(self.enabled, |el| el.on_focus_press(on_focus_press))
                             .margin(theme_layout.inner_margin)
                             .cursor_index(cursor_index)
                             .cursor_color(cursor_color)

--- a/crates/freya-components/src/input.rs
+++ b/crates/freya-components/src/input.rs
@@ -454,7 +454,7 @@ impl Component for Input {
             editable.process_event(EditableEvent::KeyUp { key: &e.key });
         };
 
-        let on_input_focus_press = move |e: Event<StartPressEventData>| {
+        let on_input_focus_press = move |e: Event<FocusPressEventData>| {
             e.stop_propagation();
             e.prevent_default();
             is_dragging.set(true);
@@ -472,7 +472,7 @@ impl Component for Input {
             a11y_id.request_focus();
         };
 
-        let on_focus_press = move |e: Event<StartPressEventData>| {
+        let on_focus_press = move |e: Event<FocusPressEventData>| {
             e.stop_propagation();
             e.prevent_default();
             is_dragging.set(true);

--- a/crates/freya-components/src/input.rs
+++ b/crates/freya-components/src/input.rs
@@ -454,7 +454,7 @@ impl Component for Input {
             editable.process_event(EditableEvent::KeyUp { key: &e.key });
         };
 
-        let on_input_pointer_down = move |e: Event<PointerEventData>| {
+        let on_input_start_press = move |e: Event<StartPressEventData>| {
             e.stop_propagation();
             e.prevent_default();
             is_dragging.set(true);
@@ -472,7 +472,7 @@ impl Component for Input {
             a11y_id.request_focus();
         };
 
-        let on_pointer_down = move |e: Event<PointerEventData>| {
+        let on_start_press = move |e: Event<StartPressEventData>| {
             e.stop_propagation();
             e.prevent_default();
             is_dragging.set(true);
@@ -608,7 +608,7 @@ impl Component for Input {
             .maybe(self.enabled, |el| {
                 el.on_key_up(on_key_up)
                     .on_key_down(on_key_down)
-                    .on_pointer_down(on_input_pointer_down)
+                    .on_start_press(on_input_start_press)
                     .on_ime_preedit(on_ime_preedit)
                     .on_pointer_press(on_pointer_press)
                     .on_global_pointer_press(on_global_pointer_press)
@@ -641,7 +641,7 @@ impl Component for Input {
                             .min_width(Size::func(move |context| {
                                 Some(context.parent - theme_layout.inner_margin.horizontal())
                             }))
-                            .maybe(self.enabled, |el| el.on_pointer_down(on_pointer_down))
+                            .maybe(self.enabled, |el| el.on_start_press(on_start_press))
                             .margin(theme_layout.inner_margin)
                             .cursor_index(cursor_index)
                             .cursor_color(cursor_color)

--- a/crates/freya-components/src/scrollviews/scrollview.rs
+++ b/crates/freya-components/src/scrollviews/scrollview.rs
@@ -290,6 +290,7 @@ impl Component for ScrollView {
                     dragging_content.set(Some(coords));
                     e.prevent_default();
                     timeout.reset();
+                    a11y_id.request_focus();
                     return;
                 } else if let Some(origin) = drag_origin() {
                     let coords = e.global_location();
@@ -310,6 +311,7 @@ impl Component for ScrollView {
                         dragging_content.set(Some(coords));
                         e.prevent_default();
                         timeout.reset();
+                        a11y_id.request_focus();
                     }
                     return;
                 }
@@ -344,9 +346,7 @@ impl Component for ScrollView {
             if clicking_scrollbar.is_some() {
                 e.prevent_default();
                 timeout.reset();
-                if !a11y_id.is_focused() {
-                    a11y_id.request_focus();
-                }
+                a11y_id.request_focus();
             }
         };
 
@@ -398,8 +398,6 @@ impl Component for ScrollView {
         let on_pointer_down = move |e: Event<PointerEventData>| {
             if drag_scrolling {
                 drag_origin.set(Some(e.global_location()));
-                a11y_id.request_focus();
-                timeout.reset();
             }
         };
 

--- a/crates/freya-components/src/scrollviews/virtual_scrollview.rs
+++ b/crates/freya-components/src/scrollviews/virtual_scrollview.rs
@@ -377,6 +377,7 @@ impl<D: PartialEq + 'static, B: Fn(usize, &D) -> Element + 'static> Component
                     dragging_content.set(Some(coords));
                     e.prevent_default();
                     timeout.reset();
+                    a11y_id.request_focus();
                     return;
                 } else if let Some(origin) = drag_origin() {
                     let coords = e.global_location();
@@ -397,6 +398,7 @@ impl<D: PartialEq + 'static, B: Fn(usize, &D) -> Element + 'static> Component
                         dragging_content.set(Some(coords));
                         e.prevent_default();
                         timeout.reset();
+                        a11y_id.request_focus();
                     }
                     return;
                 }
@@ -519,8 +521,6 @@ impl<D: PartialEq + 'static, B: Fn(usize, &D) -> Element + 'static> Component
         let on_pointer_down = move |e: Event<PointerEventData>| {
             if drag_scrolling {
                 drag_origin.set(Some(e.global_location()));
-                a11y_id.request_focus();
-                timeout.reset();
             }
         };
 

--- a/crates/freya-components/src/scrollviews/virtual_scrollview.rs
+++ b/crates/freya-components/src/scrollviews/virtual_scrollview.rs
@@ -433,9 +433,7 @@ impl<D: PartialEq + 'static, B: Fn(usize, &D) -> Element + 'static> Component
             if clicking_scrollbar.is_some() {
                 e.prevent_default();
                 timeout.reset();
-                if !a11y_id.is_focused() {
-                    a11y_id.request_focus();
-                }
+                a11y_id.request_focus();
             }
         };
 

--- a/crates/freya-core/src/elements/extensions.rs
+++ b/crates/freya-core/src/elements/extensions.rs
@@ -338,7 +338,7 @@ pub trait EventHandlersExt: Sized {
     /// - **Started clicking**: There is a `MouseDown` event (Left button)
     /// - **Touched**: There is a `TouchEnd` event in the same element that there had been a `TouchStart` just before
     ///
-    /// This event is intended to focus elements.
+    /// This event is intended to focus elements such as text inputs following each platform style.
     fn on_focus_press(
         self,
         on_focus_press: impl Into<EventHandler<Event<FocusPressEventData>>>,

--- a/crates/freya-core/src/elements/extensions.rs
+++ b/crates/freya-core/src/elements/extensions.rs
@@ -336,15 +336,17 @@ pub trait EventHandlersExt: Sized {
     }
     /// Gets triggered when:
     /// - **Started clicking**: There is a `MouseDown` event (Left button)
-    /// - **Started touching**: There is a `TouchStart` event
-    fn on_start_press(
+    /// - **Touched**: There is a `TouchEnd` event in the same element that there had been a `TouchStart` just before
+    ///
+    /// This event is intended to focus elements.
+    fn on_focus_press(
         self,
-        on_start_press: impl Into<EventHandler<Event<StartPressEventData>>>,
+        on_focus_press: impl Into<EventHandler<Event<StartPressEventData>>>,
     ) -> Self {
-        let on_start_press = on_start_press.into();
+        let on_focus_press = on_focus_press.into();
         if cfg!(target_os = "android") {
             self.on_pointer_press({
-                let on_start_press = on_start_press.clone();
+                let on_focus_press = on_focus_press.clone();
                 move |e: Event<PointerEventData>| {
                     let event = e.try_map(|d| match d {
                         PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
@@ -354,13 +356,13 @@ pub trait EventHandlersExt: Sized {
                         _ => None,
                     });
                     if let Some(event) = event {
-                        on_start_press.call(event);
+                        on_focus_press.call(event);
                     }
                 }
             })
         } else {
             self.on_pointer_down({
-                let on_start_press = on_start_press.clone();
+                let on_focus_press = on_focus_press.clone();
                 move |e: Event<PointerEventData>| {
                     let event = e.try_map(|d| match d {
                         PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
@@ -370,7 +372,7 @@ pub trait EventHandlersExt: Sized {
                         _ => None,
                     });
                     if let Some(event) = event {
-                        on_start_press.call(event);
+                        on_focus_press.call(event);
                     }
                 }
             })

--- a/crates/freya-core/src/elements/extensions.rs
+++ b/crates/freya-core/src/elements/extensions.rs
@@ -345,35 +345,29 @@ pub trait EventHandlersExt: Sized {
     ) -> Self {
         let on_focus_press = on_focus_press.into();
         if cfg!(target_os = "android") {
-            self.on_pointer_press({
-                let on_focus_press = on_focus_press.clone();
-                move |e: Event<PointerEventData>| {
-                    let event = e.try_map(|d| match d {
-                        PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
-                            Some(StartPressEventData::Mouse(m))
-                        }
-                        PointerEventData::Touch(t) => Some(StartPressEventData::Touch(t)),
-                        _ => None,
-                    });
-                    if let Some(event) = event {
-                        on_focus_press.call(event);
+            self.on_pointer_press(move |e: Event<PointerEventData>| {
+                let event = e.try_map(|d| match d {
+                    PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
+                        Some(StartPressEventData::Mouse(m))
                     }
+                    PointerEventData::Touch(t) => Some(StartPressEventData::Touch(t)),
+                    _ => None,
+                });
+                if let Some(event) = event {
+                    on_focus_press.call(event);
                 }
             })
         } else {
-            self.on_pointer_down({
-                let on_focus_press = on_focus_press.clone();
-                move |e: Event<PointerEventData>| {
-                    let event = e.try_map(|d| match d {
-                        PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
-                            Some(StartPressEventData::Mouse(m))
-                        }
-                        PointerEventData::Touch(t) => Some(StartPressEventData::Touch(t)),
-                        _ => None,
-                    });
-                    if let Some(event) = event {
-                        on_focus_press.call(event);
+            self.on_pointer_down(move |e: Event<PointerEventData>| {
+                let event = e.try_map(|d| match d {
+                    PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
+                        Some(StartPressEventData::Mouse(m))
                     }
+                    PointerEventData::Touch(t) => Some(StartPressEventData::Touch(t)),
+                    _ => None,
+                });
+                if let Some(event) = event {
+                    on_focus_press.call(event);
                 }
             })
         }

--- a/crates/freya-core/src/elements/extensions.rs
+++ b/crates/freya-core/src/elements/extensions.rs
@@ -341,16 +341,16 @@ pub trait EventHandlersExt: Sized {
     /// This event is intended to focus elements.
     fn on_focus_press(
         self,
-        on_focus_press: impl Into<EventHandler<Event<StartPressEventData>>>,
+        on_focus_press: impl Into<EventHandler<Event<FocusPressEventData>>>,
     ) -> Self {
         let on_focus_press = on_focus_press.into();
         if cfg!(target_os = "android") {
             self.on_pointer_press(move |e: Event<PointerEventData>| {
                 let event = e.try_map(|d| match d {
                     PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
-                        Some(StartPressEventData::Mouse(m))
+                        Some(FocusPressEventData::Mouse(m))
                     }
-                    PointerEventData::Touch(t) => Some(StartPressEventData::Touch(t)),
+                    PointerEventData::Touch(t) => Some(FocusPressEventData::Touch(t)),
                     _ => None,
                 });
                 if let Some(event) = event {
@@ -361,9 +361,9 @@ pub trait EventHandlersExt: Sized {
             self.on_pointer_down(move |e: Event<PointerEventData>| {
                 let event = e.try_map(|d| match d {
                     PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
-                        Some(StartPressEventData::Mouse(m))
+                        Some(FocusPressEventData::Mouse(m))
                     }
-                    PointerEventData::Touch(t) => Some(StartPressEventData::Touch(t)),
+                    PointerEventData::Touch(t) => Some(FocusPressEventData::Touch(t)),
                     _ => None,
                 });
                 if let Some(event) = event {
@@ -375,12 +375,12 @@ pub trait EventHandlersExt: Sized {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum StartPressEventData {
+pub enum FocusPressEventData {
     Mouse(MouseEventData),
     Touch(TouchEventData),
 }
 
-impl StartPressEventData {
+impl FocusPressEventData {
     pub fn global_location(&self) -> CursorPoint {
         match self {
             Self::Mouse(m) => m.global_location,

--- a/crates/freya-core/src/elements/extensions.rs
+++ b/crates/freya-core/src/elements/extensions.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use paste::paste;
+use ragnarok::CursorPoint;
 use rustc_hash::{
     FxHashMap,
     FxHasher,
@@ -320,13 +321,11 @@ pub trait EventHandlersExt: Sized {
         self.on_pointer_press({
             let on_press = on_press.clone();
             move |e: Event<PointerEventData>| {
-                let event = e.try_map(|d| match d {
-                    PointerEventData::Mouse(m) => Some(PressEventData::Mouse(m)),
-                    PointerEventData::Touch(t) => Some(PressEventData::Touch(t)),
+                let event = e.map(|d| match d {
+                    PointerEventData::Mouse(m) => PressEventData::Mouse(m),
+                    PointerEventData::Touch(t) => PressEventData::Touch(t),
                 });
-                if let Some(event) = event {
-                    on_press.call(event);
-                }
+                on_press.call(event);
             }
         })
         .on_key_down(move |e: Event<KeyboardEventData>| {
@@ -334,6 +333,77 @@ pub trait EventHandlersExt: Sized {
                 on_press.call(e.map(PressEventData::Keyboard))
             }
         })
+    }
+    /// Gets triggered when:
+    /// - **Started clicking**: There is a `MouseDown` event (Left button)
+    /// - **Started touching**: There is a `TouchStart` event
+    fn on_start_press(
+        self,
+        on_start_press: impl Into<EventHandler<Event<StartPressEventData>>>,
+    ) -> Self {
+        let on_start_press = on_start_press.into();
+        if cfg!(target_os = "android") {
+            self.on_pointer_press({
+                let on_start_press = on_start_press.clone();
+                move |e: Event<PointerEventData>| {
+                    let event = e.try_map(|d| match d {
+                        PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
+                            Some(StartPressEventData::Mouse(m))
+                        }
+                        PointerEventData::Touch(t) => Some(StartPressEventData::Touch(t)),
+                        _ => None,
+                    });
+                    if let Some(event) = event {
+                        on_start_press.call(event);
+                    }
+                }
+            })
+        } else {
+            self.on_pointer_down({
+                let on_start_press = on_start_press.clone();
+                move |e: Event<PointerEventData>| {
+                    let event = e.try_map(|d| match d {
+                        PointerEventData::Mouse(m) if m.button == Some(MouseButton::Left) => {
+                            Some(StartPressEventData::Mouse(m))
+                        }
+                        PointerEventData::Touch(t) => Some(StartPressEventData::Touch(t)),
+                        _ => None,
+                    });
+                    if let Some(event) = event {
+                        on_start_press.call(event);
+                    }
+                }
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum StartPressEventData {
+    Mouse(MouseEventData),
+    Touch(TouchEventData),
+}
+
+impl StartPressEventData {
+    pub fn global_location(&self) -> CursorPoint {
+        match self {
+            Self::Mouse(m) => m.global_location,
+            Self::Touch(t) => t.global_location,
+        }
+    }
+
+    pub fn element_location(&self) -> CursorPoint {
+        match self {
+            Self::Mouse(m) => m.element_location,
+            Self::Touch(t) => t.element_location,
+        }
+    }
+
+    pub fn button(&self) -> Option<MouseButton> {
+        match self {
+            Self::Mouse(m) => m.button,
+            Self::Touch(_) => None,
+        }
     }
 }
 


### PR DESCRIPTION
adds a new `on_focus_press` event, on desktop this is `on_pointer_down` and in android this is `on_pointer_press`, this way one can focus elements using the correct platform behavior.