### PR TITLE
Anonymous contribution via gitGost

### DIFF
--- a/crates/freya-icons/build.rs
+++ b/crates/freya-icons/build.rs
@@ -8,6 +8,7 @@ fn main() {
 }
 
 fn generate(name: &str, path: &str) {
+	fs::create_dir_all(path);
     let out_dir = std::env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join(name).with_extension("rs");
 


### PR DESCRIPTION
bugfix
cmd: cargo run --example animation_portal
err:
freya_src/target/debug/build/freya-icons-5aea4c134082f337/build-script-build` (exit status: 101)
  --- stderr

  thread main (7898) panicked at crates/freya-icons/build.rs:16:37:
  Failed to read icons directory: Os { code: 2, kind: NotFound, message: "No such file or directory" }

exp: something deletes that folder, adding mkdir to build.rs


---

*This is an anonymous contribution made via [gitGost](https://gitgost.leapcell.app).*

*The original author's identity has been anonymized to protect their privacy.*