### PR TITLE
fix(core): Properly opt-out of events when using interactive No

### DIFF
--- a/crates/freya-core/src/data.rs
+++ b/crates/freya-core/src/data.rs
@@ -375,7 +375,6 @@ impl EffectState {
                 }
             }
 
-            // Opt-out only.
             if effect_data.interactive == Interactive::No {
                 self.interactive = Interactive::No;
             }

--- a/crates/freya-core/src/data.rs
+++ b/crates/freya-core/src/data.rs
@@ -375,7 +375,10 @@ impl EffectState {
                 }
             }
 
-            self.interactive = effect_data.interactive;
+            // Opt-out only.
+            if effect_data.interactive == Interactive::No {
+                self.interactive = Interactive::No;
+            }
         }
     }
 

--- a/crates/freya-core/src/events/measurer.rs
+++ b/crates/freya-core/src/events/measurer.rs
@@ -97,13 +97,15 @@ impl ragnarok::EventsMeasurer for EventsMeasurerAdapter<'_> {
 
     fn is_node_transparent(&self, key: &Self::Key) -> bool {
         let element = self.tree.elements.get(key).unwrap();
-        if element.style().background == Fill::Color(Color::TRANSPARENT) {
-            return true;
-        }
-        if let Some(effect_state) = self.tree.effect_state.get(key) {
-            return effect_state.interactive == Interactive::No;
-        }
-        false
+        element.style().background == Fill::Color(Color::TRANSPARENT)
+    }
+
+    fn is_node_interactive(&self, key: &Self::Key) -> bool {
+        self.tree
+            .effect_state
+            .get(key)
+            .map(|effect_state| effect_state.interactive != Interactive::No)
+            .unwrap_or(true)
     }
 
     fn try_area_of(&self, key: &Self::Key) -> Option<ragnarok::Area> {

--- a/crates/freya-core/src/events/measurer.rs
+++ b/crates/freya-core/src/events/measurer.rs
@@ -104,7 +104,7 @@ impl ragnarok::EventsMeasurer for EventsMeasurerAdapter<'_> {
         self.tree
             .effect_state
             .get(key)
-            .map(|effect_state| effect_state.interactive != Interactive::No)
+            .map(|effect_state| effect_state.interactive == Interactive::Yes)
             .unwrap_or(true)
     }
 

--- a/crates/freya-core/tests/interactive.rs
+++ b/crates/freya-core/tests/interactive.rs
@@ -37,7 +37,6 @@ fn interactive_false_passes_events_through() {
 
     assert!(
         test.find(|_, e| Label::try_downcast(e).filter(|l| l.text.as_ref() == "behind:1 overlay:0"))
-            .is_some(),
-        "click should reach the node behind and nothing in the interactive(false) subtree"
+            .is_some()
     );
 }

--- a/crates/freya-core/tests/interactive.rs
+++ b/crates/freya-core/tests/interactive.rs
@@ -1,0 +1,43 @@
+use freya::prelude::*;
+use freya_testing::prelude::*;
+
+#[test]
+fn interactive_false_passes_events_through() {
+    fn app() -> impl IntoElement {
+        let mut behind = use_state(|| 0);
+        let mut overlay = use_state(|| 0);
+
+        rect()
+            .width(Size::percent(100.))
+            .height(Size::percent(100.))
+            .child(
+                rect()
+                    .expanded()
+                    .background(Color::RED)
+                    .on_mouse_up(move |_| behind.set(behind() + 1)),
+            )
+            .child(
+                rect()
+                    .position(Position::new_absolute())
+                    .layer(Layer::Overlay)
+                    .interactive(false)
+                    .expanded()
+                    .child(
+                        rect()
+                            .expanded()
+                            .opacity(0.99)
+                            .on_mouse_up(move |_| overlay.set(overlay() + 1)),
+                    ),
+            )
+            .child(label().text(format!("behind:{} overlay:{}", behind(), overlay())))
+    }
+
+    let mut test = launch_test(app);
+    test.click_cursor((50.0, 50.0));
+
+    assert!(
+        test.find(|_, e| Label::try_downcast(e).filter(|l| l.text.as_ref() == "behind:1 overlay:0"))
+            .is_some(),
+        "click should reach the node behind and nothing in the interactive(false) subtree"
+    );
+}

--- a/crates/ragnarok/src/measurement.rs
+++ b/crates/ragnarok/src/measurement.rs
@@ -72,6 +72,9 @@ pub fn measure_potential_events<
         .sorted_by(|(layer, _), (layer_b, _)| layer.cmp(layer_b))
     {
         for node_id in layer_nodes {
+            if !events_measurer.is_node_interactive(node_id) {
+                continue;
+            }
             for source_event in source_events {
                 let Some(cursor) = source_event.try_location() else {
                     if focus_id == Some(*node_id) {

--- a/crates/ragnarok/src/measurer.rs
+++ b/crates/ragnarok/src/measurer.rs
@@ -30,6 +30,7 @@ where
     fn is_node_parent_of(&self, key: &Self::Key, parent: Self::Key) -> bool;
     fn is_listening_to(&self, key: &Self::Key, name: &Self::Name) -> bool;
     fn is_node_transparent(&self, key: &Self::Key) -> bool;
+    fn is_node_interactive(&self, key: &Self::Key) -> bool;
 
     fn try_area_of(&self, key: &Self::Key) -> Option<Area>;
 

--- a/crates/ragnarok/tests/state.rs
+++ b/crates/ragnarok/tests/state.rs
@@ -354,6 +354,10 @@ impl EventsMeasurer for TestMeasurer {
         false
     }
 
+    fn is_node_interactive(&self, _key: &Self::Key) -> bool {
+        true
+    }
+
     fn try_area_of(&self, key: &Self::Key) -> Option<ragnarok::Area> {
         self.areas.get(key).cloned()
     }


### PR DESCRIPTION
It was only opting out for its children but not the element itself.