### PR TITLE
feat(code-editor): Customizable tree_sitter languages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,7 @@ freya-plotters-backend = { path = "./crates/freya-plotters-backend", version = "
 freya-query = { path = "./crates/freya-query", version = "0.4.0-rc.23" }
 freya-webview = { path = "./crates/freya-webview", version = "0.4.0-rc.23" }
 freya-terminal = { path = "./crates/freya-terminal", version = "0.4.0-rc.23" }
-freya-code-editor = { path = "./crates/freya-code-editor", version = "0.4.0-rc.23", features = [
-  "rust",
-] }
+freya-code-editor = { path = "./crates/freya-code-editor", version = "0.4.0-rc.23" }
 freya-camera = { path = "./crates/freya-camera", version = "0.4.0-rc.23" }
 freya-android = { path = "./crates/freya-android", version = "0.4.0-rc.23" }
 mundy = { version = "0.2.3", default-features = false, features = [
@@ -190,6 +188,7 @@ freya-devtools = { workspace = true, features = ["server", "client"] }
 freya-webview = { workspace = true }
 freya-terminal = { workspace = true }
 freya-code-editor = { workspace = true }
+tree-sitter-rust = "0.24"
 
 freya-skia-safe = { workspace = true }
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ fn app() -> impl IntoElement {
 
 ### Code Editor
 
-Create and control text Code Editors. It is state agnostic so as long as it can be turned into a `Writable` it will work. Uses Rope for text editing and tree-sitter for syntax highlighting. 
+Create and control text Code Editors. It is state agnostic so as long as it can be turned into a `Writable` it will work. Uses Rope for text editing and tree-sitter for syntax highlighting. You bring your own tree-sitter grammar and its highlights query, so any language can be supported.
 Enable with the `code-editor` feature.
 
 <details>
@@ -203,7 +203,11 @@ fn app() -> impl IntoElement {
     let editor = use_state(|| {
         let path = PathBuf::from("./crates/freya-code-editor/src/editor_ui.rs");
         let rope = Rope::from_str(&std::fs::read_to_string(&path).unwrap());
-        let mut editor = CodeEditorData::new(rope, LanguageId::Rust);
+        let language = EditorLanguage::new(
+            tree_sitter_rust::LANGUAGE,
+            tree_sitter_rust::HIGHLIGHTS_QUERY,
+        );
+        let mut editor = CodeEditorData::new(rope, language);
         editor.parse();
         editor.measure(14., "Jetbrains Mono");
         editor

--- a/crates/freya-code-editor/Cargo.toml
+++ b/crates/freya-code-editor/Cargo.toml
@@ -14,14 +14,6 @@ categories = ["gui"]
 [lints]
 workspace = true
 
-[features]
-all = ["rust", "md", "json", "toml", "sql"]
-rust = ["dep:tree-sitter-rust"]
-md = ["dep:tree-sitter-md"]
-json = ["dep:tree-sitter-json"]
-toml = ["dep:tree-sitter-toml-ng"]
-sql = ["dep:tree-sitter-sequel"]
-
 [dependencies]
 freya-core = { workspace = true }
 freya-engine = { workspace = true }
@@ -32,9 +24,4 @@ ropey = { workspace = true }
 
 smallvec = "1.15.1"
 tree-sitter = "0.26"
-tree-sitter-rust = { version = "0.24", optional = true }
-tree-sitter-md = { version = "0.5", optional = true }
-tree-sitter-json = { version = "0.24", optional = true }
-tree-sitter-toml-ng = { version = "0.7", optional = true }
-tree-sitter-sequel = { version = "0.3.11", optional = true }
 rustc-hash = { workspace = true }

--- a/crates/freya-code-editor/Cargo.toml
+++ b/crates/freya-code-editor/Cargo.toml
@@ -25,3 +25,6 @@ ropey = { workspace = true }
 smallvec = "1.15.1"
 tree-sitter = "0.26"
 rustc-hash = { workspace = true }
+
+[dev-dependencies]
+tree-sitter-rust = "0.24"

--- a/crates/freya-code-editor/src/editor_data.rs
+++ b/crates/freya-code-editor/src/editor_data.rs
@@ -18,7 +18,7 @@ use tree_sitter::InputEdit;
 
 use crate::{
     editor_theme::SyntaxTheme,
-    languages::LanguageId,
+    languages::EditorLanguage,
     metrics::EditorMetrics,
     syntax::InputEditExt,
 };
@@ -32,13 +32,13 @@ pub struct CodeEditorData {
     pub(crate) dragging: TextDragging,
     pub(crate) scrolls: (i32, i32),
     pub(crate) pending_edit: Option<InputEdit>,
-    pub language_id: LanguageId,
+    pub language: Option<EditorLanguage>,
     theme: SyntaxTheme,
 }
 
 impl CodeEditorData {
-    pub fn new(rope: Rope, language_id: LanguageId) -> Self {
-        Self {
+    pub fn new(rope: Rope, language: impl Into<Option<EditorLanguage>>) -> Self {
+        let mut data = Self {
             rope,
             selection: TextSelection::new_cursor(0),
             history: EditorHistory::new(Duration::from_secs(1)),
@@ -47,9 +47,24 @@ impl CodeEditorData {
             dragging: TextDragging::default(),
             scrolls: (0, 0),
             pending_edit: None,
-            language_id,
+            language: language.into(),
             theme: SyntaxTheme::default(),
-        }
+        };
+        data.configure_highlighter();
+        data
+    }
+
+    /// Reconfigures the highlighter with the current language and theme.
+    fn configure_highlighter(&mut self) {
+        self.metrics
+            .highlighter
+            .set_language(self.language.as_ref(), &self.theme);
+    }
+
+    /// Sets the language used for syntax highlighting, or disables it with `None`.
+    pub fn set_language(&mut self, language: impl Into<Option<EditorLanguage>>) {
+        self.language = language.into();
+        self.configure_highlighter();
     }
 
     pub fn is_edited(&self) -> bool {
@@ -62,8 +77,7 @@ impl CodeEditorData {
 
     pub fn parse(&mut self) {
         let edit = self.pending_edit.take();
-        self.metrics
-            .run_parser(&self.rope, self.language_id, edit, &self.theme);
+        self.metrics.run_parser(&self.rope, edit, &self.theme);
     }
 
     pub fn measure(&mut self, font_size: f32, font_family: &str) {
@@ -73,6 +87,7 @@ impl CodeEditorData {
 
     pub fn set_theme(&mut self, theme: SyntaxTheme) {
         self.theme = theme;
+        self.configure_highlighter();
     }
 
     pub fn process(

--- a/crates/freya-code-editor/src/languages.rs
+++ b/crates/freya-code-editor/src/languages.rs
@@ -1,47 +1,33 @@
-use std::fmt::Display;
+use std::borrow::Cow;
 
-#[derive(Default, Clone, Debug, PartialEq, Copy)]
-pub enum LanguageId {
-    Rust,
-    Python,
-    JavaScript,
-    TypeScript,
-    Markdown,
-    Toml,
-    Json,
-    SQL,
-    #[default]
-    Unknown,
+use tree_sitter::Language;
+
+/// A language definition used for syntax highlighting.
+///
+/// Bring your own tree-sitter grammar and its highlights query, so the editor
+/// can highlight any language without the crate depending on specific grammars.
+///
+/// ```no_run
+/// # use freya_code_editor::prelude::EditorLanguage;
+/// let language = EditorLanguage::new(
+///     tree_sitter_rust::LANGUAGE,
+///     tree_sitter_rust::HIGHLIGHTS_QUERY,
+/// );
+/// ```
+#[derive(Clone)]
+pub struct EditorLanguage {
+    pub language: Language,
+    pub highlights_query: Cow<'static, str>,
 }
 
-impl Display for LanguageId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Rust => f.write_str("Rust"),
-            Self::Python => f.write_str("Python"),
-            Self::JavaScript => f.write_str("JavaScript"),
-            Self::TypeScript => f.write_str("TypeScript"),
-            Self::Markdown => f.write_str("Markdown"),
-            Self::Toml => f.write_str("TOML"),
-            Self::Json => f.write_str("JSON"),
-            Self::SQL => f.write_str("SQL"),
-            Self::Unknown => f.write_str("Unknown"),
-        }
-    }
-}
-
-impl LanguageId {
-    pub fn parse(id: &str) -> Self {
-        match id {
-            "rs" => LanguageId::Rust,
-            "py" => LanguageId::Python,
-            "js" => LanguageId::JavaScript,
-            "ts" => LanguageId::TypeScript,
-            "md" => LanguageId::Markdown,
-            "toml" => LanguageId::Toml,
-            "json" => LanguageId::Json,
-            "sql" => LanguageId::SQL,
-            _ => LanguageId::Unknown,
+impl EditorLanguage {
+    pub fn new(
+        language: impl Into<Language>,
+        highlights_query: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        Self {
+            language: language.into(),
+            highlights_query: highlights_query.into(),
         }
     }
 }

--- a/crates/freya-code-editor/src/lib.rs
+++ b/crates/freya-code-editor/src/lib.rs
@@ -7,6 +7,8 @@ pub mod languages;
 pub mod metrics;
 pub mod syntax;
 
+pub use tree_sitter;
+
 pub mod prelude {
     pub use ropey::Rope;
 
@@ -24,7 +26,7 @@ pub mod prelude {
             SyntaxTheme,
         },
         editor_ui::CodeEditor,
-        languages::LanguageId,
+        languages::EditorLanguage,
         metrics::EditorMetrics,
         syntax::{
             InputEditExt,

--- a/crates/freya-code-editor/src/metrics.rs
+++ b/crates/freya-code-editor/src/metrics.rs
@@ -5,7 +5,6 @@ use tree_sitter::InputEdit;
 
 use crate::{
     editor_theme::SyntaxTheme,
-    languages::LanguageId,
     syntax::*,
 };
 
@@ -54,14 +53,7 @@ impl EditorMetrics {
         self.longest_width = max_chars as f32 * char_width;
     }
 
-    pub fn run_parser(
-        &mut self,
-        rope: &Rope,
-        language_id: LanguageId,
-        edit: Option<InputEdit>,
-        theme: &SyntaxTheme,
-    ) {
-        self.highlighter.set_language(language_id, theme);
+    pub fn run_parser(&mut self, rope: &Rope, edit: Option<InputEdit>, theme: &SyntaxTheme) {
         self.highlighter
             .parse(rope, &mut self.syntax_blocks, edit, theme);
     }

--- a/crates/freya-code-editor/src/syntax.rs
+++ b/crates/freya-code-editor/src/syntax.rs
@@ -17,7 +17,7 @@ use tree_sitter::{
 
 use crate::{
     editor_theme::SyntaxTheme,
-    languages::LanguageId,
+    languages::EditorLanguage,
 };
 
 #[allow(dead_code)]
@@ -122,7 +122,6 @@ pub struct SyntaxHighlighter {
     tree: Option<Tree>,
     config: Option<LangConfig>,
     cursor: QueryCursor,
-    language_id: LanguageId,
 }
 
 impl Default for SyntaxHighlighter {
@@ -138,18 +137,13 @@ impl SyntaxHighlighter {
             tree: None,
             config: None,
             cursor: QueryCursor::new(),
-            language_id: LanguageId::Unknown,
         }
     }
 
-    pub fn set_language(&mut self, language_id: LanguageId, theme: &SyntaxTheme) {
-        if self.language_id == language_id {
-            return;
-        }
-        self.language_id = language_id;
+    /// Configures the language used for highlighting, or disables it with `None`.
+    pub fn set_language(&mut self, language: Option<&EditorLanguage>, theme: &SyntaxTheme) {
         self.tree = None;
-
-        self.config = language_id.lang_config(theme);
+        self.config = language.and_then(|language| language.lang_config(theme));
         if let Some(cfg) = &self.config {
             let _ = self.parser.set_language(&cfg.language);
         }
@@ -429,38 +423,10 @@ impl<'a> Iterator for RopeChunkIter<'a> {
     }
 }
 
-impl LanguageId {
+impl EditorLanguage {
     fn lang_config(&self, theme: &SyntaxTheme) -> Option<LangConfig> {
-        let (language, highlights_query) = match self {
-            #[cfg(feature = "rust")]
-            LanguageId::Rust => Some((
-                tree_sitter_rust::LANGUAGE.into(),
-                tree_sitter_rust::HIGHLIGHTS_QUERY,
-            )),
-            #[cfg(feature = "json")]
-            LanguageId::Json => Some((
-                tree_sitter_json::LANGUAGE.into(),
-                tree_sitter_json::HIGHLIGHTS_QUERY,
-            )),
-            #[cfg(feature = "toml")]
-            LanguageId::Toml => Some((
-                tree_sitter_toml_ng::LANGUAGE.into(),
-                tree_sitter_toml_ng::HIGHLIGHTS_QUERY,
-            )),
-            #[cfg(feature = "md")]
-            LanguageId::Markdown => Some((
-                tree_sitter_md::LANGUAGE.into(),
-                tree_sitter_md::HIGHLIGHT_QUERY_BLOCK,
-            )),
-            #[cfg(feature = "sql")]
-            LanguageId::SQL => Some((
-                tree_sitter_sequel::LANGUAGE.into(),
-                tree_sitter_sequel::HIGHLIGHTS_QUERY,
-            )),
-            _ => None,
-        }?;
-
-        let query = Query::new(&language, highlights_query).ok()?;
+        let language = self.language.clone();
+        let query = Query::new(&language, self.highlights_query.as_ref()).ok()?;
         let capture_colors: Vec<Color> = query
             .capture_names()
             .iter()

--- a/examples/android/Cargo.toml
+++ b/examples/android/Cargo.toml
@@ -14,6 +14,7 @@ freya = { workspace = true, features = [
   "remote-asset",
 ] }
 freya-winit = { workspace = true }
+tree-sitter-rust = "0.24"
 env_logger = "0.11.9"
 log = "0.4.29"
 

--- a/examples/android/src/app/routes/editor.rs
+++ b/examples/android/src/app/routes/editor.rs
@@ -142,7 +142,11 @@ impl Component for EditorDemo {
 
         let editor = use_state(move || {
             let rope = Rope::from_str(SAMPLE_CODE);
-            let mut editor = CodeEditorData::new(rope, LanguageId::Rust);
+            let language = EditorLanguage::new(
+                tree_sitter_rust::LANGUAGE,
+                tree_sitter_rust::HIGHLIGHTS_QUERY,
+            );
+            let mut editor = CodeEditorData::new(rope, language);
             editor.set_theme(SyntaxTheme::default());
             editor.parse();
             editor.measure(14., "Jetbrains Mono");

--- a/examples/feature_code_editor.rs
+++ b/examples/feature_code_editor.rs
@@ -25,7 +25,11 @@ fn app() -> impl IntoElement {
     let editor = use_state(move || {
         let path = PathBuf::from("./crates/freya-code-editor/src/editor_ui.rs");
         let rope = Rope::from_str(&std::fs::read_to_string(&path).unwrap());
-        let mut editor = CodeEditorData::new(rope, LanguageId::Rust);
+        let language = EditorLanguage::new(
+            tree_sitter_rust::LANGUAGE,
+            tree_sitter_rust::HIGHLIGHTS_QUERY,
+        );
+        let mut editor = CodeEditorData::new(rope, language);
         editor.set_theme(SyntaxTheme {
             comment: (230, 230, 230).into(),
             ..Default::default()

--- a/examples/website.rs
+++ b/examples/website.rs
@@ -55,7 +55,11 @@ impl Component for Home {
         });
         let editor = use_state(move || {
             let rope = Rope::from_str(CODE);
-            let mut editor = CodeEditorData::new(rope, LanguageId::Rust);
+            let language = EditorLanguage::new(
+                tree_sitter_rust::LANGUAGE,
+                tree_sitter_rust::HIGHLIGHTS_QUERY,
+            );
+            let mut editor = CodeEditorData::new(rope, language);
             editor.set_theme(SyntaxTheme {
                 comment: (230, 230, 230).into(),
                 ..Default::default()

--- a/plugins/freya/skills/freya/SKILL.md
+++ b/plugins/freya/skills/freya/SKILL.md
@@ -808,11 +808,15 @@ Use `use_editable` to manage a text editor with cursor, selection, keyboard shor
 
 ## Code Editor
 
-Enable with `features = ["code-editor"]`. `CodeEditorData` holds a `Rope`-backed buffer with tree-sitter syntax highlighting. Pass it to the `CodeEditor` component:
+Enable with `features = ["code-editor"]`. `CodeEditorData` holds a `Rope`-backed buffer with tree-sitter syntax highlighting. You bring your own tree-sitter grammar and highlights query via `EditorLanguage`, so any language can be supported (add the grammar crate, e.g. `tree-sitter-rust`, as a dependency). Pass `None` to disable highlighting. Then pass the data to the `CodeEditor` component:
 
 ```rust
 let editor = use_state(|| {
-    let mut e = CodeEditorData::new(Rope::from_str(src), LanguageId::Rust);
+    let language = EditorLanguage::new(
+        tree_sitter_rust::LANGUAGE,
+        tree_sitter_rust::HIGHLIGHTS_QUERY,
+    );
+    let mut e = CodeEditorData::new(Rope::from_str(src), language);
     e.parse();
     e.measure(14., "Jetbrains Mono");
     e


### PR DESCRIPTION
removes the built-in set of languages, now expects the user to pass them, these way users can pass whatever they want to pass.