### PR TITLE
fix(core): Always use longest line for paragraph shaders

### DIFF
--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -808,7 +808,7 @@ pub(crate) fn paint_paragraph_with_fill(
         return;
     }
 
-    let width = paragraph.longest_line().max(paragraph.max_width());
+    let width = paragraph.longest_line();
     let height = paragraph.height();
     let area = Area::new(origin, Size2D::new(width, height));
     let bounds_rect = SkRect::from_xywh(area.min_x(), area.min_y(), width, height);


### PR DESCRIPTION
<img width="978" height="939" alt="image" src="https://github.com/user-attachments/assets/825a4e72-00ab-48e2-8213-54144b650d76" />


We dont really want to use the max width, but the width of the longest line.