### PR TITLE
fix(query): Notify subscribers when the query data changes

### DIFF
--- a/crates/freya-query/src/mutation.rs
+++ b/crates/freya-query/src/mutation.rs
@@ -284,7 +284,7 @@ impl<Q: MutationCapability> UseMutation<Q> {
     pub fn read(&self) -> MutationReader<Q> {
         let storage = consume_context::<MutationsStorage<Q>>();
         let map = storage.storage.peek();
-        let mutation_data = map.get(&self.mutation.peek()).cloned().unwrap();
+        let mutation_data = map.get(&self.mutation.read()).cloned().unwrap();
 
         // Subscribe if possible
         if let Some(mut reactive_context) = ReactiveContext::try_current() {

--- a/crates/freya-query/src/query.rs
+++ b/crates/freya-query/src/query.rs
@@ -583,7 +583,7 @@ impl<Q: QueryCapability> UseQuery<Q> {
     pub fn read(&self) -> QueryReader<Q> {
         let storage = consume_context::<QueriesStorage<Q>>();
         let map = storage.storage.peek();
-        let query_data = map.get(&self.query.peek()).cloned().unwrap();
+        let query_data = map.get(&self.query.read()).cloned().unwrap();
 
         // Subscribe if possible
         if let Some(mut reactive_context) = ReactiveContext::try_current() {

--- a/crates/freya-query/tests/mutation_tests.rs
+++ b/crates/freya-query/tests/mutation_tests.rs
@@ -3,6 +3,7 @@ use std::{
     rc::Rc,
 };
 
+use freya::prelude::Size;
 use freya_query::prelude::*;
 use freya_testing::prelude::*;
 
@@ -92,5 +93,85 @@ fn mutation_basic() {
             .unwrap()
             .text
             .contains("John")
+    );
+}
+
+#[derive(Clone, PartialEq, Hash, Eq)]
+struct CheckUser {
+    user_id: usize,
+}
+
+impl MutationCapability for CheckUser {
+    type Ok = ();
+    type Err = ();
+    type Keys = ();
+
+    async fn run(&self, _keys: &Self::Keys) -> Result<Self::Ok, Self::Err> {
+        match self.user_id {
+            0 => Ok(()),
+            _ => Err(()),
+        }
+    }
+}
+
+#[test]
+fn mutation_reactive_context_reruns_on_identity_change() {
+    fn app() -> impl IntoElement {
+        let mut observed = use_consume::<State<Vec<bool>>>();
+        let mut user_id = use_state(|| 0usize);
+
+        let mutation = use_mutation(Mutation::new(CheckUser {
+            user_id: *user_id.read(),
+        }));
+
+        // Records every settled result this reactive context sees.
+        use_side_effect(move || {
+            let reader = mutation.read();
+            let state = reader.state();
+            if state.is_ok() || state.is_err() {
+                observed.write().push(state.is_ok());
+            }
+        });
+
+        // Runs the mutation again whenever the identity changes.
+        use_after_side_effect(move || {
+            let _ = user_id.read();
+            mutation.mutate(());
+        });
+
+        rect()
+            .width(Size::fill())
+            .height(Size::fill())
+            .on_press(move |_| {
+                *user_id.write() = 1;
+            })
+    }
+
+    let (mut test, observed) = TestingRunner::new(
+        app,
+        (200., 200.).into(),
+        |runner| runner.provide_root_context(|| State::create(Vec::<bool>::new())),
+        1.,
+    );
+
+    test.sync_and_update();
+    test.poll(
+        std::time::Duration::from_millis(10),
+        std::time::Duration::from_millis(200),
+    );
+
+    assert_eq!(&*observed.peek(), &[true]);
+
+    // Changing the identity re-runs the mutation with user `1`, which fails.
+    test.click_cursor((100.0, 100.0));
+    test.poll(
+        std::time::Duration::from_millis(10),
+        std::time::Duration::from_millis(200),
+    );
+
+    assert_eq!(
+        &*observed.peek(),
+        &[true, false],
+        "the reactive context was not notified when the mutation re-ran"
     );
 }

--- a/crates/freya-query/tests/query_tests.rs
+++ b/crates/freya-query/tests/query_tests.rs
@@ -1,3 +1,4 @@
+use freya::prelude::Size;
 use freya_query::prelude::*;
 use freya_testing::prelude::*;
 
@@ -57,5 +58,62 @@ fn query_basic() {
             .unwrap()
             .text
             .contains("Settled")
+    );
+}
+
+#[test]
+fn query_reactive_subcontext_reruns_on_keys_change() {
+    fn app() -> impl IntoElement {
+        let mut observed = use_consume::<State<Vec<bool>>>();
+        let mut user_id = use_state(|| 0usize);
+
+        let user = use_query(Query::new(
+            *user_id.read(),
+            GetUserName(Captured(FancyClient)),
+        ));
+
+        // Records every settled result this reactive context sees.
+        use_side_effect(move || {
+            let reader = user.read();
+            let state = reader.state();
+            if state.is_ok() || state.is_err() {
+                observed.write().push(state.is_ok());
+            }
+        });
+
+        rect()
+            .width(Size::fill())
+            .height(Size::fill())
+            .on_press(move |_| {
+                *user_id.write() = 1;
+            })
+    }
+
+    let (mut test, observed) = TestingRunner::new(
+        app,
+        (200., 200.).into(),
+        |runner| runner.provide_root_context(|| State::create(Vec::<bool>::new())),
+        1.,
+    );
+
+    test.sync_and_update();
+    test.poll(
+        std::time::Duration::from_millis(10),
+        std::time::Duration::from_millis(200),
+    );
+
+    assert_eq!(&*observed.peek(), &[true]);
+
+    // Changing the keys re-runs the query with key `1`, which fails.
+    test.click_cursor((100.0, 100.0));
+    test.poll(
+        std::time::Duration::from_millis(10),
+        std::time::Duration::from_millis(200),
+    );
+
+    assert_eq!(
+        &*observed.peek(),
+        &[true, false],
+        "the reactive context was not notified when the query re-ran"
     );
 }


### PR DESCRIPTION
I did not consider the case where the query data could change and I didnt notify subscribers. This specially happens if you subscribe to the query in a component that doesnt rerun just after the query also changes.

Closes https://github.com/marc2332/freya/issues/1960