### PR TITLE
chore(components): Implement TextStyleExt for Input

### DIFF
--- a/crates/freya-components/src/input.rs
+++ b/crates/freya-components/src/input.rs
@@ -181,7 +181,7 @@ pub struct Input {
     key: DiffKey,
     style_variant: InputStyleVariant,
     layout_variant: InputLayoutVariant,
-    text_align: TextAlign,
+    text_style: TextStyleData,
     a11y_id: Option<AccessibilityId>,
     leading: Option<Element>,
     trailing: Option<Element>,
@@ -210,7 +210,7 @@ impl Input {
             key: DiffKey::default(),
             style_variant: InputStyleVariant::Normal,
             layout_variant: InputLayoutVariant::Normal,
-            text_align: TextAlign::default(),
+            text_style: TextStyleData::default(),
             a11y_id: None,
             leading: None,
             trailing: None,
@@ -271,11 +271,6 @@ impl Input {
         self
     }
 
-    pub fn text_align(mut self, text_align: impl Into<TextAlign>) -> Self {
-        self.text_align = text_align.into();
-        self
-    }
-
     pub fn style_variant(mut self, style_variant: impl Into<InputStyleVariant>) -> Self {
         self.style_variant = style_variant.into();
         self
@@ -331,6 +326,12 @@ impl Input {
     ) -> Self {
         self.on_pre_key_down = on_pre_key_down.into();
         self
+    }
+}
+
+impl TextStyleExt for Input {
+    fn get_text_style_data(&mut self) -> &mut TextStyleData {
+        &mut self.text_style
     }
 }
 
@@ -684,7 +685,7 @@ impl Component for Input {
                             .cursor_index(cursor_index)
                             .cursor_color(cursor_color)
                             .color(color)
-                            .text_align(self.text_align)
+                            .text_style(self.text_style.clone())
                             .max_lines(1)
                             .highlights(text_selection.map(|h| vec![h]))
                             .maybe(display_placeholder, |el| {

--- a/examples/component_input.rs
+++ b/examples/component_input.rs
@@ -20,9 +20,10 @@ fn app() -> impl IntoElement {
         .child(rect().spacing(6.).children(disabled_inputs(text)))
 }
 
-fn inputs(text: State<String>) -> [Element; 9] {
+fn inputs(text: State<String>) -> [Element; 10] {
     [
         Input::new(text).placeholder("Normal").into(),
+        Input::new(text).placeholder("Small Text").font_size(10.).into(),
         Input::new(text).placeholder("Filled").filled().into(),
         Input::new(text).placeholder("Flat").flat().into(),
         Input::new(text).placeholder("Expanded").expanded().into(),
@@ -50,9 +51,10 @@ fn inputs(text: State<String>) -> [Element; 9] {
     ]
 }
 
-fn disabled_inputs(text: State<String>) -> [Element; 9] {
+fn disabled_inputs(text: State<String>) -> [Element; 10] {
     [
         Input::new(text).placeholder("Normal").enabled(false).into(),
+        Input::new(text).placeholder("Small Text").font_size(10.).enabled(false).into(),
         Input::new(text)
             .placeholder("Filled")
             .enabled(false)

--- a/examples/component_input.rs
+++ b/examples/component_input.rs
@@ -20,10 +20,18 @@ fn app() -> impl IntoElement {
         .child(rect().spacing(6.).children(disabled_inputs(text)))
 }
 
-fn inputs(text: State<String>) -> [Element; 10] {
+fn inputs(text: State<String>) -> [Element; 11] {
     [
         Input::new(text).placeholder("Normal").into(),
-        Input::new(text).placeholder("Small Text").font_size(10.).into(),
+        Input::new(text)
+            .placeholder("Centered")
+            .text_align(TextAlign::Center)
+            .inner_margin(Gaps::new_symmetric(8., 4.))
+            .into(),
+        Input::new(text)
+            .placeholder("Small Text")
+            .font_size(10.)
+            .into(),
         Input::new(text).placeholder("Filled").filled().into(),
         Input::new(text).placeholder("Flat").flat().into(),
         Input::new(text).placeholder("Expanded").expanded().into(),
@@ -51,10 +59,20 @@ fn inputs(text: State<String>) -> [Element; 10] {
     ]
 }
 
-fn disabled_inputs(text: State<String>) -> [Element; 10] {
+fn disabled_inputs(text: State<String>) -> [Element; 11] {
     [
         Input::new(text).placeholder("Normal").enabled(false).into(),
-        Input::new(text).placeholder("Small Text").font_size(10.).enabled(false).into(),
+        Input::new(text)
+            .placeholder("Centered")
+            .text_align(TextAlign::Center)
+            .inner_margin(Gaps::new_symmetric(8., 4.))
+            .enabled(false)
+            .into(),
+        Input::new(text)
+            .placeholder("Small Text")
+            .font_size(10.)
+            .enabled(false)
+            .into(),
         Input::new(text)
             .placeholder("Filled")
             .enabled(false)


### PR DESCRIPTION
## Description

Implements the TextStyleExt trait for better text styling in the Input component.

## Motivation

Missing implementation of a special trait.

## Checklist

- [x] I have tested my changes.
- [ ] I used AI assistance (e.g. ChatGPT, Copilot, etc.) to write this code.
- [ ] I have added or updated documentation where relevant.
- [ ] I have added or updated tests where relevant.
