### PR TITLE
fix(core): Avoid negative text layouts

### DIFF
--- a/crates/freya-core/src/elements/label.rs
+++ b/crates/freya-core/src/elements/label.rs
@@ -273,7 +273,7 @@ impl ElementExt for LabelElement {
                     .insert(context.node_id, &cached_paragraph, paragraph)
             });
 
-        let size = Size2D::new(paragraph.longest_line(), paragraph.height());
+        let size = Size2D::new(paragraph.longest_line(), paragraph.height()).max(Size2D::zero());
 
         Some((size, paragraph))
     }

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -325,7 +325,7 @@ impl ElementExt for ParagraphElement {
                     .insert(context.node_id, &cached_paragraph, paragraph)
             });
 
-        let size = Size2D::new(paragraph.longest_line(), paragraph.height());
+        let size = Size2D::new(paragraph.longest_line(), paragraph.height()).max(Size2D::zero());
 
         self.sk_paragraph
             .0


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/1972

Added a max zeroed size so that text cannot make negative layouts, which can happen if the sk paragraph has no text.