### PR TITLE
fix(components): Properly close Selects when they really lose focus

### DIFF
--- a/crates/freya-components/src/select.rs
+++ b/crates/freya-components/src/select.rs
@@ -164,6 +164,12 @@ impl Component for Select {
             }
         });
 
+        let (scale, opacity, slide) = animation.read().value();
+
+        if !open() && opacity == 0. && list_size().is_some() {
+            let _ = list_size.take();
+        }
+
         let cursor_icon = self.cursor_icon;
         use_drop(move || {
             if status() == SelectStatus::Hovering {
@@ -171,15 +177,12 @@ impl Component for Select {
             }
         });
 
-        // Close the select when the focused accessibility node changes and its not the select or any of its children
+        // Close the select when the focus leaves it.
         use_side_effect(move || {
             let platform = Platform::get();
-            let should_close = platform
-                .focused_accessibility_node
-                .read()
-                .member_of()
-                .is_none_or(|member_of| member_of != a11y_id);
-            if should_close {
+            let focus_within =
+                platform.focused_accessibility_node.read().member_of() == Some(a11y_id);
+            if !focus_within && list_size.peek().is_some() {
                 open.set_if_modified(false);
             }
         });
@@ -216,8 +219,6 @@ impl Component for Select {
             }
             _ => {}
         };
-
-        let (scale, opacity, slide) = animation.read().value();
 
         let offset_y = match (button_area(), list_size()) {
             (Some(button), Some(list)) => {

--- a/crates/freya-components/src/select.rs
+++ b/crates/freya-components/src/select.rs
@@ -166,6 +166,7 @@ impl Component for Select {
 
         let (scale, opacity, slide) = animation.read().value();
 
+        // Clear the list size when the select dropdown is not rendered
         if !open() && opacity == 0. && list_size().is_some() {
             let _ = list_size.take();
         }

--- a/crates/freya-components/tests/input.rs
+++ b/crates/freya-components/tests/input.rs
@@ -187,8 +187,9 @@ pub fn input_escape_unfocus_test() {
     });
     assert!(label.is_some());
 
-    // Press Escape to unfocus
+    // Press Escape to unfocus.
     test.press_key(Key::Named(NamedKey::Escape));
+    test.sync_and_update();
 
     // Type more text, should not be captured since the input lost focus
     test.write_text("world");

--- a/crates/freya-components/tests/select.rs
+++ b/crates/freya-components/tests/select.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use freya::prelude::*;
+use freya_testing::prelude::*;
+
+fn two_selects_app() -> impl IntoElement {
+    rect()
+        .horizontal()
+        .spacing(6.)
+        .child(
+            Select::new()
+                .selected_item("Select A")
+                .child(MenuItem::new().child("A Item 1"))
+                .child(MenuItem::new().child("A Item 2")),
+        )
+        .child(
+            Select::new()
+                .selected_item("Select B")
+                .child(MenuItem::new().child("B Item 1"))
+                .child(MenuItem::new().child("B Item 2")),
+        )
+}
+
+fn label_center(test: &TestingRunner, text: &str) -> (f64, f64) {
+    let node = test
+        .find(|node, element| {
+            Label::try_downcast(element)
+                .filter(|label| label.text == text)
+                .map(|_| node)
+        })
+        .unwrap_or_else(|| panic!("label `{text}` not found"));
+    let area = node.layout().area;
+    (
+        area.min_x() as f64 + area.size.width as f64 / 2.0,
+        area.min_y() as f64 + area.size.height as f64 / 2.0,
+    )
+}
+
+fn label_exists(test: &TestingRunner, text: &str) -> bool {
+    test.find(|node, element| {
+        Label::try_downcast(element)
+            .filter(|label| label.text == text)
+            .map(|_| node)
+    })
+    .is_some()
+}
+
+#[test]
+pub fn clicking_another_select_keeps_it_open() {
+    let mut test = launch_test(two_selects_app);
+    test.sync_and_update();
+
+    test.click_cursor(label_center(&test, "Select A"));
+    test.poll_n(Duration::from_millis(5), 100);
+    test.sync_and_update();
+
+    assert!(label_exists(&test, "A Item 1"), "Select A should be open");
+
+    test.click_cursor(label_center(&test, "Select B"));
+    test.poll_n(Duration::from_millis(5), 100);
+    test.sync_and_update();
+
+    assert!(
+        !label_exists(&test, "A Item 1"),
+        "Select A should close once Select B is clicked"
+    );
+    assert!(
+        label_exists(&test, "B Item 1"),
+        "Select B should stay open after being clicked"
+    );
+}

--- a/crates/freya-testing/src/lib.rs
+++ b/crates/freya-testing/src/lib.rs
@@ -157,6 +157,8 @@ pub struct TestingRunner {
     events_receiver: futures_channel::mpsc::UnboundedReceiver<EventsChunk>,
     events_sender: futures_channel::mpsc::UnboundedSender<EventsChunk>,
 
+    requested_focus_strategy: Rc<RefCell<Option<AccessibilityFocusStrategy>>>,
+
     font_manager: FontMgr,
     font_collection: FontCollection,
 
@@ -193,8 +195,11 @@ impl TestingRunner {
         let tree = Tree::default();
         let tree = Rc::new(RefCell::new(tree));
 
+        let requested_focus_strategy: Rc<RefCell<Option<AccessibilityFocusStrategy>>> =
+            Rc::new(RefCell::new(None));
+
         let platform = runner.provide_root_context({
-            let tree = tree.clone();
+            let requested_focus_strategy = requested_focus_strategy.clone();
             || Platform {
                 focused_accessibility_id: State::create(ACCESSIBILITY_ROOT_ID),
                 focused_accessibility_node: State::create(accesskit::Node::new(
@@ -212,7 +217,7 @@ impl TestingRunner {
                             // Nothing
                         }
                         UserEvent::FocusAccessibilityNode(strategy) => {
-                            tree.borrow_mut().accessibility_diff.request_focus(strategy);
+                            requested_focus_strategy.borrow_mut().replace(strategy);
                         }
                         UserEvent::SetCursorIcon(_) => {
                             // Nothing
@@ -261,6 +266,8 @@ impl TestingRunner {
             nodes_state,
             events_receiver,
             events_sender,
+
+            requested_focus_strategy,
 
             font_manager,
             font_collection,
@@ -321,6 +328,13 @@ impl TestingRunner {
     }
 
     pub fn sync_and_update(&mut self) {
+        if let Some(strategy) = self.requested_focus_strategy.borrow_mut().take() {
+            self.tree
+                .borrow_mut()
+                .accessibility_diff
+                .request_focus(strategy);
+        }
+
         while let Ok(events_chunk) = self.events_receiver.try_recv() {
             match events_chunk {
                 EventsChunk::Processed(processed_events) => {


### PR DESCRIPTION
They should only close when they really lose focus and they are not showing their dropdowns at all.