### PR TITLE
chore(core): Rename RelativeOverlay to OverlayLevel

### DIFF
--- a/crates/freya-core/src/data.rs
+++ b/crates/freya-core/src/data.rs
@@ -257,8 +257,8 @@ impl LayerState {
                 .saturating_add(relative_layer)
                 .saturating_add(1),
             Layer::Overlay => parent_layer.layer.saturating_add(i16::MAX / 16),
-            Layer::RelativeOverlay(relative_layer) => {
-                (relative_layer.max(1) as i16).saturating_mul(i16::MAX / 16)
+            Layer::OverlayLayer(overlay_layer) => {
+                (overlay_layer.max(1) as i16).saturating_mul(i16::MAX / 16)
             }
         };
         layers.insert_node_in_layer(node_id, self.layer);

--- a/crates/freya-core/src/data.rs
+++ b/crates/freya-core/src/data.rs
@@ -257,8 +257,8 @@ impl LayerState {
                 .saturating_add(relative_layer)
                 .saturating_add(1),
             Layer::Overlay => parent_layer.layer.saturating_add(i16::MAX / 16),
-            Layer::OverlayLayer(overlay_layer) => {
-                (overlay_layer.max(1) as i16).saturating_mul(i16::MAX / 16)
+            Layer::OverlayLevel(overlay_level) => {
+                (overlay_level.max(1) as i16).saturating_mul(i16::MAX / 16)
             }
         };
         layers.insert_node_in_layer(node_id, self.layer);

--- a/crates/freya-core/src/layers.rs
+++ b/crates/freya-core/src/layers.rs
@@ -15,13 +15,15 @@ use crate::node_id::NodeId;
 /// Converts from an `i16`, which becomes a [`Layer::Relative`] offset.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Layer {
-    /// Offset from the parent's layer. `0` (the default) keeps the normal stacking order;
-    /// negative values move behind siblings and positive values in front.
+    /// Relative layer to the parent's layer. `0` (the default) keeps the normal stacking order.
+    /// Negative values move behind siblings and positive values in front.
     Relative(i16),
-    /// Paint far above everything else, for overlays such as popups and tooltips.
+    /// Adds a big layer jump relative to the parents layer.
+    /// You may stack multiple overlays on top of each other.
     Overlay,
-    /// Paint on an overlay layer offset by the given multiplier, to stack overlays among themselves.
-    RelativeOverlay(u8),
+    /// Paint on a specific, numbered overlay layer, regardless of the parent's layer.
+    /// There are up to 16 layers you can use, anything above will be capped at 16.
+    OverlayLayer(u8),
 }
 
 impl Default for Layer {

--- a/crates/freya-core/src/layers.rs
+++ b/crates/freya-core/src/layers.rs
@@ -21,9 +21,9 @@ pub enum Layer {
     /// Adds a big layer jump relative to the parents layer.
     /// You may stack multiple overlays on top of each other.
     Overlay,
-    /// Paint on a specific, numbered overlay layer, regardless of the parent's layer.
-    /// There are up to 16 layers you can use, anything above will be capped at 16.
-    OverlayLayer(u8),
+    /// Paint on a specific, numbered overlay level, regardless of the parent's layer.
+    /// There are up to 16 levels you can use, anything above will be capped at 16.
+    OverlayLevel(u8),
 }
 
 impl Default for Layer {

--- a/crates/freya/src/_docs/layers.rs
+++ b/crates/freya/src/_docs/layers.rs
@@ -6,7 +6,7 @@
 //!
 //! - [`Layer::Relative(i16)`](freya_core::prelude::Layer::Relative) *(default)*: relative layer to the parent's layer. `0` keeps the normal stacking order, negative values move behind siblings and positive values in front.
 //! - [`Layer::Overlay`](freya_core::prelude::Layer::Overlay): adds a big layer jump relative to the parent's layer. You may stack multiple overlays on top of each other.
-//! - [`Layer::OverlayLayer(u8)`](freya_core::prelude::Layer::OverlayLayer): paint on a specific, numbered overlay layer, regardless of the parent's layer. There are up to 16 layers you can use, anything above will be capped at 16.
+//! - [`Layer::OverlayLevel(u8)`](freya_core::prelude::Layer::OverlayLevel): paint on a specific, numbered overlay level, regardless of the parent's layer. There are up to 16 levels you can use, anything above will be capped at 16.
 //!
 //! ```rust,no_run
 //! # use freya::prelude::*;

--- a/crates/freya/src/_docs/layers.rs
+++ b/crates/freya/src/_docs/layers.rs
@@ -4,9 +4,9 @@
 //!
 //! Use the `.layer()` method with one of three variants:
 //!
-//! - [`Layer::Relative(i16)`](freya_core::prelude::Layer::Relative) *(default)*: offset relative to the parent's layer. Positive values render higher, negative values render lower.
-//! - [`Layer::Overlay`](freya_core::prelude::Layer::Overlay): jumps to a very high layer, useful for modals or tooltips that must appear above everything.
-//! - [`Layer::RelativeOverlay(u8)`](freya_core::prelude::Layer::RelativeOverlay): similar to `Overlay` but you have multiple overlay layers options.
+//! - [`Layer::Relative(i16)`](freya_core::prelude::Layer::Relative) *(default)*: relative layer to the parent's layer. `0` keeps the normal stacking order, negative values move behind siblings and positive values in front.
+//! - [`Layer::Overlay`](freya_core::prelude::Layer::Overlay): adds a big layer jump relative to the parent's layer. You may stack multiple overlays on top of each other.
+//! - [`Layer::OverlayLayer(u8)`](freya_core::prelude::Layer::OverlayLayer): paint on a specific, numbered overlay layer, regardless of the parent's layer. There are up to 16 layers you can use, anything above will be capped at 16.
 //!
 //! ```rust,no_run
 //! # use freya::prelude::*;


### PR DESCRIPTION
RelativeOverlay is confusing, OverlayLevel is a better fit as Overlays have a fixed number of layers.