### PR TITLE
fix(draggable_canvas): fix canvas drag offset jump

### DIFF
--- a/crates/freya-components/src/draggable_canvas.rs
+++ b/crates/freya-components/src/draggable_canvas.rs
@@ -84,7 +84,7 @@ impl Component for DraggableCanvas {
             if !e.data().is_primary() {
                 return;
             }
-            dragging_position.set(Some((offset() - e.element_location()).to_point()));
+            dragging_position.set(Some((e.element_location() - offset()).to_point()));
             e.stop_propagation();
         };
 


### PR DESCRIPTION
## Description
Fix offset jump when dragging `DraggableCanvas` background. The formula `offset = element_location - dragging_position` requires `dragging_position = element_location - offset` on pointer down. Stored with wrong sign, causing first mouse-move frame to jump offset to `2 * element_location`.

## Motivation
Dragging canvas background caused child components to flash/jump on first mouse move.

## Checklist
- [x] Tested locally
- [ ] AI assistance
- [ ] Documentation
- [ ] Tests