### PR TITLE
fix(core): Treat text elements as non-transparent in events measuring

### DIFF
--- a/crates/freya-core/src/element.rs
+++ b/crates/freya-core/src/element.rs
@@ -50,10 +50,12 @@ use crate::{
     layers::Layer,
     node_id::NodeId,
     prelude::{
+        Color,
         FileEventData,
         ImePreeditEventData,
         MaybeExt,
     },
+    style::fill::Fill,
     text_cache::TextCache,
     tree::{
         DiffModifies,
@@ -91,6 +93,12 @@ pub trait ElementExt: Any {
 
     fn style(&'_ self) -> Cow<'_, StyleState> {
         Cow::Owned(Default::default())
+    }
+
+    /// Whether the element paints nothing, letting events fall through to
+    /// non-ancestor elements behind it.
+    fn is_transparent(&self) -> bool {
+        self.style().background == Fill::Color(Color::TRANSPARENT)
     }
 
     fn text_style(&'_ self) -> Cow<'_, TextStyleData> {

--- a/crates/freya-core/src/elements/label.rs
+++ b/crates/freya-core/src/elements/label.rs
@@ -179,6 +179,10 @@ impl ElementExt for LabelElement {
         Cow::Owned(StyleState::default())
     }
 
+    fn is_transparent(&self) -> bool {
+        false
+    }
+
     fn text_style(&'_ self) -> Cow<'_, TextStyleData> {
         Cow::Borrowed(&self.text_style_data)
     }

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -276,6 +276,10 @@ impl ElementExt for ParagraphElement {
         Cow::Owned(StyleState::default())
     }
 
+    fn is_transparent(&self) -> bool {
+        false
+    }
+
     fn text_style(&'_ self) -> Cow<'_, TextStyleData> {
         Cow::Borrowed(&self.text_style_data)
     }

--- a/crates/freya-core/src/events/measurer.rs
+++ b/crates/freya-core/src/events/measurer.rs
@@ -7,8 +7,6 @@ use crate::{
         platform::PlatformEvent,
     },
     node_id::NodeId,
-    prelude::Color,
-    style::fill::Fill,
     tree::Tree,
 };
 
@@ -101,7 +99,7 @@ impl ragnarok::EventsMeasurer for EventsMeasurerAdapter<'_> {
 
     fn is_node_transparent(&self, key: &Self::Key) -> bool {
         let element = self.tree.elements.get(key).unwrap();
-        element.style().background == Fill::Color(Color::TRANSPARENT)
+        element.is_transparent()
     }
 
     fn is_node_interactive(&self, key: &Self::Key) -> bool {

--- a/crates/freya-core/tests/events.rs
+++ b/crates/freya-core/tests/events.rs
@@ -5,7 +5,10 @@ use freya_core::{
 };
 use freya_testing::TestingRunner;
 use rustc_hash::FxHashMap;
-use torin::size::Size;
+use torin::{
+    position::Position,
+    size::Size,
+};
 
 struct RawIdMap(FxHashMap<u64, Vec<u64>>);
 
@@ -361,4 +364,49 @@ fn large_coordinate_hover_does_not_trigger_other_elements() {
     test.move_cursor((200., 200.));
     test.sync_and_update();
     assert_eq!(*counters.0.peek(), (11, 11));
+}
+
+#[test]
+fn text_blocks_events_to_lower_layers() {
+    #[derive(Clone, Copy)]
+    struct Counters(State<(i32, i32)>);
+
+    fn app() -> Element {
+        let mut counters = use_consume::<Counters>().0;
+        rect()
+            .expanded()
+            .background((255, 255, 255))
+            .child(
+                rect()
+                    .layer(Layer::OverlayLevel(2))
+                    .on_pointer_press(move |_| counters.write().0 += 1)
+                    .child(label().text("Button")),
+            )
+            .child(
+                rect()
+                    .layer(Layer::OverlayLevel(1))
+                    .width(Size::px(300.))
+                    .height(Size::px(300.))
+                    .position(Position::new_absolute().top(0.).left(0.))
+                    .background((255, 0, 0))
+                    .on_pointer_down(move |_| counters.write().1 += 1),
+            )
+            .into()
+    }
+
+    let (mut test, counters) = TestingRunner::new(
+        app,
+        (500., 500.).into(),
+        |runner| runner.provide_root_context(|| Counters(State::create((0, 0)))),
+        1.,
+    );
+    test.sync_and_update();
+
+    // Clicking over the text only reaches the button, not the rect behind it
+    test.click_cursor((5., 5.));
+    assert_eq!(*counters.0.peek(), (1, 0));
+
+    // Clicking away from the button reaches the rect behind it
+    test.click_cursor((200., 200.));
+    assert_eq!(*counters.0.peek(), (1, 1));
 }


### PR DESCRIPTION
Code to reproduce:

```rust
fn main() {
    launch(LaunchConfig::new().with_window(WindowConfig::new(|| {
        rect()
            .child(
                rect()
                    .layer(Layer::OverlayLevel(10))
                    .center()
                    .expanded()
                    .on_all_press(move |e: Event<PressEventData>| {
                        println!("Pressed !!!");
                    })
                    .child("Hello, World"),
            )
            .child(
                rect()
                    .on_pointer_down(move |e: Event<PointerEventData>| {
                        e.prevent_default();
                    })
                    .width(Size::window_percent(100.))
                    .height(Size::window_percent(100.))
                    .background(Color::RED.with_a(125))
                    .position(Position::new_absolute().top(0.).left(0.)),
            )
    })))
}
```

Context: https://discord.com/channels/1015005816094478347/1015005816648118347/1523746084273258682

Text elements are now treated as nontransparent.