### PR TITLE
fix(components): Synchronous decoding by default in SVG, allow passing event handlers and use visible area for sizing, exclude margin from image rendering, prevent a11y init races

### DIFF
--- a/crates/freya-components/src/gif_viewer.rs
+++ b/crates/freya-components/src/gif_viewer.rs
@@ -616,11 +616,7 @@ impl ElementExt for GifElement {
         let image_width = image.width() as f32;
         let image_height = image.height() as f32;
 
-        let margin = &context.torin_node.margin;
-        let area_size = Size2D::new(
-            (context.area_size.width - margin.horizontal()).max(0.),
-            (context.area_size.height - margin.vertical()).max(0.),
-        );
+        let area_size = (*context.area_size - context.torin_node.margin.into()).max(Size2D::zero());
 
         let width_ratio = area_size.width / image_width;
         let height_ratio = area_size.height / image_height;

--- a/crates/freya-components/src/gif_viewer.rs
+++ b/crates/freya-components/src/gif_viewer.rs
@@ -616,8 +616,14 @@ impl ElementExt for GifElement {
         let image_width = image.width() as f32;
         let image_height = image.height() as f32;
 
-        let width_ratio = context.area_size.width / image.width() as f32;
-        let height_ratio = context.area_size.height / image.height() as f32;
+        let margin = &context.torin_node.margin;
+        let area_size = Size2D::new(
+            (context.area_size.width - margin.horizontal()).max(0.),
+            (context.area_size.height - margin.vertical()).max(0.),
+        );
+
+        let width_ratio = area_size.width / image_width;
+        let height_ratio = area_size.height / image_height;
 
         let size = match self.image_data.aspect_ratio {
             AspectRatio::Max => {
@@ -631,7 +637,7 @@ impl ElementExt for GifElement {
                 Size2D::new(image_width * ratio, image_height * ratio)
             }
             AspectRatio::Fit => Size2D::new(image_width, image_height),
-            AspectRatio::None => *context.area_size,
+            AspectRatio::None => area_size,
         };
 
         Some((size, Rc::new(())))

--- a/crates/freya-components/src/gif_viewer.rs
+++ b/crates/freya-components/src/gif_viewer.rs
@@ -570,6 +570,10 @@ impl ElementExt for GifElement {
             diff.insert(DiffModifies::STYLE);
         }
 
+        if self.event_handlers != image.event_handlers {
+            diff.insert(DiffModifies::EVENT_HANDLERS);
+        }
+
         diff
     }
 
@@ -591,6 +595,10 @@ impl ElementExt for GifElement {
 
     fn accessibility(&'_ self) -> Cow<'_, AccessibilityData> {
         Cow::Borrowed(&self.accessibility)
+    }
+
+    fn events_handlers(&'_ self) -> Option<Cow<'_, FxHashMap<EventName, EventHandlerType>>> {
+        Some(Cow::Borrowed(&self.event_handlers))
     }
 
     fn should_measure_inner_children(&self) -> bool {

--- a/crates/freya-components/src/svg_viewer.rs
+++ b/crates/freya-components/src/svg_viewer.rs
@@ -137,6 +137,7 @@ pub struct SvgViewer {
     show_loader: bool,
     parallel: bool,
 
+    children: Vec<Element>,
     error_renderer: Option<Callback<String, Element>>,
 
     key: DiffKey,
@@ -158,6 +159,7 @@ impl SvgViewer {
             style: SvgStyle::default(),
             show_loader: true,
             parallel: false,
+            children: Vec::new(),
             error_renderer: None,
             key: DiffKey::None,
         }
@@ -224,7 +226,15 @@ impl LayoutExt for SvgViewer {
     }
 }
 
-impl ContainerExt for SvgViewer {}
+impl ContainerSizeExt for SvgViewer {}
+impl ContainerWithContentExt for SvgViewer {}
+impl ContainerPositionExt for SvgViewer {}
+
+impl ChildrenExt for SvgViewer {
+    fn get_children(&mut self) -> &mut Vec<Element> {
+        &mut self.children
+    }
+}
 
 impl ImageExt for SvgViewer {
     fn get_image_data(&mut self) -> &mut ImageData {
@@ -328,6 +338,7 @@ impl Component for SvgViewer {
                     .layout(layout)
                     .image_data(self.image_data.clone())
                     .effect(self.effect.clone())
+                    .children(self.children.clone())
                     .with_event_handlers(self.event_handlers.clone())
                     .on_sized(move |event: Event<SizedEventData>| {
                         measured.set_if_modified(Some(event.visible_area.size));

--- a/crates/freya-components/src/svg_viewer.rs
+++ b/crates/freya-components/src/svg_viewer.rs
@@ -60,54 +60,57 @@ impl SvgStyle {
     }
 }
 
-/// Fetch, parse and rasterize an SVG at `size` off the main thread.
-async fn rasterize(
-    source: ImageSource,
-    size: DecodeSize,
-    style: SvgStyle,
-) -> anyhow::Result<SkImage> {
-    #[cfg(feature = "remote-asset")]
-    let bytes = {
-        let client = Http::get();
-        blocking::unblock(move || source.fetch(&client)).await?
-    };
-    #[cfg(not(feature = "remote-asset"))]
-    let bytes = blocking::unblock(move || source.fetch()).await?;
+/// Parse SVG bytes, apply the style overrides and rasterize them at `size`.
+fn rasterize_bytes(bytes: &[u8], size: DecodeSize, style: SvgStyle) -> anyhow::Result<SkImage> {
+    let width = size.width.max(1) as i32;
+    let height = size.height.max(1) as i32;
 
-    let _permit = RASTER_LIMIT.acquire().await;
-    blocking::unblock(move || {
-        let width = size.width.max(1) as i32;
-        let height = size.height.max(1) as i32;
+    let mut dom = svg::Dom::from_bytes(bytes, FontMgr::empty())
+        .map_err(|err| anyhow::anyhow!("Failed to parse SVG: {err:?}"))?;
+    dom.set_container_size((width, height));
 
-        let mut dom = svg::Dom::from_bytes(&bytes, FontMgr::empty())
-            .map_err(|err| anyhow::anyhow!("Failed to parse SVG: {err:?}"))?;
-        dom.set_container_size((width, height));
+    let mut root = dom.root();
+    root.set_width(svg::Length::new(width as f32, svg::LengthUnit::PX));
+    root.set_height(svg::Length::new(height as f32, svg::LengthUnit::PX));
+    root.set_color(style.color.unwrap_or(Color::BLACK).into());
+    if let Some(fill) = style.fill {
+        root.set_fill(svg::Paint::from_color(fill.into()));
+    }
+    if let Some(stroke) = style.stroke {
+        root.set_stroke(svg::Paint::from_color(stroke.into()));
+    }
+    if let Some(stroke_width) = style.stroke_width {
+        root.set_stroke_width(svg::Length::new(stroke_width, svg::LengthUnit::PX));
+    }
 
-        let mut root = dom.root();
-        root.set_width(svg::Length::new(width as f32, svg::LengthUnit::PX));
-        root.set_height(svg::Length::new(height as f32, svg::LengthUnit::PX));
-        root.set_color(style.color.unwrap_or(Color::BLACK).into());
-        if let Some(fill) = style.fill {
-            root.set_fill(svg::Paint::from_color(fill.into()));
+    let mut surface =
+        raster_n32_premul((width, height)).context("Failed to create the SVG surface.")?;
+    dom.render(surface.canvas());
+    Ok(surface.image_snapshot())
+}
+
+/// Store a raster result in the asset cache, as either a cached image or an error.
+fn store_raster(
+    mut asset_cacher: AssetCacher,
+    asset_config: AssetConfiguration,
+    result: anyhow::Result<SkImage>,
+) {
+    match result {
+        Ok(image) => {
+            asset_cacher.update_asset(
+                asset_config,
+                Asset::Cached(Rc::new(ImageHandle::new(image, Bytes::new()))),
+            );
         }
-        if let Some(stroke) = style.stroke {
-            root.set_stroke(svg::Paint::from_color(stroke.into()));
+        Err(err) => {
+            asset_cacher.update_asset(asset_config, Asset::Error(err.to_string()));
         }
-        if let Some(stroke_width) = style.stroke_width {
-            root.set_stroke_width(svg::Length::new(stroke_width, svg::LengthUnit::PX));
-        }
-
-        let mut surface =
-            raster_n32_premul((width, height)).context("Failed to create the SVG surface.")?;
-        dom.render(surface.canvas());
-        Ok(surface.image_snapshot())
-    })
-    .await
+    }
 }
 
 /// SVG viewer component.
 ///
-/// Rasterizes the SVG asynchronously to the size measured on its container, caching the result.
+/// Rasterizes the SVG synchronously or asynchronously and caches the result.
 /// See [`ImageSource`] for all supported sources.
 ///
 /// # Example
@@ -132,6 +135,7 @@ pub struct SvgViewer {
     event_handlers: FxHashMap<EventName, EventHandlerType>,
     style: SvgStyle,
     show_loader: bool,
+    parallel: bool,
 
     error_renderer: Option<Callback<String, Element>>,
 
@@ -153,6 +157,7 @@ impl SvgViewer {
             event_handlers: FxHashMap::default(),
             style: SvgStyle::default(),
             show_loader: true,
+            parallel: false,
             error_renderer: None,
             key: DiffKey::None,
         }
@@ -161,6 +166,12 @@ impl SvgViewer {
     /// Whether to render a loading indicator while the SVG is being rasterized. Defaults to `true`.
     pub fn show_loader(mut self, show_loader: bool) -> Self {
         self.show_loader = show_loader;
+        self
+    }
+
+    /// Whether to fetch and rasterize the SVG in a background thread. Defaults to `false`.
+    pub fn parallel(mut self, parallel: bool) -> Self {
+        self.parallel = parallel;
         self
     }
 
@@ -239,19 +250,14 @@ impl EventHandlersExt for SvgViewer {
     }
 }
 
-/// The logical size implied by a pixel-sized layout.
-fn layout_pixel_size(layout: &LayoutData) -> Option<Size2D> {
-    match (&layout.width, &layout.height) {
-        (Size::Pixels(width), Size::Pixels(height)) => Some(Size2D::new(width.get(), height.get())),
-        _ => None,
-    }
-}
-
 impl Component for SvgViewer {
     fn render(&self) -> impl IntoElement {
         let scale_factor = *Platform::get().scale_factor.read();
-        let seed = layout_pixel_size(&self.layout);
-        let mut measured = use_state(|| seed);
+        let layout = self.layout.clone();
+        let mut measured = use_state(|| match (&layout.width, &layout.height) {
+            (Size::Pixels(width), Size::Pixels(height)) => Some(Size2D::new(width.get(), height.get())),
+            _ => None,
+        });
         let mut asset_cacher = use_hook(AssetCacher::get);
 
         let target = measured().map(|logical| {
@@ -266,50 +272,65 @@ impl Component for SvgViewer {
             AssetConfiguration::new((&self.source, target, style.as_key()), self.asset_age);
         let asset = use_asset(&asset_config);
 
-        use_side_effect_with_deps(
-            &(self.source.clone(), asset_config, target, style),
-            move |(source, asset_config, target, style)| {
-                let Some(target) = *target else {
-                    return;
-                };
-                if matches!(
-                    asset_cacher.read_asset(asset_config),
-                    Some(Asset::Pending) | Some(Asset::Error(_))
-                ) {
-                    asset_cacher.update_asset(asset_config.clone(), Asset::Loading);
+        // Rasterize whenever the source, size, style or parallel flag change.
+        let mut previous_configuration = use_state(|| None);
+        if *previous_configuration.peek() != Some((asset_config.clone(), self.parallel)) {
+            previous_configuration.set(Some((asset_config.clone(), self.parallel)));
 
-                    let source = source.clone();
+            if let Some(target) = target
+                && matches!(
+                    asset_cacher.read_asset(&asset_config),
+                    Some(Asset::Pending) | Some(Asset::Error(_))
+                )
+            {
+                asset_cacher.update_asset(asset_config.clone(), Asset::Loading);
+
+                if self.parallel {
+                    let source = self.source.clone();
                     let asset_config = asset_config.clone();
-                    let style = *style;
                     spawn_forever(async move {
-                        match rasterize(source, target, style).await {
-                            Ok(image) => {
-                                asset_cacher.update_asset(
-                                    asset_config,
-                                    Asset::Cached(Rc::new(ImageHandle::new(image, Bytes::new()))),
-                                );
+                        #[cfg(feature = "remote-asset")]
+                        let bytes = {
+                            let client = Http::get();
+                            blocking::unblock(move || source.fetch(&client)).await
+                        };
+                        #[cfg(not(feature = "remote-asset"))]
+                        let bytes = blocking::unblock(move || source.fetch()).await;
+
+                        let result = match bytes {
+                            Ok(bytes) => {
+                                let _permit = RASTER_LIMIT.acquire().await;
+                                blocking::unblock(move || rasterize_bytes(&bytes, target, style))
+                                    .await
                             }
-                            Err(err) => {
-                                asset_cacher
-                                    .update_asset(asset_config, Asset::Error(err.to_string()));
-                            }
-                        }
+                            Err(err) => Err(err),
+                        };
+                        store_raster(asset_cacher, asset_config, result);
                     });
+                } else {
+                    #[cfg(feature = "remote-asset")]
+                    let bytes = self.source.clone().fetch(&Http::get());
+                    #[cfg(not(feature = "remote-asset"))]
+                    let bytes = self.source.clone().fetch();
+
+                    let result =
+                        bytes.and_then(|bytes| rasterize_bytes(&bytes, target, style));
+                    store_raster(asset_cacher, asset_config.clone(), result);
                 }
-            },
-        );
+            }
+        }
 
         match asset {
             Asset::Cached(asset) => {
                 let handle = asset.downcast_ref::<ImageHandle>().unwrap().clone();
                 image(handle)
                     .accessibility(self.accessibility.clone())
-                    .layout(self.layout.clone())
+                    .layout(layout)
                     .image_data(self.image_data.clone())
                     .effect(self.effect.clone())
                     .with_event_handlers(self.event_handlers.clone())
                     .on_sized(move |event: Event<SizedEventData>| {
-                        measured.set_if_modified(Some(event.area.size));
+                        measured.set_if_modified(Some(event.visible_area.size));
                     })
                     .into_element()
             }
@@ -318,9 +339,10 @@ impl Component for SvgViewer {
                 None => err.into(),
             },
             Asset::Pending | Asset::Loading => rect()
-                .layout(self.layout.clone())
+                .layout(layout)
+                .with_event_handlers(self.event_handlers.clone())
                 .on_sized(move |event: Event<SizedEventData>| {
-                    measured.set_if_modified(Some(event.area.size));
+                    measured.set_if_modified(Some(event.visible_area.size));
                 })
                 .center()
                 .maybe(self.show_loader, |loading| {

--- a/crates/freya-components/src/svg_viewer.rs
+++ b/crates/freya-components/src/svg_viewer.rs
@@ -255,7 +255,9 @@ impl Component for SvgViewer {
         let scale_factor = *Platform::get().scale_factor.read();
         let layout = self.layout.clone();
         let mut measured = use_state(|| match (&layout.width, &layout.height) {
-            (Size::Pixels(width), Size::Pixels(height)) => Some(Size2D::new(width.get(), height.get())),
+            (Size::Pixels(width), Size::Pixels(height)) => {
+                Some(Size2D::new(width.get(), height.get()))
+            }
             _ => None,
         });
         let mut asset_cacher = use_hook(AssetCacher::get);
@@ -287,7 +289,6 @@ impl Component for SvgViewer {
 
                 if self.parallel {
                     let source = self.source.clone();
-                    let asset_config = asset_config.clone();
                     spawn_forever(async move {
                         #[cfg(feature = "remote-asset")]
                         let bytes = {
@@ -313,9 +314,8 @@ impl Component for SvgViewer {
                     #[cfg(not(feature = "remote-asset"))]
                     let bytes = self.source.clone().fetch();
 
-                    let result =
-                        bytes.and_then(|bytes| rasterize_bytes(&bytes, target, style));
-                    store_raster(asset_cacher, asset_config.clone(), result);
+                    let result = bytes.and_then(|bytes| rasterize_bytes(&bytes, target, style));
+                    store_raster(asset_cacher, asset_config, result);
                 }
             }
         }

--- a/crates/freya-components/tests/svg_viewer.rs
+++ b/crates/freya-components/tests/svg_viewer.rs
@@ -10,18 +10,11 @@ pub fn svg_viewer_rasterizes_and_renders() {
         SvgViewer::new(("ferris", include_bytes!("../../../examples/ferris.svg")))
             .width(Size::px(100.))
             .height(Size::px(100.))
+            .parallel(true)
     }
 
     let mut test = launch_test(app);
     test.sync_and_update();
-
-    // Nothing is rendered until the container is measured and the SVG is rasterized.
-    assert!(
-        test.find(|_, element| Image::try_downcast(element))
-            .is_none(),
-        "no image before rasterization"
-    );
-
     test.poll(
         std::time::Duration::from_millis(1),
         std::time::Duration::from_millis(120),
@@ -36,6 +29,43 @@ pub fn svg_viewer_rasterizes_and_renders() {
 }
 
 #[test]
+pub fn svg_viewer_rasterizes_synchronously_by_default() {
+    fn app() -> impl IntoElement {
+        SvgViewer::new(("ferris", include_bytes!("../../../examples/ferris.svg")))
+            .width(Size::px(100.))
+            .height(Size::px(100.))
+    }
+
+    let mut test = launch_test(app);
+    test.sync_and_update();
+
+    assert!(
+        test.find(|_, element| Image::try_downcast(element))
+            .is_some(),
+        "SVG should be rasterized without polling async tasks"
+    );
+}
+
+#[test]
+pub fn svg_viewer_rasterizes_at_visible_size() {
+    fn app() -> impl IntoElement {
+        SvgViewer::new(("ferris", include_bytes!("../../../examples/ferris.svg")))
+            .width(Size::px(100.))
+            .height(Size::px(100.))
+            .margin((0., 0., 0., 20.))
+    }
+
+    let mut test = launch_test(app);
+    test.sync_and_update();
+
+    let dimensions = test.find(|_, element| {
+        Image::try_downcast(element).map(|image| image.image_handle.image.dimensions())
+    });
+    // The raster must match the element's visible size, margins excluded.
+    assert_eq!(dimensions.map(|d| (d.width, d.height)), Some((100, 100)));
+}
+
+#[test]
 pub fn svg_viewer_custom_error_renderer() {
     fn app() -> impl IntoElement {
         SvgViewer::new(std::path::PathBuf::from("/non/existent.svg"))
@@ -45,11 +75,6 @@ pub fn svg_viewer_custom_error_renderer() {
     }
 
     let mut test = launch_test(app);
-    test.sync_and_update();
-    test.poll(
-        std::time::Duration::from_millis(1),
-        std::time::Duration::from_millis(120),
-    );
     test.sync_and_update();
 
     let error_label = test.find(|node, element| {

--- a/crates/freya-core/src/elements/extensions.rs
+++ b/crates/freya-core/src/elements/extensions.rs
@@ -550,7 +550,7 @@ where
 
 impl<T: ContainerExt> ContainerSizeExt for T {}
 
-/// Method for setting how an element is placed relative to its parent or the window.
+/// Methods for setting how an element is placed relative to its parent or the window.
 pub trait ContainerPositionExt
 where
     Self: LayoutExt,
@@ -558,6 +558,12 @@ where
     /// Set how the element is placed relative to its parent or the window. See [`Position`].
     fn position(mut self, position: impl Into<Position>) -> Self {
         self.get_layout().layout.position = position.into();
+        self
+    }
+
+    /// Set the outer spacing between the element's edges and its surroundings. See [`Gaps`].
+    fn margin(mut self, margin: impl Into<Gaps>) -> Self {
+        self.get_layout().layout.margin = margin.into();
         self
     }
 }
@@ -572,12 +578,6 @@ where
     /// Set the inner spacing between the element's edges and its content. See [`Gaps`].
     fn padding(mut self, padding: impl Into<Gaps>) -> Self {
         self.get_layout().layout.padding = padding.into();
-        self
-    }
-
-    /// Set the outer spacing between the element's edges and its surroundings. See [`Gaps`].
-    fn margin(mut self, margin: impl Into<Gaps>) -> Self {
-        self.get_layout().layout.margin = margin.into();
         self
     }
 

--- a/crates/freya-core/src/elements/image.rs
+++ b/crates/freya-core/src/elements/image.rs
@@ -292,8 +292,14 @@ impl ElementExt for ImageElement {
         let image_width = image.width() as f32;
         let image_height = image.height() as f32;
 
-        let width_ratio = context.area_size.width / image_width;
-        let height_ratio = context.area_size.height / image_height;
+        let margin = &context.torin_node.margin;
+        let area_size = Size2D::new(
+            (context.area_size.width - margin.horizontal()).max(0.),
+            (context.area_size.height - margin.vertical()).max(0.),
+        );
+
+        let width_ratio = area_size.width / image_width;
+        let height_ratio = area_size.height / image_height;
 
         let size = match self.image_data.aspect_ratio {
             AspectRatio::Max => {
@@ -307,7 +313,7 @@ impl ElementExt for ImageElement {
                 Size2D::new(image_width * ratio, image_height * ratio)
             }
             AspectRatio::Fit => Size2D::new(image_width, image_height),
-            AspectRatio::None => *context.area_size,
+            AspectRatio::None => area_size,
         };
 
         Some((size, Rc::new(size)))

--- a/crates/freya-core/src/elements/image.rs
+++ b/crates/freya-core/src/elements/image.rs
@@ -292,11 +292,7 @@ impl ElementExt for ImageElement {
         let image_width = image.width() as f32;
         let image_height = image.height() as f32;
 
-        let margin = &context.torin_node.margin;
-        let area_size = Size2D::new(
-            (context.area_size.width - margin.horizontal()).max(0.),
-            (context.area_size.height - margin.vertical()).max(0.),
-        );
+        let area_size = (*context.area_size - context.torin_node.margin.into()).max(Size2D::zero());
 
         let width_ratio = area_size.width / image_width;
         let height_ratio = area_size.height / image_height;

--- a/crates/freya-core/src/elements/image.rs
+++ b/crates/freya-core/src/elements/image.rs
@@ -240,6 +240,10 @@ impl ElementExt for ImageElement {
             diff.insert(DiffModifies::STYLE);
         }
 
+        if self.event_handlers != image.event_handlers {
+            diff.insert(DiffModifies::EVENT_HANDLERS);
+        }
+
         diff
     }
 
@@ -268,6 +272,10 @@ impl ElementExt for ImageElement {
 
     fn layer(&self) -> Layer {
         self.relative_layer
+    }
+
+    fn events_handlers(&'_ self) -> Option<Cow<'_, FxHashMap<EventName, EventHandlerType>>> {
+        Some(Cow::Borrowed(&self.event_handlers))
     }
 
     fn should_measure_inner_children(&self) -> bool {

--- a/crates/freya-winit/src/lib.rs
+++ b/crates/freya-winit/src/lib.rs
@@ -51,7 +51,6 @@ pub mod tray {
 pub fn launch(mut launch_config: LaunchConfig) {
     use std::collections::HashMap;
 
-    use freya_core::integration::*;
     use freya_engine::prelude::{
         FontCollection,
         FontMgr,
@@ -96,8 +95,6 @@ pub fn launch(mut launch_config: LaunchConfig) {
     font_collection.set_dynamic_font_manager(font_mgr.clone());
     font_collection.paragraph_cache_mut().turn_on(false);
 
-    let screen_reader = ScreenReader::new();
-
     struct FuturesWaker(EventLoopProxy<NativeEvent>);
 
     impl ArcWake for FuturesWaker {
@@ -131,7 +128,6 @@ pub fn launch(mut launch_config: LaunchConfig) {
         windows_configs: launch_config.windows_configs,
         plugins: launch_config.plugins,
         fallback_fonts: launch_config.fallback_fonts,
-        screen_reader,
         waker,
         exit_on_close: launch_config.exit_on_close,
         gpu_resource_cache_limit: launch_config.gpu_resource_cache_limit,

--- a/crates/freya-winit/src/renderer.rs
+++ b/crates/freya-winit/src/renderer.rs
@@ -88,7 +88,6 @@ pub struct WinitRenderer {
     pub proxy: EventLoopProxy<NativeEvent>,
     pub plugins: PluginsManager,
     pub fallback_fonts: Vec<Cow<'static, str>>,
-    pub screen_reader: ScreenReader,
     pub font_manager: FontMgr,
     pub font_collection: FontCollection,
     pub futures: Vec<Pin<Box<dyn std::future::Future<Output = ()>>>>,
@@ -102,7 +101,6 @@ pub struct RendererContext<'a> {
     pub proxy: &'a mut EventLoopProxy<NativeEvent>,
     pub plugins: &'a mut PluginsManager,
     pub fallback_fonts: &'a mut Vec<Cow<'static, str>>,
-    pub screen_reader: &'a mut ScreenReader,
     pub font_manager: &'a mut FontMgr,
     pub font_collection: &'a mut FontCollection,
     pub active_event_loop: &'a ActiveEventLoop,
@@ -119,7 +117,6 @@ impl RendererContext<'_> {
             self.font_collection,
             self.font_manager,
             self.fallback_fonts,
-            self.screen_reader.clone(),
             self.gpu_resource_cache_limit,
         );
 
@@ -290,7 +287,6 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                     &mut self.font_collection,
                     &self.font_manager,
                     &self.fallback_fonts,
-                    self.screen_reader.clone(),
                     self.gpu_resource_cache_limit,
                 );
 
@@ -352,7 +348,6 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                     windows: &mut self.windows,
                     proxy: &mut self.proxy,
                     plugins: &mut self.plugins,
-                    screen_reader: &mut self.screen_reader,
                     font_manager: &mut self.font_manager,
                     font_collection: &mut self.font_collection,
                     gpu_resource_cache_limit: self.gpu_resource_cache_limit,
@@ -379,7 +374,6 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                     windows: &mut self.windows,
                     proxy: &mut self.proxy,
                     plugins: &mut self.plugins,
-                    screen_reader: &mut self.screen_reader,
                     font_manager: &mut self.font_manager,
                     font_collection: &mut self.font_collection,
                     gpu_resource_cache_limit: self.gpu_resource_cache_limit,
@@ -410,7 +404,6 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                             &mut self.font_collection,
                             &self.font_manager,
                             &self.fallback_fonts,
-                            self.screen_reader.clone(),
                             self.gpu_resource_cache_limit,
                         );
 
@@ -519,7 +512,7 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                         NativeWindowEventAction::Accessibility(
                             accesskit_winit::WindowEvent::AccessibilityDeactivated,
                         ) => {
-                            self.screen_reader.set(false);
+                            app.screen_reader.set(false);
                         }
                         NativeWindowEventAction::Accessibility(
                             accesskit_winit::WindowEvent::ActionRequested(_),
@@ -529,7 +522,6 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                         ) => {
                             app.accessibility_tasks_for_next_render = AccessibilityTask::Init;
                             app.window.request_redraw();
-                            self.screen_reader.set(true);
                         }
                         NativeWindowEventAction::User(user_event) => match user_event {
                             UserEvent::RequestRedraw => {
@@ -570,7 +562,6 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                                             &mut self.font_collection,
                                             &self.font_manager,
                                             &self.fallback_fonts,
-                                            self.screen_reader.clone(),
                                             self.gpu_resource_cache_limit,
                                         );
 
@@ -615,7 +606,6 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                                             windows: &mut self.windows,
                                             proxy: &mut self.proxy,
                                             plugins: &mut self.plugins,
-                                            screen_reader: &mut self.screen_reader,
                                             font_manager: &mut self.font_manager,
                                             font_collection: &mut self.font_collection,
                                             gpu_resource_cache_limit: self.gpu_resource_cache_limit,
@@ -680,7 +670,6 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                             windows: &mut self.windows,
                             proxy: &mut self.proxy,
                             plugins: &mut self.plugins,
-                            screen_reader: &mut self.screen_reader,
                             font_manager: &mut self.font_manager,
                             font_collection: &mut self.font_collection,
                             gpu_resource_cache_limit: self.gpu_resource_cache_limit,
@@ -848,7 +837,9 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                                     LogicalSize::new(area.width(), area.height()),
                                 );
 
-                                app.accessibility_adapter.update_if_active(|| update);
+                                if app.screen_reader.is_on() {
+                                    app.accessibility_adapter.update_if_active(|| update);
+                                }
                             }
                             AccessibilityTask::Init => {
                                 let update = app.accessibility.init(&mut app.tree);
@@ -870,6 +861,7 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                                     LogicalSize::new(area.width(), area.height()),
                                 );
 
+                                app.screen_reader.set(true);
                                 app.accessibility_adapter.update_if_active(|| update);
                             }
                             AccessibilityTask::None => {}

--- a/crates/freya-winit/src/window.rs
+++ b/crates/freya-winit/src/window.rs
@@ -87,6 +87,7 @@ pub struct AppWindow {
     pub(crate) accessibility: AccessibilityTree,
     pub(crate) accessibility_adapter: accesskit_winit::Adapter,
     pub(crate) accessibility_tasks_for_next_render: AccessibilityTask,
+    pub(crate) screen_reader: ScreenReader,
 
     pub(crate) process_layout_on_next_render: bool,
 
@@ -127,7 +128,6 @@ impl AppWindow {
         font_collection: &mut FontCollection,
         font_manager: &FontMgr,
         fallback_fonts: &[Cow<'static, str>],
-        screen_reader: ScreenReader,
         gpu_resource_cache_limit: usize,
     ) -> Self {
         #[cfg(feature = "hotreload")]
@@ -180,7 +180,8 @@ impl AppWindow {
             }
         });
 
-        runner.provide_root_context(|| screen_reader);
+        let screen_reader = ScreenReader::new();
+        runner.provide_root_context(|| screen_reader.clone());
 
         let (mut ticker_sender, ticker) = RenderingTicker::new();
         ticker_sender.set_overflow(true);
@@ -349,6 +350,7 @@ impl AppWindow {
             accessibility: AccessibilityTree::default(),
             accessibility_adapter,
             accessibility_tasks_for_next_render: AccessibilityTask::ProcessUpdate { mode: None },
+            screen_reader,
 
             process_layout_on_next_render: true,
 

--- a/crates/torin/src/values/gaps.rs
+++ b/crates/torin/src/values/gaps.rs
@@ -1,7 +1,10 @@
 pub use euclid::Rect;
 
 use crate::{
-    geometry::Length,
+    geometry::{
+        Length,
+        Size2D,
+    },
     scaled::Scaled,
 };
 
@@ -40,6 +43,12 @@ impl From<(f32, f32)> for Gaps {
 impl From<(f32, f32, f32, f32)> for Gaps {
     fn from((top, right, bottom, left): (f32, f32, f32, f32)) -> Self {
         Gaps::new(top, right, bottom, left)
+    }
+}
+
+impl From<Gaps> for Size2D {
+    fn from(gaps: Gaps) -> Self {
+        Size2D::new(gaps.horizontal(), gaps.vertical())
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/2004

- Synchronous decoding by default in SvgViewer
- Allow passing event handlers in SvgViewer
- Use visible area for sizing in SvgViewer
- Exclude margin from image element rendering
- Prevent a11y init races by guarding properly