### PR TITLE
fix(core):Implement event handling for ImageElement

### DIFF
--- a/crates/freya-core/src/elements/image.rs
+++ b/crates/freya-core/src/elements/image.rs
@@ -240,6 +240,10 @@ impl ElementExt for ImageElement {
             diff.insert(DiffModifies::STYLE);
         }
 
+        if self.event_handlers != image.event_handlers {
+            diff.insert(DiffModifies::EVENT_HANDLERS);
+        }
+
         diff
     }
 
@@ -268,6 +272,10 @@ impl ElementExt for ImageElement {
 
     fn layer(&self) -> Layer {
         self.relative_layer
+    }
+
+    fn events_handlers(&'_ self) -> Option<Cow<'_, FxHashMap<EventName, EventHandlerType>>> {
+        Some(Cow::Borrowed(&self.event_handlers))
     }
 
     fn should_measure_inner_children(&self) -> bool {


### PR DESCRIPTION
## Description

`ImageElement` was missing an override of `events_handlers()` from `ElementExt`. The default implementation returns `None`, so the tree never registered the Image node's event handlers in its listener map. Consequently, any event handler attached to an `image()` element — including those forwarded by `SvgViewer` via `.with_event_handlers()` — was silently ignored and never fired.

This commit adds the missing `events_handlers()` override and also adds the `EVENT_HANDLERS` flag check in `diff()` so that handler changes on an existing Image element are properly tracked.

## Motivation

I encountered this bug while running the `component_input_form` example: clicking the eye icon had no effect — the password visibility toggle never fired. After investigation, the root cause was traced to `ImageElement` not reporting its event handlers to the tree.

## Checklist

- [x] I have tested my changes.
- [ ] I used AI assistance (e.g. ChatGPT, Copilot, etc.) to write this code.
- [ ] I have added or updated documentation where relevant.
- [ ] I have added or updated tests where relevant.
