### PR TITLE
fix(core): Use async watch instead of broadcast channel for rendering ticket to avoid congestion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 
 # Animations
 easer = "0.3.0"
-async-broadcast = "0.7.2"
+async-watch = "0.3.1"
 
 # Text editing
 ropey = "1.6.1"

--- a/crates/freya-core/Cargo.toml
+++ b/crates/freya-core/Cargo.toml
@@ -25,7 +25,7 @@ futures-channel = { workspace = true }
 futures-lite = { workspace = true }
 
 # Animations
-async-broadcast = { workspace = true }
+async-watch = { workspace = true }
 
 # Text
 keyboard-types = { workspace = true }

--- a/crates/freya-core/src/rendering_ticker.rs
+++ b/crates/freya-core/src/rendering_ticker.rs
@@ -1,22 +1,25 @@
 use crate::prelude::consume_root_context;
 
-pub type RenderingTickerSender = async_broadcast::Sender<()>;
+pub type RenderingTickerSender = async_watch::Sender<()>;
 
+/// Receives frame notifications.
 #[derive(Clone)]
 pub struct RenderingTicker {
-    rx: async_broadcast::Receiver<()>,
+    rx: async_watch::Receiver<()>,
 }
 
 impl RenderingTicker {
     pub fn get() -> Self {
         consume_root_context()
     }
-    pub fn new() -> (async_broadcast::Sender<()>, Self) {
-        let (tx, rx) = async_broadcast::broadcast(256);
+
+    pub fn new() -> (RenderingTickerSender, Self) {
+        let (tx, rx) = async_watch::channel(());
         (tx, Self { rx })
     }
 
+    /// Wait until the next frame should be processed.
     pub async fn tick(&mut self) {
-        self.rx.recv().await.ok();
+        self.rx.changed().await.ok();
     }
 }

--- a/crates/freya-testing/src/lib.rs
+++ b/crates/freya-testing/src/lib.rs
@@ -184,8 +184,7 @@ impl TestingRunner {
 
         runner.provide_root_context(ScreenReader::new);
 
-        let (mut ticker_sender, ticker) = RenderingTicker::new();
-        ticker_sender.set_overflow(true);
+        let (ticker_sender, ticker) = RenderingTicker::new();
         runner.provide_root_context(|| ticker);
 
         let animation_clock = runner.provide_root_context(AnimationClock::new);
@@ -392,7 +391,7 @@ impl TestingRunner {
             self.handle_events_immediately();
             self.sync_and_update();
             std::thread::sleep(step);
-            self.ticker_sender.broadcast_blocking(()).unwrap();
+            self.ticker_sender.send(()).ok();
         }
     }
 
@@ -403,7 +402,7 @@ impl TestingRunner {
             self.handle_events_immediately();
             self.sync_and_update();
             std::thread::sleep(step);
-            self.ticker_sender.broadcast_blocking(()).unwrap();
+            self.ticker_sender.send(()).ok();
         }
     }
 

--- a/crates/freya-winit/src/renderer.rs
+++ b/crates/freya-winit/src/renderer.rs
@@ -876,9 +876,7 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                             PluginHandle::new(&self.proxy),
                         );
 
-                        if app.ticker_sender.receiver_count() > 0 {
-                            app.ticker_sender.broadcast_blocking(()).unwrap();
-                        }
+                        app.ticker_sender.send(()).ok();
 
                         self.plugins.send(
                             PluginEvent::AfterRedraw {

--- a/crates/freya-winit/src/window.rs
+++ b/crates/freya-winit/src/window.rs
@@ -183,8 +183,7 @@ impl AppWindow {
         let screen_reader = ScreenReader::new();
         runner.provide_root_context(|| screen_reader.clone());
 
-        let (mut ticker_sender, ticker) = RenderingTicker::new();
-        ticker_sender.set_overflow(true);
+        let (ticker_sender, ticker) = RenderingTicker::new();
         runner.provide_root_context(|| ticker);
 
         let animation_clock = AnimationClock::new();


### PR DESCRIPTION
Closes https://github.com/marc2332/freya/issues/2009

The issue goes basically like:

<- RedrawRequest
-> RenderingTicker is notified
---> animation moves forward
<- RedrawRequest
-> RenderingTicker is notified
<- RedrawRequest
-> RenderingTicker is notified
<- RedrawRequest
-> RenderingTicker is notified
<- RedrawRequest
-> RenderingTicker is notified
---> animation moves forward
<- RedrawRequest
---> animation moves forward
<- RedrawRequest
---> animation moves forward
<- RedrawRequest
---> animation moves forward

Now it goes like

<- RedrawRequest
-> RenderingTicker is notified
---> animation moves forward
<- RedrawRequest
-> RenderingTicker is notified
<- RedrawRequest
-> RenderingTicker is notified
<- RedrawRequest
-> RenderingTicker is notified
<- RedrawRequest
-> RenderingTicker is notified
---> animation moves forward
<- RedrawRequest


RenderingTicker notifications are no longer accumulated, leading to less events sent to the winit event loop, which for unknown reasons to me was freezing only in Windows. Linux was working fine already before. Unexpected outcome of this is that animations should be smoother in theory in all platforms, but only in heavy animations will the difference be notable anyway.