### PR TITLE
fix(components): Hide scrollbar and thumb when its smaller than the minimum

### DIFF
--- a/crates/freya-components/src/scrollviews/shared.rs
+++ b/crates/freya-components/src/scrollviews/shared.rs
@@ -72,11 +72,7 @@ pub fn is_scrollbar_visible(
     inner_size: f32,
     viewport_size: f32,
 ) -> bool {
-    if is_scrollbar_enabled {
-        viewport_size > 0. && viewport_size < inner_size
-    } else {
-        false
-    }
+    is_scrollbar_enabled && viewport_size > MIN_SCROLLBAR_SIZE && viewport_size < inner_size
 }
 
 const MIN_SCROLLBAR_SIZE: f32 = 50.0;
@@ -87,16 +83,12 @@ pub fn get_scrollbar_pos_and_size(
     viewport_size: f32,
     scroll_position: f32,
 ) -> (f32, f32) {
-    if viewport_size >= inner_size {
-        return (0.0, inner_size);
+    if viewport_size <= MIN_SCROLLBAR_SIZE || viewport_size >= inner_size {
+        return (0.0, 0.0);
     }
 
     let viewable_ratio = viewport_size / inner_size;
-    let mut scrollbar_size = viewport_size * viewable_ratio;
-
-    if scrollbar_size < MIN_SCROLLBAR_SIZE {
-        scrollbar_size = MIN_SCROLLBAR_SIZE;
-    }
+    let scrollbar_size = (viewport_size * viewable_ratio).max(MIN_SCROLLBAR_SIZE);
 
     let available_scroll_range = inner_size - viewport_size;
     let available_thumb_range = viewport_size - scrollbar_size;
@@ -112,16 +104,12 @@ pub fn get_scroll_position_from_cursor(
     inner_size: f32,
     viewport_size: f32,
 ) -> i32 {
-    if viewport_size >= inner_size {
+    if viewport_size <= MIN_SCROLLBAR_SIZE || viewport_size >= inner_size {
         return 0;
     }
 
     let viewable_ratio = viewport_size / inner_size;
-    let mut scrollbar_size = viewport_size * viewable_ratio;
-
-    if scrollbar_size < MIN_SCROLLBAR_SIZE {
-        scrollbar_size = MIN_SCROLLBAR_SIZE;
-    }
+    let scrollbar_size = (viewport_size * viewable_ratio).max(MIN_SCROLLBAR_SIZE);
 
     let available_scroll_range = inner_size - viewport_size;
     let available_thumb_range = viewport_size - scrollbar_size;

--- a/crates/freya-components/tests/scrollview.rs
+++ b/crates/freya-components/tests/scrollview.rs
@@ -221,3 +221,53 @@ pub fn scroll_view_drag_scrolling_horizontal() {
     assert!(content[2].is_visible());
     assert!(content[3].is_visible());
 }
+
+#[test]
+pub fn scroll_view_scrollbar_smaller_than_thumb() {
+    fn small_scroll_view_app() -> impl IntoElement {
+        rect().height(Size::px(48.)).width(Size::px(200.)).child(
+            ScrollView::new().children((0..30).map(|i| {
+                label()
+                    .key(i)
+                    .height(Size::px(20.))
+                    .text(format!("Row {i}"))
+                    .into()
+            })),
+        )
+    }
+
+    let mut test = launch_test(small_scroll_view_app);
+    test.sync_and_update();
+
+    test.move_cursor((100., 24.));
+    test.sync_and_update();
+    test.scroll((100., 24.), (0., -20.));
+    test.sync_and_update();
+
+    let scrollview = test
+        .find(|node, element| {
+            Rect::try_downcast(element)
+                .filter(|rect| rect.accessibility.builder.role() == AccessibilityRole::ScrollView)
+                .map(move |_| node)
+        })
+        .unwrap();
+    let scrolled_before = scrollview.children()[0].children()[0].children()[0]
+        .layout()
+        .area
+        .min_y();
+
+    test.move_cursor((192., 5.));
+    test.sync_and_update();
+    test.press_cursor((192., 5.));
+    test.sync_and_update();
+    test.move_cursor((192., 30.));
+    test.sync_and_update();
+    test.release_cursor((192., 30.));
+    test.sync_and_update();
+
+    let scrolled_after = scrollview.children()[0].children()[0].children()[0]
+        .layout()
+        .area
+        .min_y();
+    assert_eq!(scrolled_before, scrolled_after);
+}

--- a/crates/freya-components/tests/scrollview.rs
+++ b/crates/freya-components/tests/scrollview.rs
@@ -225,15 +225,16 @@ pub fn scroll_view_drag_scrolling_horizontal() {
 #[test]
 pub fn scroll_view_scrollbar_smaller_than_thumb() {
     fn small_scroll_view_app() -> impl IntoElement {
-        rect().height(Size::px(48.)).width(Size::px(200.)).child(
-            ScrollView::new().children((0..30).map(|i| {
+        rect()
+            .height(Size::px(48.))
+            .width(Size::px(200.))
+            .child(ScrollView::new().children((0..30).map(|i| {
                 label()
                     .key(i)
                     .height(Size::px(20.))
                     .text(format!("Row {i}"))
                     .into()
-            })),
-        )
+            })))
     }
 
     let mut test = launch_test(small_scroll_view_app);


### PR DESCRIPTION
This effectively fixes a runtime crash:

```sh
thread 'main' (129788) panicked at /home/skye/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/f32.rs:1565:9:
min > max, or either was NaN. min = 0.0, max = -2.0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```