### PR TITLE
fix(components): More reliable context menu closing

### DIFF
--- a/crates/freya-components/src/color_picker.rs
+++ b/crates/freya-components/src/color_picker.rs
@@ -342,8 +342,7 @@ impl Component for ColorPicker {
                                 if ContextMenu::is_open() {
                                     ContextMenu::close();
                                 } else {
-                                    ContextMenu::open_from_event(
-                                        &e,
+                                    ContextMenu::open(
                                         Menu::new()
                                             .child(
                                                 MenuButton::new()

--- a/crates/freya-components/src/context_menu.rs
+++ b/crates/freya-components/src/context_menu.rs
@@ -10,10 +10,15 @@ use torin::prelude::{
 
 use crate::menu::Menu;
 
+/// Closing is only allowed once a new click starts after the menu opened.
 #[derive(Clone, Copy, PartialEq)]
-pub(crate) enum ContextMenuCloseRequest {
-    None,
-    Pending,
+pub(crate) enum ClosePhase {
+    /// A down event just happened, now waiting for its press.
+    PendingPress,
+    /// Waiting for a new click.
+    Idle,
+    /// A new click started, it may close the menu.
+    CloseAllowed,
 }
 
 /// Global context menu state.
@@ -27,9 +32,8 @@ pub(crate) enum ContextMenuCloseRequest {
 /// fn app() -> impl IntoElement {
 ///     rect().child(ContextMenuViewer::new()).child(
 ///         rect()
-///             .on_secondary_down(move |e: Event<PressEventData>| {
-///                 ContextMenu::open_from_event(
-///                     &e,
+///             .on_secondary_down(move |_| {
+///                 ContextMenu::open_from_down(
 ///                     Menu::new().child(MenuButton::new().child("Option 1")),
 ///                 );
 ///             })
@@ -41,7 +45,7 @@ pub(crate) enum ContextMenuCloseRequest {
 pub struct ContextMenu {
     pub(crate) location: State<CursorPoint>,
     pub(crate) menu: State<Option<(CursorPoint, Menu)>>,
-    pub(crate) close_request: State<ContextMenuCloseRequest>,
+    pub(crate) close_phase: State<ClosePhase>,
 }
 
 impl ContextMenu {
@@ -57,34 +61,20 @@ impl ContextMenu {
         try_consume_root_context::<Self>().is_some_and(|c| c.menu.read().is_some())
     }
 
-    /// Open the context menu with the given menu.
-    /// Prefer using [`ContextMenu::open_from_event`] instead as it correctly handles
-    /// the close behavior based on the source event.
+    /// Open the context menu, from a press event or programmatically.
     pub fn open(menu: Menu) {
-        let mut this = Self::get();
-        this.menu.set(Some(((this.location)(), menu)));
-        this.close_request.set(ContextMenuCloseRequest::None);
+        Self::open_with_phase(menu, ClosePhase::Idle);
     }
 
-    /// Open the context menu with the given menu, using the source event to determine
-    /// the close behavior. When opened from a primary button (left click) press event,
-    /// the first close request is consumed to prevent the menu from closing immediately.
-    /// When opened from a secondary button (right click) down event, the menu can be
-    /// closed with a single click.
-    pub fn open_from_event(event: &Event<PressEventData>, menu: Menu) {
-        let mut this = Self::get();
-        let was_already_open = this.menu.read().is_some();
-        this.menu.set(Some(((this.location)(), menu)));
+    /// Open the context menu from a pointer down event, like `on_secondary_down`.
+    pub fn open_from_down(menu: Menu) {
+        Self::open_with_phase(menu, ClosePhase::PendingPress);
+    }
 
-        let close_request = match event.data() {
-            PressEventData::Mouse(mouse)
-                if mouse.button == Some(MouseButton::Left) && !was_already_open =>
-            {
-                ContextMenuCloseRequest::Pending
-            }
-            _ => ContextMenuCloseRequest::None,
-        };
-        this.close_request.set(close_request);
+    fn open_with_phase(menu: Menu, phase: ClosePhase) {
+        let mut this = Self::get();
+        this.menu.set(Some(((this.location)(), menu)));
+        this.close_phase.set(phase);
     }
 
     pub fn close() {
@@ -135,10 +125,7 @@ impl ComponentOwned for ContextMenuViewer {
                 let state = ContextMenu {
                     location: State::create_in_scope(CursorPoint::default(), ScopeId::ROOT),
                     menu: State::create_in_scope(None, ScopeId::ROOT),
-                    close_request: State::create_in_scope(
-                        ContextMenuCloseRequest::None,
-                        ScopeId::ROOT,
-                    ),
+                    close_phase: State::create_in_scope(ClosePhase::Idle, ScopeId::ROOT),
                 };
                 provide_context_for_scope_id(state, ScopeId::ROOT);
                 state
@@ -148,7 +135,6 @@ impl ComponentOwned for ContextMenuViewer {
         use_side_effect(move || {
             if !*Platform::get().is_app_focused.read() {
                 context.menu.set(None);
-                context.close_request.set(ContextMenuCloseRequest::None);
             }
         });
 
@@ -156,20 +142,30 @@ impl ComponentOwned for ContextMenuViewer {
             .on_global_pointer_move(move |e: Event<PointerEventData>| {
                 context.location.set(e.global_location());
             })
+            .on_global_pointer_down(move |_: Event<PointerEventData>| {
+                if context.menu.read().is_some() {
+                    let phase = match (context.close_phase)() {
+                        ClosePhase::PendingPress => ClosePhase::Idle,
+                        _ => ClosePhase::CloseAllowed,
+                    };
+                    context.close_phase.set(phase);
+                }
+            })
             .maybe_child(context.menu.read().clone().map(|(location, menu)| {
                 let location = location.to_f32();
                 rect()
                     .layer(Layer::Overlay)
                     .position(Position::new_global().left(location.x).top(location.y))
-                    .child(menu.on_close(move |_| match (context.close_request)() {
-                        ContextMenuCloseRequest::None => {
-                            context.close_request.set(ContextMenuCloseRequest::Pending);
-                        }
-                        ContextMenuCloseRequest::Pending => {
+                    .child(
+                        menu.on_close(move |_| {
+                            if (context.close_phase)() == ClosePhase::CloseAllowed {
+                                context.menu.set(None);
+                            }
+                        })
+                        .on_escape(move |_| {
                             context.menu.set(None);
-                            context.close_request.set(ContextMenuCloseRequest::None);
-                        }
-                    }))
+                        }),
+                    )
             }))
     }
 

--- a/crates/freya-components/src/menu.rs
+++ b/crates/freya-components/src/menu.rs
@@ -106,6 +106,7 @@ pub struct Menu {
     pub(crate) theme: Option<MenuContainerThemePartial>,
     children: Vec<Element>,
     on_close: Option<EventHandler<()>>,
+    on_escape: Option<EventHandler<()>>,
     key: DiffKey,
 }
 
@@ -124,6 +125,12 @@ impl KeyExt for Menu {
 impl Menu {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Called when Escape closes the menu, falls back to [`Menu::on_close`].
+    pub fn on_escape(mut self, f: impl Into<EventHandler<()>>) -> Self {
+        self.on_escape = Some(f.into());
+        self
     }
 
     pub fn on_close<F>(mut self, f: F) -> Self
@@ -150,13 +157,13 @@ impl ComponentOwned for Menu {
         // Provide this the ROOT Menu ID
         use_provide_context(|| ROOT_MENU);
 
-        let on_close = self.on_close.clone();
+        let on_escape = self.on_escape.clone().or(self.on_close.clone());
         let on_global_key_down = move |e: Event<KeyboardEventData>| {
             if e.key == Key::Named(NamedKey::Escape) {
                 if menus.read().len() > 1 {
                     menus.write().pop();
-                } else if let Some(on_close) = &on_close {
-                    on_close.call(());
+                } else if let Some(on_escape) = &on_escape {
+                    on_escape.call(());
                 }
             }
         };

--- a/crates/freya-components/tests/context_menu.rs
+++ b/crates/freya-components/tests/context_menu.rs
@@ -1,0 +1,80 @@
+use freya::prelude::*;
+use freya_testing::prelude::*;
+
+fn context_menu_app() -> impl IntoElement {
+    rect().expanded().child(ContextMenuViewer::new()).child(
+        rect()
+            .expanded()
+            .on_secondary_down(|_| {
+                ContextMenu::open_from_down(Menu::new().child(MenuButton::new().child("Item")));
+            })
+            .child("Area"),
+    )
+}
+
+fn menu_is_open(test: &mut TestingRunner) -> bool {
+    test.find(|_, element| Label::try_downcast(element).filter(|l| l.text.as_ref() == "Item"))
+        .is_some()
+}
+
+fn right_button(test: &mut TestingRunner, name: MouseEventName, cursor: (f64, f64)) {
+    test.send_event(PlatformEvent::Mouse {
+        name,
+        cursor: cursor.into(),
+        button: Some(MouseButton::Right),
+    });
+}
+
+fn right_click(test: &mut TestingRunner, cursor: (f64, f64)) {
+    right_button(test, MouseEventName::MouseDown, cursor);
+    test.sync_and_update();
+    right_button(test, MouseEventName::MouseUp, cursor);
+    test.sync_and_update();
+}
+
+#[test]
+pub fn context_menu_closes_with_a_single_click() {
+    let mut test = launch_test(context_menu_app);
+    test.sync_and_update();
+
+    right_click(&mut test, (100.0, 100.0));
+    assert!(menu_is_open(&mut test));
+
+    test.click_cursor((400.0, 400.0));
+    assert!(!menu_is_open(&mut test));
+
+    right_click(&mut test, (100.0, 100.0));
+    right_click(&mut test, (300.0, 200.0));
+    assert!(menu_is_open(&mut test));
+
+    test.click_cursor((400.0, 400.0));
+    assert!(!menu_is_open(&mut test));
+}
+
+#[test]
+pub fn context_menu_closes_with_a_single_click_after_a_fast_open() {
+    let mut test = launch_test(context_menu_app);
+    test.sync_and_update();
+
+    // A fast click's release is processed before the menu has mounted
+    right_button(&mut test, MouseEventName::MouseDown, (100.0, 100.0));
+    right_button(&mut test, MouseEventName::MouseUp, (100.0, 100.0));
+    test.sync_and_update();
+    assert!(menu_is_open(&mut test));
+
+    test.click_cursor((400.0, 400.0));
+    assert!(!menu_is_open(&mut test));
+}
+
+#[test]
+pub fn context_menu_closes_with_escape() {
+    let mut test = launch_test(context_menu_app);
+    test.sync_and_update();
+
+    right_click(&mut test, (100.0, 100.0));
+    assert!(menu_is_open(&mut test));
+
+    test.press_key(Key::Named(NamedKey::Escape));
+    test.sync_and_update();
+    assert!(!menu_is_open(&mut test));
+}

--- a/crates/freya-devtools-app/src/node.rs
+++ b/crates/freya-devtools-app/src/node.rs
@@ -77,7 +77,7 @@ impl Component for NodeElement {
             let on_expand_all = self.on_expand_all.clone();
             let on_collapse_all = self.on_collapse_all.clone();
             let is_open = self.is_open;
-            move |e: Event<PressEventData>| {
+            move |_: Event<PressEventData>| {
                 let on_toggle = on_toggle.clone();
                 let on_expand_all = on_expand_all.clone();
                 let on_collapse_all = on_collapse_all.clone();

--- a/crates/freya-devtools-app/src/node.rs
+++ b/crates/freya-devtools-app/src/node.rs
@@ -81,8 +81,7 @@ impl Component for NodeElement {
                 let on_toggle = on_toggle.clone();
                 let on_expand_all = on_expand_all.clone();
                 let on_collapse_all = on_collapse_all.clone();
-                ContextMenu::open_from_event(
-                    &e,
+                ContextMenu::open_from_down(
                     Menu::new()
                         .child(
                             MenuItem::new()

--- a/examples/component_context_menu.rs
+++ b/examples/component_context_menu.rs
@@ -39,7 +39,7 @@ fn app() -> impl IntoElement {
         .child(ContextMenuViewer::new())
         .child(
             Button::new()
-                .on_press(move |e: Event<PressEventData>| {
+                .on_press(move |_: Event<PressEventData>| {
                     if ContextMenu::is_open() {
                         ContextMenu::close();
                     } else {

--- a/examples/component_context_menu.rs
+++ b/examples/component_context_menu.rs
@@ -43,7 +43,7 @@ fn app() -> impl IntoElement {
                     if ContextMenu::is_open() {
                         ContextMenu::close();
                     } else {
-                        ContextMenu::open_from_event(&e, context_menu())
+                        ContextMenu::open(context_menu())
                     }
                 })
                 .child("Open"),

--- a/examples/feature_material_design.rs
+++ b/examples/feature_material_design.rs
@@ -48,7 +48,7 @@ fn app() -> impl IntoElement {
                     if ContextMenu::is_open() {
                         ContextMenu::close();
                     } else {
-                        ContextMenu::open_from_event(&e, context_menu());
+                        ContextMenu::open(context_menu());
                     }
                 })
                 .flat()

--- a/examples/feature_material_design.rs
+++ b/examples/feature_material_design.rs
@@ -44,7 +44,7 @@ fn app() -> impl IntoElement {
         .child(ContextMenuViewer::new())
         .child(
             Button::new()
-                .on_press(|e: Event<PressEventData>| {
+                .on_press(|_: Event<PressEventData>| {
                     if ContextMenu::is_open() {
                         ContextMenu::close();
                     } else {

--- a/examples/feature_secondary_press.rs
+++ b/examples/feature_secondary_press.rs
@@ -11,8 +11,7 @@ fn main() {
 
 fn app() -> impl IntoElement {
     let on_secondary_down = move |e: Event<PressEventData>| {
-        ContextMenu::open_from_event(
-            &e,
+        ContextMenu::open_from_down(
             Menu::new().child(
                 MenuItem::new()
                     .on_press(move |_| {

--- a/examples/feature_secondary_press.rs
+++ b/examples/feature_secondary_press.rs
@@ -10,7 +10,7 @@ fn main() {
 }
 
 fn app() -> impl IntoElement {
-    let on_secondary_down = move |e: Event<PressEventData>| {
+    let on_secondary_down = move |_: Event<PressEventData>| {
         ContextMenu::open_from_down(
             Menu::new().child(
                 MenuItem::new()


### PR DESCRIPTION
Seems like how I was tracking the close requests was not good enough as it would not work as I expected when using open_from_event and right click in apps where opening the context menu just takes a bit more of time that I expected, e.g feature_secondary_press is just too simple to notice this issue.