### PR TITLE
remove rust toolchain from nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,94 +11,66 @@
     inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = {
-    nixpkgs,
-    flake-utils,
-    fenix,
-    ...
-  }:
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      fenix,
+      ...
+    }:
     flake-utils.lib.eachDefaultSystem (
-      system: let
+      system:
+      let
         pkgs = nixpkgs.legacyPackages.${system};
-
-        commonPackages = [
-          pkgs.python3
-          pkgs.just
-          pkgs.taplo
-          pkgs.cargo-nextest
-          pkgs.alejandra
-          pkgs.dioxus-cli
-        ];
-
-        commonBuildInputs = with pkgs; [
-          libxkbcommon
-          libGL
-          udev
-          openssl
-          pkg-config
-          fontconfig
-          libgcc.lib
-          freetype
-          cairo
-          gdk-pixbuf
-          pango
-          atk
-          xdo
-
-          llvmPackages.bintools
-
-          # required by "webview" and "tray" `--features`
-          glib
-          gtk3
-          webkitgtk_4_1
-          libsoup_3
-          xdotool
-
-          # WINIT_UNIX_BACKEND=wayland
-          wayland
-
-          # WINIT_UNIX_BACKEND=x11
-          libxcursor
-          libxrandr
-          libxi
-          libx11
-        ];
-
-        mkDevShell = toolchain:
-          pkgs.mkShell rec {
-            packages =
-              commonPackages
-              ++ [
-                toolchain
-              ];
-            buildInputs = commonBuildInputs;
-            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath buildInputs}";
-          };
-
-        stableToolchain = fenix.packages.${system}.fromToolchainFile {
-          file = ./rust-toolchain.toml;
-          # Whenever `channel` in `rust-toolchain.toml` has been updated, `sha256` needs to be updated as well: 
-          # 1. replace `sha256` with `pkgs.lib.fakeSha256`, 
-          # 2. copy the expected hash from the error
-          # 3. Update `sha256` with the new hash
-          sha256 = "sha256-zC8E38iDVJ1oPIzCqTk/Ujo9+9kx9dXq7wAwPMpkpg0=";
-        };
-
-        nightlyToolchain = fenix.packages.${system}.fromToolchainFile {
-          file = ./rust-toolchain-nightly.toml;
-          # Whenever `channel` in `rust-toolchain-nightly.toml` has been updated, `sha256` needs to be updated as well: 
-          # 1. replace `sha256` with `pkgs.lib.fakeSha256`, 
-          # 2. copy the expected hash from the error
-          # 3. Update `sha256` with the new hash
-          # sha256 = pkgs.lib.fakeSha256;
-          sha256 = "sha256-4ot8+Fs79G1hUwlEYI6700QBLKdkLb33yzwOou1o5Yk=";
-        };
-      in {
+      in
+      {
         formatter = pkgs.alejandra;
 
         devShells = {
-          default = mkDevShell stableToolchain;
-          unstable = mkDevShell nightlyToolchain;
+          default = pkgs.mkShell rec {
+            packages = [
+              pkgs.python3
+              pkgs.just
+              pkgs.taplo
+              pkgs.cargo-nextest
+              pkgs.alejandra
+              pkgs.dioxus-cli
+            ];
+            buildInputs = with pkgs; [
+              libxkbcommon
+              libGL
+              udev
+              openssl
+              pkg-config
+              fontconfig
+              libgcc.lib
+              freetype
+              cairo
+              gdk-pixbuf
+              pango
+              atk
+              xdo
+
+              llvmPackages.bintools
+
+              # required by "webview" and "tray" `--features`
+              glib
+              gtk3
+              webkitgtk_4_1
+              libsoup_3
+              xdotool
+
+              # WINIT_UNIX_BACKEND=wayland
+              wayland
+
+              # WINIT_UNIX_BACKEND=x11
+              libxcursor
+              libxrandr
+              libxi
+              libx11
+            ];
+            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath buildInputs}";
+          };
         };
       }
     );

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 profile = "default"
 components = ["rust-src", "rust-analyzer"]


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->
removes the rust toolchain from the devshell in favor of using rustup directly
## Motivation

<!-- Why did you make this change? (e.g. I encountered a crash, a weird behavior, a missing feature, or I was reading the source code and spotted an improvement) -->

## Checklist

- [x] I have tested my changes.
- [ ] I used AI assistance (e.g. ChatGPT, Copilot, etc.) to write this code.
- [x] I have added or updated documentation where relevant.
- [x] I have added or updated tests where relevant.
