### PR TITLE
chore: Move rendering backend features selection to freya-winit

### DIFF
--- a/crates/freya-engine/Cargo.toml
+++ b/crates/freya-engine/Cargo.toml
@@ -14,21 +14,12 @@ categories = ["gui"]
 [lints]
 workspace = true
 
+[features]
+gl = ["freya-skia-safe/gl"]
+vulkan = ["freya-skia-safe/vulkan"]
+metal = ["freya-skia-safe/metal"]
+x11 = ["freya-skia-safe/x11"]
+wayland = ["freya-skia-safe/wayland"]
+
 [dependencies]
 freya-skia-safe = { workspace = true }
-
-[target."cfg(target_os = \"linux\")".dependencies.freya-skia-safe]
-workspace = true
-features = ["textlayout", "svg", "x11", "wayland", "vulkan", "gl"]
-
-[target."cfg(target_os = \"macos\")".dependencies.freya-skia-safe]
-workspace = true
-features = ["textlayout", "svg", "metal"]
-
-[target."cfg(target_os = \"windows\")".dependencies.freya-skia-safe]
-workspace = true
-features = ["textlayout", "svg", "vulkan", "gl"]
-
-[target."cfg(target_os = \"android\")".dependencies.freya-skia-safe]
-workspace = true
-features = ["textlayout", "svg", "gl"]

--- a/crates/freya-engine/src/skia.rs
+++ b/crates/freya-engine/src/skia.rs
@@ -1,13 +1,28 @@
-#[cfg(any(target_os = "linux", target_os = "windows", target_os = "android"))]
+#[cfg(feature = "gl")]
 pub use skia_safe::gpu::gl::{
     Format,
     FramebufferInfo,
     Interface,
 };
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 pub use skia_safe::gpu::mtl;
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(feature = "vulkan")]
 pub use skia_safe::gpu::vk;
+#[cfg(any(feature = "gl", feature = "vulkan", feature = "metal"))]
+pub use skia_safe::gpu::{
+    self,
+    BackendRenderTarget,
+    Budgeted,
+    DirectContext,
+    RecordingContext,
+    SurfaceOrigin,
+    backend_render_targets,
+    direct_contexts,
+    surfaces::{
+        render_target,
+        wrap_backend_render_target,
+    },
+};
 pub use skia_safe::{
     AlphaType,
     Bitmap,
@@ -64,20 +79,6 @@ pub use skia_safe::{
         Slant,
         Weight,
         Width,
-    },
-    gpu::{
-        self,
-        BackendRenderTarget,
-        Budgeted,
-        DirectContext,
-        RecordingContext,
-        SurfaceOrigin,
-        backend_render_targets,
-        direct_contexts,
-        surfaces::{
-            render_target,
-            wrap_backend_render_target,
-        },
     },
     gradient::{
         Colors,

--- a/crates/freya-winit/Cargo.toml
+++ b/crates/freya-winit/Cargo.toml
@@ -66,6 +66,15 @@ rfd = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18.2", optional = true }
+freya-engine = { workspace = true, features = [
+  "gl",
+  "vulkan",
+  "x11",
+  "wayland",
+] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+freya-engine = { workspace = true, features = ["gl", "vulkan"] }
 
 # Rendering OpenGL + Vulkan (Linux/Windows)
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
@@ -80,6 +89,7 @@ ash-window = { workspace = true }
 gl = { workspace = true }
 glutin = { workspace = true }
 glutin-winit = { workspace = true }
+freya-engine = { workspace = true, features = ["gl"] }
 
 # Rendering Metal (macOS)
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -88,6 +98,7 @@ objc2 = { version = "0.6" }
 objc2-metal = { version = "0.3" }
 objc2-quartz-core = { version = "0.3" }
 objc2-app-kit = { version = "0.3" }
+freya-engine = { workspace = true, features = ["metal"] }
 
 [dev-dependencies]
 freya = { path = "../freya" }


### PR DESCRIPTION
Move rendering backend features selection to freya-winit so that using freya without winit doesnt pull e.g gl.