### PR TITLE
fix(core): Reset scope when component with the same key changes its type

### DIFF
--- a/crates/freya-core/src/runner.rs
+++ b/crates/freya-core/src/runner.rs
@@ -1,5 +1,8 @@
 use std::{
-    any::TypeId,
+    any::{
+        Any,
+        TypeId,
+    },
     cell::RefCell,
     cmp::Ordering,
     collections::{
@@ -811,11 +814,16 @@ impl Runner {
                     .map(|s| s.try_borrow_mut())
                 {
                     let key_changed = existing_scope.key != *key;
-                    if key_changed || existing_scope.props.changed(props.as_ref()) {
+                    // Colliding keys can pair components of different types, which requires a full reset
+                    let type_changed = (existing_scope.props.as_ref() as &dyn Any).type_id()
+                        != (props.as_ref() as &dyn Any).type_id();
+                    if key_changed || type_changed || existing_scope.props.changed(props.as_ref()) {
                         self.dirty_scopes.insert(assigned_scope_id);
                         existing_scope.props = props.clone();
 
-                        if key_changed {
+                        if key_changed || type_changed {
+                            existing_scope.key = key.clone();
+                            existing_scope.comp = comp.clone();
                             self.scopes_storages
                                 .borrow_mut()
                                 .get_mut(&assigned_scope_id)

--- a/crates/freya-core/tests/keys.rs
+++ b/crates/freya-core/tests/keys.rs
@@ -117,3 +117,66 @@ pub fn same_key_different_from_fn_component() {
     });
     assert!(label.is_some());
 }
+
+#[derive(PartialEq)]
+struct IdCompA {
+    id: usize,
+}
+
+impl Component for IdCompA {
+    fn render(&self) -> impl IntoElement {
+        let count = use_state(|| 0usize);
+        format!("A{}", count.read())
+    }
+
+    fn render_key(&self) -> DiffKey {
+        DiffKey::from(&self.id)
+    }
+}
+
+#[derive(PartialEq)]
+struct IdCompB {
+    id: usize,
+}
+
+impl Component for IdCompB {
+    fn render(&self) -> impl IntoElement {
+        let text = use_state(|| "B");
+        *text.read()
+    }
+
+    fn render_key(&self) -> DiffKey {
+        DiffKey::from(&self.id)
+    }
+}
+
+#[test]
+pub fn colliding_value_key_different_component_type() {
+    fn app() -> impl IntoElement {
+        let mut toggle = use_state(|| false);
+        rect()
+            .width(Size::px(100.))
+            .height(Size::px(100.))
+            .on_mouse_up(move |_| toggle.toggle())
+            .child(if toggle() {
+                (IdCompB { id: 1 }).into_element()
+            } else {
+                (IdCompA { id: 1 }).into_element()
+            })
+    }
+
+    let mut test = launch_test(app);
+    test.sync_and_update();
+
+    let label = test.find(|_, element| {
+        Label::try_downcast(element).filter(|label| label.text.as_ref() == "A0")
+    });
+    assert!(label.is_some());
+
+    test.click_cursor((50., 50.));
+    test.sync_and_update();
+
+    let label = test
+        .find(|_, element| Label::try_downcast(element).filter(|label| label.text.as_ref() == "B"));
+    assert!(label.is_some());
+}


### PR DESCRIPTION
Improvement over https://github.com/marc2332/freya/pull/2084