### PR TITLE
feat(winit): set main window title as a11y label

### DIFF
--- a/crates/freya-core/src/accessibility/tree.rs
+++ b/crates/freya-core/src/accessibility/tree.rs
@@ -1,4 +1,7 @@
-use std::any::Any;
+use std::{
+    any::Any,
+    borrow::Cow,
+};
 
 use accesskit::{
     Action,
@@ -362,6 +365,7 @@ impl AccessibilityTree {
 
         if node_id == NodeId::ROOT {
             accessibility_data.builder.set_role(Role::Window);
+            accessibility_data.builder.set_label(Cow::from(&tree.title));
         }
 
         // Set children

--- a/crates/freya-core/src/accessibility/tree.rs
+++ b/crates/freya-core/src/accessibility/tree.rs
@@ -1,7 +1,4 @@
-use std::{
-    any::Any,
-    borrow::Cow,
-};
+use std::any::Any;
 
 use accesskit::{
     Action,
@@ -79,7 +76,7 @@ impl AccessibilityTree {
     }
 
     /// Initialize the Accessibility Tree
-    pub fn init(&mut self, tree: &mut Tree) -> TreeUpdate {
+    pub fn init(&mut self, tree: &mut Tree, title: &str) -> TreeUpdate {
         tree.accessibility_diff.clear();
 
         let mut nodes = vec![];
@@ -87,7 +84,7 @@ impl AccessibilityTree {
         tree.traverse_depth(|node_id| {
             let accessibility_state = tree.accessibility_state.get(&node_id).unwrap();
             let layout_node = tree.layout.get(&node_id).unwrap();
-            let accessibility_node = Self::create_node(node_id, layout_node, tree);
+            let accessibility_node = Self::create_node(node_id, layout_node, tree, title);
             nodes.push((accessibility_state.a11y_id, accessibility_node));
             self.map.insert(accessibility_state.a11y_id, node_id);
         });
@@ -116,6 +113,7 @@ impl AccessibilityTree {
         &mut self,
         tree: &mut Tree,
         events_sender: &futures_channel::mpsc::UnboundedSender<EventsChunk>,
+        title: &str,
     ) -> TreeUpdate {
         let requested_focus = tree.accessibility_diff.requested_focus.take();
         let removed_ids = tree
@@ -165,7 +163,7 @@ impl AccessibilityTree {
         for node_id in added_or_updated_ids {
             let accessibility_state = tree.accessibility_state.get(&node_id).unwrap();
             let layout_node = tree.layout.get(&node_id).unwrap();
-            let accessibility_node = Self::create_node(node_id, layout_node, tree);
+            let accessibility_node = Self::create_node(node_id, layout_node, tree, title);
             nodes.push((accessibility_state.a11y_id, accessibility_node));
         }
 
@@ -359,13 +357,18 @@ impl AccessibilityTree {
     }
 
     /// Create an accessibility node
-    pub fn create_node(node_id: NodeId, layout_node: &LayoutNode, tree: &Tree) -> Node {
+    pub fn create_node(
+        node_id: NodeId,
+        layout_node: &LayoutNode,
+        tree: &Tree,
+        title: &str,
+    ) -> Node {
         let element = tree.elements.get(&node_id).unwrap();
         let mut accessibility_data = element.accessibility().into_owned();
 
         if node_id == NodeId::ROOT {
             accessibility_data.builder.set_role(Role::Window);
-            accessibility_data.builder.set_label(Cow::from(&tree.title));
+            accessibility_data.builder.set_label(title);
         }
 
         // Set children

--- a/crates/freya-core/src/tree.rs
+++ b/crates/freya-core/src/tree.rs
@@ -83,6 +83,9 @@ pub struct Tree {
     pub children: FxHashMap<NodeId, Vec<NodeId>>,
     pub heights: FxHashMap<NodeId, u16>,
 
+    // The root window title
+    pub title: String,
+
     pub elements: FxHashMap<NodeId, Rc<dyn ElementExt>>,
 
     // Event listeners

--- a/crates/freya-core/src/tree.rs
+++ b/crates/freya-core/src/tree.rs
@@ -83,9 +83,6 @@ pub struct Tree {
     pub children: FxHashMap<NodeId, Vec<NodeId>>,
     pub heights: FxHashMap<NodeId, u16>,
 
-    // The root window title
-    pub title: String,
-
     pub elements: FxHashMap<NodeId, Rc<dyn ElementExt>>,
 
     // Event listeners

--- a/crates/freya-testing/src/lib.rs
+++ b/crates/freya-testing/src/lib.rs
@@ -312,7 +312,7 @@ impl TestingRunner {
         );
         self.tree.borrow_mut().accessibility_diff.clear();
         self.accessibility.focused_id = ACCESSIBILITY_ROOT_ID;
-        self.accessibility.init(&mut self.tree.borrow_mut());
+        self.accessibility.init(&mut self.tree.borrow_mut(), "");
         self.sync_and_update();
     }
 
@@ -369,9 +369,11 @@ impl TestingRunner {
             &self.default_fonts,
         );
 
-        let accessibility_update = self
-            .accessibility
-            .process_updates(&mut self.tree.borrow_mut(), &self.events_sender);
+        let accessibility_update = self.accessibility.process_updates(
+            &mut self.tree.borrow_mut(),
+            &self.events_sender,
+            "",
+        );
 
         self.platform
             .focused_accessibility_id
@@ -381,7 +383,12 @@ impl TestingRunner {
         let layout_node = tree.layout.get(&node_id).unwrap();
         self.platform
             .focused_accessibility_node
-            .set_if_modified(AccessibilityTree::create_node(node_id, layout_node, &tree));
+            .set_if_modified(AccessibilityTree::create_node(
+                node_id,
+                layout_node,
+                &tree,
+                "",
+            ));
     }
 
     /// Poll async tasks and events every `step` time for a total time of `duration`.

--- a/crates/freya-winit/src/extensions.rs
+++ b/crates/freya-winit/src/extensions.rs
@@ -85,6 +85,21 @@ pub trait WinitPlatformExt {
     /// ```
     fn focus_window(&self, window_id: Option<WindowId>);
 
+    /// Set the title of a window, also updating its accessibility label.
+    ///
+    /// If `window_id` is `None`, the title will be applied to the current window.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use freya::prelude::*;
+    ///
+    /// fn rename_current_window() {
+    ///     Platform::get().set_window_title(None, "New Title");
+    /// }
+    /// ```
+    fn set_window_title(&self, window_id: Option<WindowId>, title: impl Into<String>);
+
     /// Execute a callback with mutable access to a [`Window`].
     ///
     /// If `window_id` is `None`, the callback will be executed on the current window.
@@ -95,16 +110,7 @@ pub trait WinitPlatformExt {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use freya::{
-    ///     prelude::*,
-    ///     winit::window::WindowId,
-    /// };
-    ///
-    /// fn set_window_title(window_id: Option<WindowId>, title: &'static str) {
-    ///     Platform::get().with_window(window_id, move |window| {
-    ///         window.set_title(title);
-    ///     });
-    /// }
+    /// use freya::prelude::*;
     ///
     /// fn minimize_current_window() {
     ///     Platform::get().with_window(None, |window| {
@@ -181,6 +187,16 @@ impl WinitPlatformExt for Platform {
 
     fn focus_window(&self, window_id: Option<WindowId>) {
         self.with_window(window_id, |w| w.focus_window());
+    }
+
+    fn set_window_title(&self, window_id: Option<WindowId>, title: impl Into<String>) {
+        let title = title.into();
+        self.send(UserEvent::Erased(SingleThreadErasedEvent(Box::new(
+            NativeWindowErasedEventAction::RendererCallback(Box::new(move |id, context| {
+                let app = context.windows.get_mut(&window_id.unwrap_or(id)).unwrap();
+                app.set_title(&title);
+            })),
+        ))));
     }
 
     fn with_window(

--- a/crates/freya-winit/src/renderer.rs
+++ b/crates/freya-winit/src/renderer.rs
@@ -846,14 +846,19 @@ impl ApplicationHandler<NativeEvent> for WinitRenderer {
                                 app.process_accessibility_update(mode);
                             }
                             AccessibilityTask::Init => {
-                                let update = app.accessibility.init(&mut app.tree);
+                                let title = app.window.title();
+                                let update = app.accessibility.init(&mut app.tree, &title);
                                 app.platform
                                     .focused_accessibility_id
                                     .set_if_modified(update.focus);
                                 let node_id = app.accessibility.focused_node_id().unwrap();
                                 let layout_node = app.tree.layout.get(&node_id).unwrap();
-                                let focused_node =
-                                    AccessibilityTree::create_node(node_id, layout_node, &app.tree);
+                                let focused_node = AccessibilityTree::create_node(
+                                    node_id,
+                                    layout_node,
+                                    &app.tree,
+                                    &title,
+                                );
                                 app.window.set_ime_allowed(is_ime_role(focused_node.role()));
                                 app.platform
                                     .focused_accessibility_node

--- a/crates/freya-winit/src/window.rs
+++ b/crates/freya-winit/src/window.rs
@@ -309,6 +309,7 @@ impl AppWindow {
         if let Some(strategy) = result.auto_focus {
             tree.accessibility_diff.request_focus(strategy);
         }
+        tree.title = window.title();
         tree.measure_layout(
             (
                 window.inner_size().width as f32,

--- a/crates/freya-winit/src/window.rs
+++ b/crates/freya-winit/src/window.rs
@@ -124,15 +124,16 @@ fn clamp_custom_scale_factor(custom_scale_factor: f64) -> f64 {
 
 impl AppWindow {
     pub(crate) fn process_accessibility_update(&mut self, mode: Option<NavigationMode>) {
-        let update = self
-            .accessibility
-            .process_updates(&mut self.tree, &self.events_sender);
+        let title = self.window.title();
+        let update =
+            self.accessibility
+                .process_updates(&mut self.tree, &self.events_sender, &title);
         self.platform
             .focused_accessibility_id
             .set_if_modified(update.focus);
         let node_id = self.accessibility.focused_node_id().unwrap();
         let layout_node = self.tree.layout.get(&node_id).unwrap();
-        let focused_node = AccessibilityTree::create_node(node_id, layout_node, &self.tree);
+        let focused_node = AccessibilityTree::create_node(node_id, layout_node, &self.tree, &title);
         self.window
             .set_ime_allowed(is_ime_role(focused_node.role()));
         self.platform
@@ -151,6 +152,17 @@ impl AppWindow {
         if self.screen_reader.is_on() {
             self.accessibility_adapter.update_if_active(|| update);
         }
+    }
+
+    /// Set the window title and refresh the accessibility label of the root node.
+    pub fn set_title(&mut self, title: &str) {
+        if self.window.title() == title {
+            return;
+        }
+        self.window.set_title(title);
+        self.tree.accessibility_diff.add_or_update(NodeId::ROOT);
+        self.accessibility_tasks_for_next_render |= AccessibilityTask::ProcessUpdate { mode: None };
+        self.window.request_redraw();
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -309,7 +321,6 @@ impl AppWindow {
         if let Some(strategy) = result.auto_focus {
             tree.accessibility_diff.request_focus(strategy);
         }
-        tree.title = window.title();
         tree.measure_layout(
             (
                 window.inner_size().width as f32,


### PR DESCRIPTION
## Description

Currently, main windows do not have any name in the accessibility tree. This commit makes -winit set a new Tree property to the title of the window, which is then used when constructing the a11y tree.

Note that this will not pick up changes to the window title performed after the window has been created.

## Motivation

I've been playing with accessibility in Freya, and given the general state of accessibility at least on Linux it's already pretty promising, thank you for that!

One thing I immediately noticed was that the main window does not have an accessibility label (that is, the screen reader doesn't know the name/title of the window). I initially thought that this should probably be handled by `accesskit_winit`, but indeed it isn't, as is also manifested in its ["simple" example](https://github.com/AccessKit/accesskit/blob/main/adapters/winit/examples/simple.rs#L115).

So I set out to add it in Freya, but honestly I might need a pointer or two. The window node gets its a11y attributes [here](https://github.com/marc2332/freya/blob/main/crates/freya-core/src/accessibility/tree.rs#L364), but I think getting the window title at this point is a no-go, as this would make -core depend on -winit.

What I did here was sort of the least-invasive change I could come up with. It's probably not great, but the question that looms over all of this is: if it is to be done right, should there be a "freya" way to change the window title? Right now this would go through `Platform::get().with_window()` which operates on a `winit` window, so this cannot be intercepted by Freya. I guess it would also be fine to say if you change the window title you have to change the a11y label yourself as well, but as is this isn't really easy either. So, any thoughts you might have around this would be greatly appreciated...

Edit: forgot to mention, but I suppose if there were to be a "freya" way to set/get the window title, it would probably be via `Platform` as well?

## Checklist

- [x] I have tested my changes.
- [ ] I used AI assistance (e.g. ChatGPT, Copilot, etc.) to write this code.
- [ ] I have added or updated documentation where relevant.
- [ ] I have added or updated tests where relevant.
