### PR TITLE
feat(core/edit): Proper vertical cursor navigation on multi line single paragraphs

### DIFF
--- a/crates/freya-code-editor/src/editor_data.rs
+++ b/crates/freya-code-editor/src/editor_data.rs
@@ -189,7 +189,12 @@ impl CodeEditorData {
             EditableEvent::Release => {
                 self.dragging.clicked = false;
             }
-            EditableEvent::KeyDown { key, modifiers } => {
+            EditableEvent::KeyDown {
+                key,
+                modifiers,
+                editor_line,
+                holder,
+            } => {
                 match key {
                     // Handle dragging
                     Key::Named(NamedKey::Shift) => {
@@ -197,7 +202,16 @@ impl CodeEditorData {
                     }
                     // Handle editing
                     _ => {
-                        let event = self.process_key(key, &modifiers, true, true, true, true);
+                        let event = self.process_key(
+                            key,
+                            &modifiers,
+                            editor_line,
+                            holder,
+                            true,
+                            true,
+                            true,
+                            true,
+                        );
                         if event.contains(TextEvent::TEXT_CHANGED) {
                             self.parse();
                             self.measure(font_size, font_family);
@@ -233,6 +247,10 @@ impl TextEditor for CodeEditorData {
 
     fn lines(&self) -> Self::LinesIterator<'_> {
         unimplemented!("Unused.")
+    }
+
+    fn text(&self) -> Cow<'_, str> {
+        self.rope.slice(..).into()
     }
 
     fn insert_char(&mut self, ch: char, idx: usize) -> usize {

--- a/crates/freya-code-editor/src/editor_ui.rs
+++ b/crates/freya-code-editor/src/editor_ui.rs
@@ -214,6 +214,8 @@ impl Component for CodeEditor {
                                 .map(|_| EditableEvent::KeyDown {
                                     key: &key,
                                     modifiers,
+                                    editor_line: None,
+                                    holder: None,
                                 })
                                 .collect::<Vec<EditableEvent>>()
                         }
@@ -224,6 +226,8 @@ impl Component for CodeEditor {
                                 .map(|_| EditableEvent::KeyDown {
                                     key: &key,
                                     modifiers,
+                                    editor_line: None,
+                                    holder: None,
                                 })
                                 .collect::<Vec<EditableEvent>>()
                         }
@@ -234,12 +238,16 @@ impl Component for CodeEditor {
                                 .map(|_| EditableEvent::KeyDown {
                                     key: &key,
                                     modifiers,
+                                    editor_line: None,
+                                    holder: None,
                                 })
                                 .collect::<Vec<EditableEvent>>()
                         }
                         _ => vec![EditableEvent::KeyDown {
                             key: &key,
                             modifiers,
+                            editor_line: None,
+                            holder: None,
                         }],
                     };
 

--- a/crates/freya-components/src/input.rs
+++ b/crates/freya-components/src/input.rs
@@ -9,8 +9,8 @@ use std::{
 
 use freya_core::{
     elements::paragraph::{
+        ParagraphCursorExt,
         ParagraphHolderInner,
-        cursor_character_rect,
     },
     prelude::*,
 };
@@ -463,8 +463,7 @@ impl Component for Input {
                 InputMode::Shown => editor.rope().to_string(),
             };
 
-            let cursor_rect =
-                cursor_character_rect(paragraph, &text, editor.cursor_pos(), text_align);
+            let cursor_rect = paragraph.cursor_rect(&text, editor.cursor_pos(), text_align);
             let cursor_x = cursor_rect.left / (*scale_factor as f32);
 
             // Visible window start
@@ -518,6 +517,8 @@ impl Component for Input {
                     editable.process_event(EditableEvent::KeyDown {
                         key: &key,
                         modifiers,
+                        editor_line: Some(EditorLine::SingleParagraph),
+                        holder: Some(&holder.read()),
                     });
                     let text = editable.editor().read().committed_text();
 

--- a/crates/freya-components/src/selectable_text.rs
+++ b/crates/freya-components/src/selectable_text.rs
@@ -199,6 +199,8 @@ impl Component for SelectableText {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: Some(EditorLine::SingleParagraph),
+                holder: Some(&holder.read()),
             });
         };
 

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -494,11 +494,8 @@ impl ElementExt for ParagraphElement {
             highlights_paint.set_color(self.cursor_style_data.highlight_color);
 
             if rects.is_empty() && *from == 0 {
-                let caret_rect = paragraph.cursor_rect(
-                    &self.text(),
-                    *from,
-                    context.text_style_state.text_align,
-                );
+                let caret_rect =
+                    paragraph.cursor_rect(&self.text(), *from, context.text_style_state.text_align);
                 context
                     .canvas
                     .draw_rect(to_cursor_area(caret_rect), &highlights_paint);
@@ -722,7 +719,6 @@ impl ParagraphCursorExt for SkParagraph {
 
         SkRect::new(left, 0., left + 6., self.height())
     }
-
 }
 
 impl From<Paragraph> for Element {

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -494,8 +494,7 @@ impl ElementExt for ParagraphElement {
             highlights_paint.set_color(self.cursor_style_data.highlight_color);
 
             if rects.is_empty() && *from == 0 {
-                let caret_rect = cursor_character_rect(
-                    paragraph,
+                let caret_rect = paragraph.cursor_rect(
                     &self.text(),
                     *from,
                     context.text_style_state.text_align,
@@ -528,8 +527,7 @@ impl ElementExt for ParagraphElement {
         if let Some(cursor_index) = self.cursor_index
             && self.cursor_style == CursorStyle::Block
         {
-            let mut cursor_rect = cursor_character_rect(
-                paragraph,
+            let mut cursor_rect = paragraph.cursor_rect(
                 &self.text(),
                 cursor_index,
                 context.text_style_state.text_align,
@@ -554,8 +552,7 @@ impl ElementExt for ParagraphElement {
             && !visible_highlights
             && self.cursor_style != CursorStyle::Block
         {
-            let mut cursor_rect = cursor_character_rect(
-                paragraph,
+            let mut cursor_rect = paragraph.cursor_rect(
                 &self.text(),
                 cursor_index,
                 context.text_style_state.text_align,
@@ -659,62 +656,73 @@ impl ParagraphElement {
     }
 }
 
-/// Rect of the grapheme cluster at `cursor_index` (in UTF-16 code units),
-/// or a caret stub when there is nothing to measure. A caret after a
-/// trailing line break lands on the empty last line.
-pub fn cursor_character_rect(
-    paragraph: &SkParagraph,
-    text: &str,
-    cursor_index: usize,
-    text_align: TextAlign,
-) -> SkRect {
-    let mut cluster = 0..0;
-    let mut cluster_byte_index = 0;
-    for (byte_index, grapheme) in text.grapheme_indices(true) {
-        cluster = cluster.end..cluster.end + grapheme.encode_utf16().count();
-        cluster_byte_index = byte_index;
-        if cluster.end > cursor_index {
-            break;
+/// Cursor measuring over a laid out paragraph, in scaled coordinates relative to it.
+pub trait ParagraphCursorExt {
+    /// Rect of the grapheme cluster at `cursor_index`, or `None` when the paragraph has no lines.
+    fn measured_cursor_rect(&self, text: &str, cursor_index: usize) -> Option<SkRect>;
+
+    /// Rect of the grapheme cluster at `cursor_index`, or a caret stub when there is nothing to measure.
+    fn cursor_rect(&self, text: &str, cursor_index: usize, text_align: TextAlign) -> SkRect;
+}
+
+impl ParagraphCursorExt for SkParagraph {
+    fn measured_cursor_rect(&self, text: &str, cursor_index: usize) -> Option<SkRect> {
+        let mut cluster = 0..0;
+        let mut cluster_byte_index = 0;
+        for (byte_index, grapheme) in text.grapheme_indices(true) {
+            cluster = cluster.end..cluster.end + grapheme.encode_utf16().count();
+            cluster_byte_index = byte_index;
+            if cluster.end > cursor_index {
+                break;
+            }
         }
+
+        if !cluster.is_empty() {
+            // A line below the final cluster is the empty line after a trailing line break
+            if cluster.end <= cursor_index
+                && let Some(cluster_line) = self.get_line_number_at(cluster_byte_index)
+                && let Some(line) = self.get_line_metrics_at(cluster_line + 1)
+            {
+                let left = line.left as f32;
+                let top = (line.baseline - line.ascent) as f32;
+                let bottom = (line.baseline + line.descent) as f32;
+                return Some(SkRect::new(left, top, left, bottom));
+            }
+
+            let rects = self.get_rects_for_range(
+                cluster.clone(),
+                RectHeightStyle::Tight,
+                RectWidthStyle::Tight,
+            );
+            if let Some(rect) = rects.first() {
+                let mut rect = rect.rect;
+                if cluster.end <= cursor_index {
+                    rect.left = rect.right;
+                }
+                return Some(rect);
+            }
+        }
+
+        let line = self.get_line_metrics_at(0)?;
+        let left = line.left as f32;
+
+        Some(SkRect::new(left, 0., left + 6., line.height as f32))
     }
 
-    if !cluster.is_empty() {
-        // A line below the final cluster is the empty line after a trailing line break
-        if cluster.end <= cursor_index
-            && let Some(cluster_line) = paragraph.get_line_number_at(cluster_byte_index)
-            && let Some(line) = paragraph.get_line_metrics_at(cluster_line + 1)
-        {
-            let left = line.left as f32;
-            let top = (line.baseline - line.ascent) as f32;
-            let bottom = (line.baseline + line.descent) as f32;
-            return SkRect::new(left, top, left, bottom);
-        }
-
-        let rects = paragraph.get_rects_for_range(
-            cluster.clone(),
-            RectHeightStyle::Tight,
-            RectWidthStyle::Tight,
-        );
-        if let Some(rect) = rects.first() {
-            let mut rect = rect.rect;
-            if cluster.end <= cursor_index {
-                rect.left = rect.right;
-            }
+    fn cursor_rect(&self, text: &str, cursor_index: usize, text_align: TextAlign) -> SkRect {
+        if let Some(rect) = self.measured_cursor_rect(text, cursor_index) {
             return rect;
         }
+
+        let left = match text_align {
+            TextAlign::Center => self.max_width() / 2.,
+            TextAlign::Right | TextAlign::End => self.max_width() - 6.,
+            _ => 0.,
+        };
+
+        SkRect::new(left, 0., left + 6., self.height())
     }
 
-    if let Some(line) = paragraph.get_line_metrics_at(0) {
-        let left = line.left as f32;
-        return SkRect::new(left, 0., left + 6., line.height as f32);
-    }
-
-    let left = match text_align {
-        TextAlign::Center => paragraph.max_width() / 2.,
-        TextAlign::Right | TextAlign::End => paragraph.max_width() - 6.,
-        _ => 0.,
-    };
-    SkRect::new(left, 0., left + 6., paragraph.height())
 }
 
 impl From<Paragraph> for Element {

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -654,8 +654,10 @@ impl ParagraphElement {
 }
 
 pub trait ParagraphCursorExt {
+    /// Area of the character at `cursor_index`, if there is any.
     fn measured_cursor_rect(&self, text: &str, cursor_index: usize) -> Option<SkRect>;
 
+    /// Area of the character at `cursor_index`.
     fn cursor_rect(&self, text: &str, cursor_index: usize, text_align: TextAlign) -> SkRect;
 }
 
@@ -707,6 +709,7 @@ impl ParagraphCursorExt for SkParagraph {
             return rect;
         }
 
+        // In case of no rect we just center the cursor
         let left = match text_align {
             TextAlign::Center => self.max_width() / 2.,
             TextAlign::Right | TextAlign::End => self.max_width() - 6.,

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -653,12 +653,9 @@ impl ParagraphElement {
     }
 }
 
-/// Cursor measuring over a laid out paragraph, in scaled coordinates relative to it.
 pub trait ParagraphCursorExt {
-    /// Rect of the grapheme cluster at `cursor_index`, or `None` when the paragraph has no lines.
     fn measured_cursor_rect(&self, text: &str, cursor_index: usize) -> Option<SkRect>;
 
-    /// Rect of the grapheme cluster at `cursor_index`, or a caret stub when there is nothing to measure.
     fn cursor_rect(&self, text: &str, cursor_index: usize, text_align: TextAlign) -> SkRect;
 }
 
@@ -675,7 +672,6 @@ impl ParagraphCursorExt for SkParagraph {
         }
 
         if !cluster.is_empty() {
-            // A line below the final cluster is the empty line after a trailing line break
             if cluster.end <= cursor_index
                 && let Some(cluster_line) = self.get_line_number_at(cluster_byte_index)
                 && let Some(line) = self.get_line_metrics_at(cluster_line + 1)

--- a/crates/freya-edit/src/event.rs
+++ b/crates/freya-edit/src/event.rs
@@ -33,6 +33,8 @@ pub enum EditableEvent<'a> {
     KeyDown {
         key: &'a Key,
         modifiers: Modifiers,
+        editor_line: Option<EditorLine>,
+        holder: Option<&'a ParagraphHolder>,
     },
     KeyUp {
         key: &'a Key,
@@ -174,7 +176,12 @@ impl EditableEvent<'_> {
             EditableEvent::Release => {
                 dragging.write().clicked = false;
             }
-            EditableEvent::KeyDown { key, modifiers } => {
+            EditableEvent::KeyDown {
+                key,
+                modifiers,
+                editor_line,
+                holder,
+            } => {
                 match key {
                     // Handle dragging
                     Key::Named(NamedKey::Shift) => {
@@ -186,6 +193,8 @@ impl EditableEvent<'_> {
                             let event = editor.process_key(
                                 key,
                                 &modifiers,
+                                editor_line,
+                                holder,
                                 config.allow_tabs,
                                 config.allow_changes,
                                 config.allow_read_clipboard,

--- a/crates/freya-edit/src/rope_editor.rs
+++ b/crates/freya-edit/src/rope_editor.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fmt::Display,
     ops::Range,
 };
@@ -228,6 +229,10 @@ impl TextEditor for RopeEditor {
 
     fn char_to_utf16_cu(&self, idx: usize) -> usize {
         self.rope.char_to_utf16_cu(idx)
+    }
+
+    fn text(&self) -> Cow<'_, str> {
+        self.rope.slice(..).into()
     }
 
     fn line(&self, line_idx: usize) -> Option<Line<'_>> {

--- a/crates/freya-edit/src/rope_editor.rs
+++ b/crates/freya-edit/src/rope_editor.rs
@@ -387,6 +387,8 @@ mod test {
         ed.process_key(
             &Key::Named(key),
             &Modifiers::empty(),
+            None,
+            None,
             true,
             true,
             false,

--- a/crates/freya-edit/src/text_editor.rs
+++ b/crates/freya-edit/src/text_editor.rs
@@ -164,7 +164,6 @@ pub trait TextEditor {
     /// Get a line from the text
     fn line(&self, line_idx: usize) -> Option<Line<'_>>;
 
-    /// Whole text of the editor.
     fn text(&self) -> Cow<'_, str>;
 
     /// Total of lines
@@ -241,7 +240,7 @@ pub trait TextEditor {
         self.selection_mut().move_to(pos);
     }
 
-    /// Move the cursor 1 line down, following the wrapped lines of `holder` when given.
+    /// Move the cursor 1 line down
     fn cursor_down(
         &mut self,
         editor_line: Option<EditorLine>,
@@ -275,7 +274,7 @@ pub trait TextEditor {
         }
     }
 
-    /// Move the cursor 1 line up, following the wrapped lines of `holder` when given.
+    /// Move the cursor 1 line up
     fn cursor_up(
         &mut self,
         editor_line: Option<EditorLine>,
@@ -307,7 +306,6 @@ pub trait TextEditor {
         }
     }
 
-    /// UTF-16 index one visual line up or down from the cursor, keeping its horizontal offset.
     fn visual_line_position(
         &self,
         holder: &ParagraphHolder,
@@ -341,7 +339,6 @@ pub trait TextEditor {
 
         let mut x = cursor_rect.left as i32;
         if !line.hard_break {
-            // Past a soft wrap the caret belongs to the end of the line, not to the next one
             x = x.min((line.left + line.width) as i32 - 1);
         }
 

--- a/crates/freya-edit/src/text_editor.rs
+++ b/crates/freya-edit/src/text_editor.rs
@@ -6,7 +6,14 @@ use std::{
 };
 
 use freya_clipboard::clipboard::Clipboard;
-use freya_core::events::modifiers::ModifiersExt;
+use freya_core::{
+    elements::paragraph::{
+        ParagraphCursorExt,
+        ParagraphHolder,
+        ParagraphHolderInner,
+    },
+    events::modifiers::ModifiersExt,
+};
 use keyboard_types::{
     Key,
     Modifiers,
@@ -157,6 +164,9 @@ pub trait TextEditor {
     /// Get a line from the text
     fn line(&self, line_idx: usize) -> Option<Line<'_>>;
 
+    /// Whole text of the editor.
+    fn text(&self) -> Cow<'_, str>;
+
     /// Total of lines
     fn len_lines(&self) -> usize;
 
@@ -231,8 +241,19 @@ pub trait TextEditor {
         self.selection_mut().move_to(pos);
     }
 
-    /// Move the cursor 1 line down
-    fn cursor_down(&mut self) -> bool {
+    /// Move the cursor 1 line down, following the wrapped lines of `holder` when given.
+    fn cursor_down(
+        &mut self,
+        editor_line: Option<EditorLine>,
+        holder: Option<&ParagraphHolder>,
+    ) -> bool {
+        if let Some(editor_line) = editor_line
+            && let Some(holder) = holder
+            && self.cursor_visual_line(holder, editor_line, 1)
+        {
+            return true;
+        }
+
         let old_row = self.cursor_row();
         let old_col = self.cursor_col();
 
@@ -252,8 +273,19 @@ pub trait TextEditor {
         }
     }
 
-    /// Move the cursor 1 line up
-    fn cursor_up(&mut self) -> bool {
+    /// Move the cursor 1 line up, following the wrapped lines of `holder` when given.
+    fn cursor_up(
+        &mut self,
+        editor_line: Option<EditorLine>,
+        holder: Option<&ParagraphHolder>,
+    ) -> bool {
+        if let Some(editor_line) = editor_line
+            && let Some(holder) = holder
+            && self.cursor_visual_line(holder, editor_line, -1)
+        {
+            return true;
+        }
+
         let pos = self.cursor_pos();
         let old_row = self.cursor_row();
         let old_col = self.cursor_col();
@@ -269,6 +301,69 @@ pub trait TextEditor {
         } else {
             false
         }
+    }
+
+    /// UTF-16 index one visual line up or down from the cursor, keeping its horizontal offset.
+    fn visual_line_position(
+        &self,
+        holder: &ParagraphHolder,
+        editor_line: EditorLine,
+        line_offset: isize,
+    ) -> Option<usize> {
+        let holder = holder.0.borrow();
+        let ParagraphHolderInner { paragraph, .. } = holder.as_ref()?;
+
+        let cursor_pos = self.cursor_pos();
+        let (cursor_rect, line_start) = match editor_line {
+            EditorLine::SingleParagraph => {
+                (paragraph.measured_cursor_rect(&self.text(), cursor_pos)?, 0)
+            }
+            EditorLine::Paragraph(line_index) => {
+                let line = self.line(line_index)?;
+                let line_start = self.char_to_utf16_cu(self.line_to_char(line_index));
+                (
+                    paragraph
+                        .measured_cursor_rect(&line.text, cursor_pos.saturating_sub(line_start))?,
+                    line_start,
+                )
+            }
+        };
+
+        let lines = paragraph.get_line_metrics();
+        let current = lines
+            .iter()
+            .position(|line| (cursor_rect.top as f64) < line.baseline + line.descent)?;
+        let line = lines.get(current.checked_add_signed(line_offset)?)?;
+
+        // Past a soft wrap the caret belongs to the end of the line, not to the next one
+        let line_end = line.left + line.width;
+        let mut x = cursor_rect.left as f64;
+        if !line.hard_break && x > line_end {
+            x = line_end - 0.5;
+        }
+
+        let position = paragraph
+            .get_glyph_position_at_coordinate((x as i32, line.baseline as i32))
+            .position
+            .max(0) as usize;
+
+        Some(line_start + position)
+    }
+
+    /// Move the cursor one visual line up or down, following the wrapped lines of `holder`.
+    fn cursor_visual_line(
+        &mut self,
+        holder: &ParagraphHolder,
+        editor_line: EditorLine,
+        line_offset: isize,
+    ) -> bool {
+        let Some(position) = self.visual_line_position(holder, editor_line, line_offset) else {
+            return false;
+        };
+
+        self.selection_mut().move_to(position);
+
+        true
     }
 
     /// Move the cursor 1 grapheme cluster to the right
@@ -508,6 +603,8 @@ pub trait TextEditor {
         &mut self,
         key: &Key,
         modifiers: &Modifiers,
+        editor_line: Option<EditorLine>,
+        holder: Option<&ParagraphHolder>,
         allow_tabs: bool,
         allow_changes: bool,
         allow_read_clipboard: bool,
@@ -533,7 +630,7 @@ pub trait TextEditor {
                     self.selection_mut().set_as_cursor();
                 }
 
-                if !skip_arrows_movement && self.cursor_down() {
+                if !skip_arrows_movement && self.cursor_down(editor_line, holder) {
                     event.insert(TextEvent::CURSOR_CHANGED);
                 }
             }
@@ -580,7 +677,7 @@ pub trait TextEditor {
                     self.selection_mut().set_as_cursor();
                 }
 
-                if !skip_arrows_movement && self.cursor_up() {
+                if !skip_arrows_movement && self.cursor_up(editor_line, holder) {
                     event.insert(TextEvent::CURSOR_CHANGED);
                 }
             }

--- a/crates/freya-edit/src/text_editor.rs
+++ b/crates/freya-edit/src/text_editor.rs
@@ -316,21 +316,11 @@ pub trait TextEditor {
         let holder = holder.0.borrow();
         let ParagraphHolderInner { paragraph, .. } = holder.as_ref()?;
 
-        let cursor_pos = self.cursor_pos();
-        let (cursor_rect, line_start) = match editor_line {
-            EditorLine::SingleParagraph => {
-                (paragraph.measured_cursor_rect(&self.text(), cursor_pos)?, 0)
-            }
-            EditorLine::Paragraph(line_index) => {
-                let line = self.line(line_index)?;
-                let line_start = self.char_to_utf16_cu(self.line_to_char(line_index));
-                (
-                    paragraph
-                        .measured_cursor_rect(&line.text, cursor_pos.saturating_sub(line_start))?,
-                    line_start,
-                )
-            }
-        };
+        if !matches!(editor_line, EditorLine::SingleParagraph) {
+            return None;
+        }
+
+        let cursor_rect = paragraph.measured_cursor_rect(&self.text(), self.cursor_pos())?;
 
         let lines = paragraph.get_line_metrics();
         let current = lines
@@ -349,7 +339,7 @@ pub trait TextEditor {
             .position
             .max(0) as usize;
 
-        Some(line_start + position)
+        Some(position)
     }
 
     /// Move the cursor 1 grapheme cluster to the right

--- a/crates/freya-edit/src/text_editor.rs
+++ b/crates/freya-edit/src/text_editor.rs
@@ -306,6 +306,7 @@ pub trait TextEditor {
         }
     }
 
+    /// Cursor position one visual line up or down.
     fn visual_line_position(
         &self,
         holder: &ParagraphHolder,
@@ -337,13 +338,14 @@ pub trait TextEditor {
             .position(|line| (cursor_rect.top as f64) < line.baseline + line.descent)?;
         let line = lines.get(current.checked_add_signed(line_offset)?)?;
 
-        let mut x = cursor_rect.left as i32;
+        // Clamp to the end of soft wrapped lines
+        let mut horizontal_position = cursor_rect.left as i32;
         if !line.hard_break {
-            x = x.min((line.left + line.width) as i32 - 1);
+            horizontal_position = horizontal_position.min((line.left + line.width) as i32 - 1);
         }
 
         let position = paragraph
-            .get_glyph_position_at_coordinate((x, line.baseline as i32))
+            .get_glyph_position_at_coordinate((horizontal_position, line.baseline as i32))
             .position
             .max(0) as usize;
 

--- a/crates/freya-edit/src/text_editor.rs
+++ b/crates/freya-edit/src/text_editor.rs
@@ -335,15 +335,14 @@ pub trait TextEditor {
             .position(|line| (cursor_rect.top as f64) < line.baseline + line.descent)?;
         let line = lines.get(current.checked_add_signed(line_offset)?)?;
 
-        // Past a soft wrap the caret belongs to the end of the line, not to the next one
-        let line_end = line.left + line.width;
-        let mut x = cursor_rect.left as f64;
-        if !line.hard_break && x > line_end {
-            x = line_end - 0.5;
+        let mut x = cursor_rect.left as i32;
+        if !line.hard_break {
+            // Past a soft wrap the caret belongs to the end of the line, not to the next one
+            x = x.min((line.left + line.width) as i32 - 1);
         }
 
         let position = paragraph
-            .get_glyph_position_at_coordinate((x as i32, line.baseline as i32))
+            .get_glyph_position_at_coordinate((x, line.baseline as i32))
             .position
             .max(0) as usize;
 

--- a/crates/freya-edit/src/text_editor.rs
+++ b/crates/freya-edit/src/text_editor.rs
@@ -249,8 +249,10 @@ pub trait TextEditor {
     ) -> bool {
         if let Some(editor_line) = editor_line
             && let Some(holder) = holder
-            && self.cursor_visual_line(holder, editor_line, 1)
+            && let Some(position) = self.visual_line_position(holder, editor_line, 1)
         {
+            self.selection_mut().move_to(position);
+
             return true;
         }
 
@@ -281,8 +283,10 @@ pub trait TextEditor {
     ) -> bool {
         if let Some(editor_line) = editor_line
             && let Some(holder) = holder
-            && self.cursor_visual_line(holder, editor_line, -1)
+            && let Some(position) = self.visual_line_position(holder, editor_line, -1)
         {
+            self.selection_mut().move_to(position);
+
             return true;
         }
 
@@ -347,22 +351,6 @@ pub trait TextEditor {
             .max(0) as usize;
 
         Some(line_start + position)
-    }
-
-    /// Move the cursor one visual line up or down, following the wrapped lines of `holder`.
-    fn cursor_visual_line(
-        &mut self,
-        holder: &ParagraphHolder,
-        editor_line: EditorLine,
-        line_offset: isize,
-    ) -> bool {
-        let Some(position) = self.visual_line_position(holder, editor_line, line_offset) else {
-            return false;
-        };
-
-        self.selection_mut().move_to(position);
-
-        true
     }
 
     /// Move the cursor 1 grapheme cluster to the right

--- a/crates/freya-edit/src/text_editor.rs
+++ b/crates/freya-edit/src/text_editor.rs
@@ -586,6 +586,7 @@ pub trait TextEditor {
     }
 
     // Process a Keyboard event
+    #[allow(clippy::too_many_arguments)]
     fn process_key(
         &mut self,
         key: &Key,

--- a/crates/freya-edit/tests/edit.rs
+++ b/crates/freya-edit/tests/edit.rs
@@ -33,6 +33,8 @@ fn multiple_lines_single_editor() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -143,6 +145,8 @@ fn single_line_multiple_editors() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -239,6 +243,8 @@ fn highlight_multiple_lines_single_editor() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -371,6 +377,8 @@ fn highlights_single_line_multiple_editors() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -474,6 +482,8 @@ fn special_text_editing() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -533,6 +543,8 @@ fn backspace_remove() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -609,6 +621,8 @@ fn highlight_shift_click_multiple_lines_single_editor() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -676,6 +690,8 @@ fn highlights_shift_click_single_line_multiple_editors() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -795,6 +811,8 @@ fn double_click_select_word() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -865,6 +883,8 @@ fn triple_click_select_line() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -936,6 +956,8 @@ fn quadruple_click_select_all() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -999,6 +1021,8 @@ fn double_click_select_word_single_line_multiple_editors() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -1086,6 +1110,8 @@ fn triple_click_select_line_single_line_multiple_editors() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -1196,6 +1222,8 @@ fn highlight_all_text() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -1285,6 +1313,8 @@ fn replace_text() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -1361,6 +1391,8 @@ fn navigate_empty_lines() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -1417,6 +1449,8 @@ fn cursor_word_navigation() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -1565,6 +1599,8 @@ fn cursor_word_navigation_with_selection() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -1642,6 +1678,8 @@ fn word_deletion() {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 
@@ -1755,12 +1793,12 @@ fn arrow_down_clamps_to_last_line_end() {
         EditorHistory::new(Duration::from_millis(10)),
     );
 
-    editor.cursor_down();
+    editor.cursor_down(None, None);
 
     assert_eq!(editor.cursor_row(), 1);
     assert_eq!(editor.cursor_col(), 5);
 
-    editor.cursor_up();
+    editor.cursor_up(None, None);
 
     assert_eq!(editor.cursor_row(), 0);
     assert_eq!(editor.cursor_col(), 5);
@@ -1772,7 +1810,7 @@ fn arrow_down_clamps_to_last_line_end() {
         EditorHistory::new(Duration::from_millis(10)),
     );
 
-    editor.cursor_down();
+    editor.cursor_down(None, None);
 
     assert_eq!(editor.cursor_row(), 1);
     assert_eq!(editor.cursor_col(), 2);
@@ -1788,7 +1826,16 @@ fn home_end_navigation() {
     );
 
     let press = |editor: &mut RopeEditor, key: NamedKey, modifiers: Modifiers| {
-        editor.process_key(&Key::Named(key), &modifiers, false, true, true, true);
+        editor.process_key(
+        &Key::Named(key),
+        &modifiers,
+        None,
+        None,
+        false,
+        true,
+        true,
+        true,
+    );
     };
 
     press(&mut editor, NamedKey::End, Modifiers::empty());

--- a/crates/freya-edit/tests/edit.rs
+++ b/crates/freya-edit/tests/edit.rs
@@ -1827,15 +1827,15 @@ fn home_end_navigation() {
 
     let press = |editor: &mut RopeEditor, key: NamedKey, modifiers: Modifiers| {
         editor.process_key(
-        &Key::Named(key),
-        &modifiers,
-        None,
-        None,
-        false,
-        true,
-        true,
-        true,
-    );
+            &Key::Named(key),
+            &modifiers,
+            None,
+            None,
+            false,
+            true,
+            true,
+            true,
+        );
     };
 
     press(&mut editor, NamedKey::End, Modifiers::empty());

--- a/examples/shader_editor.rs
+++ b/examples/shader_editor.rs
@@ -75,6 +75,8 @@ impl Component for ShaderEditor {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         };
 

--- a/examples/text_editing.rs
+++ b/examples/text_editing.rs
@@ -49,6 +49,8 @@ fn app() -> impl IntoElement {
             editable.process_event(EditableEvent::KeyDown {
                 key: &e.key,
                 modifiers: e.modifiers,
+                editor_line: None,
+                holder: None,
             });
         })
         .on_key_up(move |e: Event<KeyboardEventData>| {


### PR DESCRIPTION
Paving the road for multi line input...

now navigation up and down with the keyboard in multi line paragraphs takes into account the paragraph lines rather than the rope lines.