### PR TITLE
fix(core): Wrapped line clicks should land on their clicked lines not the next below

### DIFF
--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -660,7 +660,7 @@ pub trait ParagraphCursorExt {
     /// Area of the character at `cursor_index`.
     fn cursor_rect(&self, text: &str, cursor_index: usize, text_align: TextAlign) -> SkRect;
 
-    /// UTF-16 index of the glyph at `point`, snapped back into the visual line the point lands on.
+    /// Cursor position at the given point.
     fn cursor_index_at_point(&self, point: (f64, f64)) -> usize;
 }
 

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -723,20 +723,19 @@ impl ParagraphCursorExt for SkParagraph {
     }
 
     fn cursor_index_at_point(&self, point: (f64, f64)) -> usize {
-        let (mut x, y) = point;
+        let (horizontal_position, vertical_position) = point;
+        let mut horizontal_position = horizontal_position as i32;
         if let Some(line) = self
             .get_line_metrics()
             .into_iter()
-            .find(|line| y < line.baseline + line.descent)
+            .find(|line| vertical_position < line.baseline + line.descent)
+            && !line.hard_break
         {
-            // Past a soft wrap the caret belongs to the end of the line, not to the next one
-            let line_end = line.left + line.width;
-            if !line.hard_break && x > line_end {
-                x = line_end - 0.5;
-            }
+            // Clamp to the end of soft wrapped lines
+            horizontal_position = horizontal_position.min((line.left + line.width) as i32 - 1);
         }
 
-        self.get_glyph_position_at_coordinate((x as i32, y as i32))
+        self.get_glyph_position_at_coordinate((horizontal_position, vertical_position as i32))
             .position
             .max(0) as usize
     }

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -659,6 +659,9 @@ pub trait ParagraphCursorExt {
 
     /// Area of the character at `cursor_index`.
     fn cursor_rect(&self, text: &str, cursor_index: usize, text_align: TextAlign) -> SkRect;
+
+    /// UTF-16 index of the glyph at `point`, snapped back into the visual line the point lands on.
+    fn cursor_index_at_point(&self, point: (f64, f64)) -> usize;
 }
 
 impl ParagraphCursorExt for SkParagraph {
@@ -717,6 +720,25 @@ impl ParagraphCursorExt for SkParagraph {
         };
 
         SkRect::new(left, 0., left + 6., self.height())
+    }
+
+    fn cursor_index_at_point(&self, point: (f64, f64)) -> usize {
+        let (mut x, y) = point;
+        if let Some(line) = self
+            .get_line_metrics()
+            .into_iter()
+            .find(|line| y < line.baseline + line.descent)
+        {
+            // Past a soft wrap the caret belongs to the end of the line, not to the next one
+            let line_end = line.left + line.width;
+            if !line.hard_break && x > line_end {
+                x = line_end - 0.5;
+            }
+        }
+
+        self.get_glyph_position_at_coordinate((x as i32, y as i32))
+            .position
+            .max(0) as usize
     }
 }
 

--- a/crates/freya-edit/src/event.rs
+++ b/crates/freya-edit/src/event.rs
@@ -1,7 +1,10 @@
 use std::ops::Mul;
 
 use freya_core::{
-    elements::paragraph::ParagraphHolderInner,
+    elements::paragraph::{
+        ParagraphCursorExt,
+        ParagraphHolderInner,
+    },
     prelude::*,
 };
 use keyboard_types::NamedKey;
@@ -74,11 +77,10 @@ impl EditableEvent<'_> {
                     PressEventType::Triple => {
                         let current_selection = text_editor.selection().clone();
 
-                        let char_position = paragraph.get_glyph_position_at_coordinate(
-                            location.mul(*scale_factor).to_i32().to_tuple(),
-                        );
-                        let press_selection = text_editor
-                            .measure_selection(char_position.position as usize, editor_line);
+                        let char_position =
+                            paragraph.cursor_index_at_point(location.mul(*scale_factor).to_tuple());
+                        let press_selection =
+                            text_editor.measure_selection(char_position, editor_line);
 
                         // Get the line start char and its length
                         let line = text_editor.char_to_line(press_selection.pos());
@@ -98,11 +100,10 @@ impl EditableEvent<'_> {
                         let new_selection = if config.select_all_on_double_click {
                             TextSelection::new_range((0, text_editor.len_utf16_cu()))
                         } else {
-                            let char_position = paragraph.get_glyph_position_at_coordinate(
-                                location.mul(*scale_factor).to_i32().to_tuple(),
-                            );
-                            let press_selection = text_editor
-                                .measure_selection(char_position.position as usize, editor_line);
+                            let char_position = paragraph
+                                .cursor_index_at_point(location.mul(*scale_factor).to_tuple());
+                            let press_selection =
+                                text_editor.measure_selection(char_position, editor_line);
 
                             let range = text_editor.find_word_boundaries(press_selection.pos());
                             TextSelection::new_range(range)
@@ -124,11 +125,10 @@ impl EditableEvent<'_> {
                     PressEventType::Single => {
                         let current_selection = text_editor.selection().clone();
 
-                        let char_position = paragraph.get_glyph_position_at_coordinate(
-                            location.mul(*scale_factor).to_i32().to_tuple(),
-                        );
-                        let new_selection = text_editor
-                            .measure_selection(char_position.position as usize, editor_line);
+                        let char_position =
+                            paragraph.cursor_index_at_point(location.mul(*scale_factor).to_tuple());
+                        let new_selection =
+                            text_editor.measure_selection(char_position, editor_line);
 
                         // Move the cursor
                         if current_selection != new_selection {
@@ -154,9 +154,7 @@ impl EditableEvent<'_> {
                     let dist_position = location.mul(*scale_factor);
 
                     // Calculate the end of the highlighting
-                    let dist_char = paragraph
-                        .get_glyph_position_at_coordinate(dist_position.to_i32().to_tuple());
-                    let to = dist_char.position as usize;
+                    let to = paragraph.cursor_index_at_point(dist_position.to_tuple());
 
                     if editor.peek().get_selection().is_none() {
                         editor.write().selection_mut().set_as_range();

--- a/crates/freya-edit/src/text_editor.rs
+++ b/crates/freya-edit/src/text_editor.rs
@@ -328,18 +328,7 @@ pub trait TextEditor {
             .position(|line| (cursor_rect.top as f64) < line.baseline + line.descent)?;
         let line = lines.get(current.checked_add_signed(line_offset)?)?;
 
-        // Clamp to the end of soft wrapped lines
-        let mut horizontal_position = cursor_rect.left as i32;
-        if !line.hard_break {
-            horizontal_position = horizontal_position.min((line.left + line.width) as i32 - 1);
-        }
-
-        let position = paragraph
-            .get_glyph_position_at_coordinate((horizontal_position, line.baseline as i32))
-            .position
-            .max(0) as usize;
-
-        Some(position)
+        Some(paragraph.cursor_index_at_point((cursor_rect.left as f64, line.baseline)))
     }
 
     /// Move the cursor 1 grapheme cluster to the right

--- a/crates/freya-edit/tests/wrapped_lines.rs
+++ b/crates/freya-edit/tests/wrapped_lines.rs
@@ -38,11 +38,11 @@ fn click_past_a_wrapped_line_end() {
                     .on_mouse_down(on_mouse_down)
                     .span(Span::new(editor.to_string())),
             )
-            .child(
-                label()
-                    .color((0, 0, 0))
-                    .text(format!("{}:{}", editor.cursor_row(), editor.cursor_col())),
-            )
+            .child(label().color((0, 0, 0)).text(format!(
+                "{}:{}",
+                editor.cursor_row(),
+                editor.cursor_col()
+            )))
     });
     utils.set_fonts(HashMap::from_iter([(
         "NotoSans",

--- a/crates/freya-edit/tests/wrapped_lines.rs
+++ b/crates/freya-edit/tests/wrapped_lines.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+
+use freya::prelude::*;
+use freya_edit::*;
+use freya_testing::prelude::*;
+
+/// Clicking past the end of a wrapped line must not land on the next line.
+#[test]
+fn click_past_a_wrapped_line_end() {
+    let mut utils = launch_test(|| {
+        let mut editable = use_editable(
+            || "dddddddddddddd asdad dddddddddddddd asdad dddddddddddddd".to_string(),
+            EditableConfig::new,
+        );
+        let holder = use_state(ParagraphHolder::default);
+        let editor = editable.editor().read();
+        let cursor_pos = editor.cursor_pos();
+
+        let on_mouse_down = move |e: Event<MouseEventData>| {
+            editable.process_event(EditableEvent::Down {
+                location: e.element_location,
+                editor_line: EditorLine::SingleParagraph,
+                holder: &holder.read(),
+            });
+        };
+
+        rect()
+            .font_family("NotoSans")
+            .width(Size::px(200.))
+            .height(Size::fill())
+            .background((255, 255, 255))
+            .child(
+                paragraph()
+                    .holder(holder.read().clone())
+                    .width(Size::fill())
+                    .cursor_index(cursor_pos)
+                    .cursor_color((0, 0, 0))
+                    .on_mouse_down(on_mouse_down)
+                    .span(Span::new(editor.to_string())),
+            )
+            .child(
+                label()
+                    .color((0, 0, 0))
+                    .text(format!("{}:{}", editor.cursor_row(), editor.cursor_col())),
+            )
+    });
+    utils.set_fonts(HashMap::from_iter([(
+        "NotoSans",
+        include_bytes!("./NotoSans-Regular.ttf").as_slice(),
+    )]));
+    utils.set_default_fonts(&["NotoSans".into()]);
+    utils.sync_and_update();
+
+    utils.click_cursor((199., 8.));
+    let end_of_first_line = utils.find(|_, e| Some(Label::try_downcast(e)?.text.to_string()));
+    assert_eq!(end_of_first_line.as_deref(), Some("0:20"));
+
+    utils.click_cursor((2., 25.));
+    let start_of_second_line = utils.find(|_, e| Some(Label::try_downcast(e)?.text.to_string()));
+    assert_eq!(start_of_second_line.as_deref(), Some("0:21"));
+}


### PR DESCRIPTION
Based off https://github.com/marc2332/freya/pull/2176