### PR TITLE
fix(core): Separate global context

### DIFF
--- a/crates/freya-components/src/http.rs
+++ b/crates/freya-components/src/http.rs
@@ -5,14 +5,12 @@ use reqwest::blocking::Client;
 pub(crate) struct Http;
 
 impl Http {
-    /// Returns the shared [`Client`], lazily creating it in the root context on first use.
+    /// Returns the shared [`Client`], lazily creating it in the global contexts on first use.
     pub(crate) fn get() -> Client {
-        try_consume_root_context::<Client>().unwrap_or_else(|| {
-            let client = Client::builder()
+        GlobalContexts::get().get_context_or_insert(|| {
+            Client::builder()
                 .build()
-                .expect("Failed to build the HTTP client.");
-            provide_root_context(client.clone());
-            client
+                .expect("Failed to build the HTTP client.")
         })
     }
 }

--- a/crates/freya-core/src/lifecycle/context.rs
+++ b/crates/freya-core/src/lifecycle/context.rs
@@ -65,19 +65,13 @@ pub fn provide_context<T: Clone + 'static>(value: T) {
     provide_context_for_scope_id(value, None)
 }
 
-/// Store the given value in the root scope, shared across windows. If a value of the same
+/// Store the given value in the root scope of the current window. If a value of the same
 /// type already exists, it is replaced.
 ///
-/// Only needed for specific cases like values consumed by queries or mutations, which run in
-/// the root scope. Prefer [provide_context] otherwise.
+/// For state shared across all windows use [GlobalContexts] instead.
 pub fn provide_root_context<T: Clone + 'static>(value: T) -> T {
-    match try_consume_root_context::<GlobalContexts>() {
-        Some(global_contexts) => global_contexts.insert_context(value),
-        None => {
-            provide_context_for_scope_id(value.clone(), Some(ScopeId::ROOT));
-            value
-        }
-    }
+    provide_context_for_scope_id(value.clone(), Some(ScopeId::ROOT));
+    value
 }
 
 pub fn provide_context_for_scope_id<T: Clone + 'static>(
@@ -109,11 +103,7 @@ pub fn try_consume_own_context<T: Clone + 'static>() -> Option<T> {
 }
 
 pub fn try_consume_root_context<T: Clone + 'static>() -> Option<T> {
-    try_consume_context_from_scope_id(Some(ScopeId::ROOT)).or_else(|| {
-        let global_contexts =
-            try_consume_context_from_scope_id::<GlobalContexts>(Some(ScopeId::ROOT))?;
-        global_contexts.try_get_context::<T>()
-    })
+    try_consume_context_from_scope_id(Some(ScopeId::ROOT))
 }
 
 pub fn try_consume_context<T: Clone + 'static>() -> Option<T> {
@@ -168,11 +158,10 @@ pub fn use_provide_context<T: Clone + 'static>(init: impl FnOnce() -> T) -> T {
     })
 }
 
-/// Store the given value in the root scope, shared across windows. If a value of the same
+/// Store the given value in the root scope of the current window. If a value of the same
 /// type already exists, that one is returned and `init` is not called.
 ///
-/// Only needed for specific cases like values consumed by queries or mutations, which run in
-/// the root scope. Prefer [use_provide_context] otherwise.
+/// For state shared across all windows use [GlobalContexts] instead.
 pub fn use_provide_root_context<T: Clone + 'static>(init: impl FnOnce() -> T) -> T {
     use_hook(|| match try_consume_root_context::<T>() {
         Some(context) => context,

--- a/crates/freya-core/src/lifecycle/context.rs
+++ b/crates/freya-core/src/lifecycle/context.rs
@@ -20,7 +20,34 @@ use crate::{
 pub struct GlobalContexts(Rc<RefCell<FxHashMap<TypeId, Rc<dyn Any>>>>);
 
 impl GlobalContexts {
-    pub fn get_or_insert<T: Clone + 'static>(&self, value: T) -> T {
+    pub fn get() -> GlobalContexts {
+        consume_context()
+    }
+
+    pub fn insert_context<T: Clone + 'static>(&self, value: T) -> T {
+        let mut contexts = self.0.borrow_mut();
+        contexts.insert(TypeId::of::<T>(), Rc::new(value.clone()));
+        value
+    }
+
+    pub fn get_context<T: Clone + 'static>(&self) -> T {
+        self.try_get_context().unwrap_or_else(|| {
+            panic!(
+                "Global context <{}> was not found.",
+                std::any::type_name::<T>()
+            )
+        })
+    }
+
+    pub fn try_get_context<T: Clone + 'static>(&self) -> Option<T> {
+        self.0
+            .borrow()
+            .get(&TypeId::of::<T>())?
+            .downcast_ref::<T>()
+            .cloned()
+    }
+
+    pub fn get_context_or_insert<T: Clone + 'static>(&self, insert: impl FnOnce() -> T) -> T {
         let mut contexts = self.0.borrow_mut();
         if let Some(context) = contexts
             .get(&TypeId::of::<T>())
@@ -28,16 +55,9 @@ impl GlobalContexts {
         {
             return context.clone();
         }
+        let value = insert();
         contexts.insert(TypeId::of::<T>(), Rc::new(value.clone()));
         value
-    }
-
-    pub fn get<T: Clone + 'static>(&self) -> Option<T> {
-        self.0
-            .borrow()
-            .get(&TypeId::of::<T>())?
-            .downcast_ref::<T>()
-            .cloned()
     }
 }
 
@@ -46,13 +66,13 @@ pub fn provide_context<T: Clone + 'static>(value: T) {
 }
 
 /// Store the given value in the root scope, shared across windows. If a value of the same
-/// type already exists, that one is returned instead.
+/// type already exists, it is replaced.
 ///
 /// Only needed for specific cases like values consumed by queries or mutations, which run in
 /// the root scope. Prefer [provide_context] otherwise.
 pub fn provide_root_context<T: Clone + 'static>(value: T) -> T {
     match try_consume_root_context::<GlobalContexts>() {
-        Some(global_contexts) => global_contexts.get_or_insert(value),
+        Some(global_contexts) => global_contexts.insert_context(value),
         None => {
             provide_context_for_scope_id(value.clone(), Some(ScopeId::ROOT));
             value
@@ -74,10 +94,6 @@ pub fn provide_context_for_scope_id<T: Clone + 'static>(
     })
 }
 
-pub fn try_consume_context<T: Clone + 'static>() -> Option<T> {
-    try_consume_context_from_scope_id(None)
-}
-
 /// Try to get a context value stored only in the current scope, without walking up to ancestors.
 pub fn try_consume_own_context<T: Clone + 'static>() -> Option<T> {
     CurrentContext::with(|context| {
@@ -96,8 +112,12 @@ pub fn try_consume_root_context<T: Clone + 'static>() -> Option<T> {
     try_consume_context_from_scope_id(Some(ScopeId::ROOT)).or_else(|| {
         let global_contexts =
             try_consume_context_from_scope_id::<GlobalContexts>(Some(ScopeId::ROOT))?;
-        global_contexts.get::<T>()
+        global_contexts.try_get_context::<T>()
     })
+}
+
+pub fn try_consume_context<T: Clone + 'static>() -> Option<T> {
+    try_consume_context_from_scope_id(None)
 }
 
 pub fn consume_context<T: Clone + 'static>() -> T {

--- a/crates/freya-i18n/src/i18n.rs
+++ b/crates/freya-i18n/src/i18n.rs
@@ -260,12 +260,14 @@ fn is_ftl_file(entry: &std::path::Path) -> bool {
 /// }
 /// ```
 pub fn use_init_i18n(init: impl FnOnce() -> I18nConfig) -> I18n {
-    use_provide_root_context(move || {
-        // Coverage false -ve: See https://github.com/xd009642/tarpaulin/issues/1675
-        match I18n::create_global(init()) {
-            Ok(i18n) => i18n,
-            Err(e) => panic!("Failed to create I18n context: {e}"),
-        }
+    use_hook(move || {
+        GlobalContexts::get().insert_context({
+            // Coverage false -ve: See https://github.com/xd009642/tarpaulin/issues/1675
+            match I18n::create_global(init()) {
+                Ok(i18n) => i18n,
+                Err(e) => panic!("Failed to create I18n context: {e}"),
+            }
+        })
     })
 }
 

--- a/crates/freya-i18n/src/i18n.rs
+++ b/crates/freya-i18n/src/i18n.rs
@@ -292,14 +292,14 @@ pub struct I18n {
 }
 
 impl I18n {
-    /// Try to retrieve the [`I18n`] instance from the root context.
+    /// Try to retrieve the [`I18n`] instance from the global contexts.
     ///
     /// Returns `None` if no [`I18n`] has been provided via [`use_init_i18n`] in any window.
     pub fn try_get() -> Option<Self> {
-        try_consume_root_context()
+        GlobalContexts::get().try_get_context()
     }
 
-    /// Retrieve the [`I18n`] instance from the root context.
+    /// Retrieve the [`I18n`] instance from the global contexts.
     ///
     /// This is the primary way to access the i18n state once any window has called
     /// [`use_init_i18n`].
@@ -327,7 +327,7 @@ impl I18n {
     /// }
     /// ```
     pub fn get() -> Self {
-        consume_root_context()
+        GlobalContexts::get().get_context()
     }
 
     /// Manually create an [`I18n`] instance from an [`I18nConfig`].
@@ -366,8 +366,8 @@ impl I18n {
     /// Unlike [`I18n::create`], the state created here is not scoped to any component and will
     /// live for the entire duration of the application. [`use_init_i18n`] uses this internally
     /// and shares the instance across all windows, so you rarely need to call it directly.
-    /// Call it when you need explicit error handling and share the result yourself with
-    /// [`use_provide_root_context`].
+    /// Call it when you need explicit error handling and share the result yourself by
+    /// inserting it into the [`GlobalContexts`].
     pub fn create_global(
         I18nConfig {
             id: selected_language,

--- a/crates/freya-query/src/mutation.rs
+++ b/crates/freya-query/src/mutation.rs
@@ -18,10 +18,6 @@ use std::{
 use async_io::Timer;
 use freya_core::{
     integration::FxHashSet,
-    lifecycle::context::{
-        consume_root_context,
-        try_consume_root_context,
-    },
     prelude::*,
 };
 
@@ -183,7 +179,7 @@ impl<Q: MutationCapability> Clone for MutationData<Q> {
 }
 
 impl<Q: MutationCapability> MutationsStorage<Q> {
-    fn new_in_root() -> Self {
+    fn create_global() -> Self {
         Self {
             storage: State::create_global(HashMap::default()),
             #[cfg(debug_assertions)]
@@ -195,7 +191,7 @@ impl<Q: MutationCapability> MutationsStorage<Q> {
     ///
     /// [MutationCapability::on_settled] still runs.
     ///
-    /// Provide it in the root scope before the app runs any mutation.
+    /// Insert it into the [GlobalContexts] before the app runs any mutation.
     #[cfg(debug_assertions)]
     pub fn mocked(mock: impl Fn(Q::Keys) -> Result<Q::Ok, Q::Err> + 'static) -> Self {
         Self::mocked_async(move |keys| {
@@ -303,7 +299,8 @@ impl<Q: MutationCapability> Mutation<Q> {
     async fn run(&self, keys: &Q::Keys) -> Result<Q::Ok, Q::Err> {
         #[cfg(debug_assertions)]
         {
-            let mock = try_consume_root_context::<MutationsStorage<Q>>()
+            let mock = GlobalContexts::get()
+                .try_get_context::<MutationsStorage<Q>>()
                 .and_then(|storage| storage.mock.peek().clone());
 
             if let Some(mock) = mock {
@@ -357,7 +354,7 @@ impl<Q: MutationCapability> UseMutation<Q> {
     /// This **will** automatically subscribe.
     /// If you want a **subscribing** method have a look at [UseMutation::peek].
     pub fn read(&self) -> MutationReader<Q> {
-        let storage = consume_root_context::<MutationsStorage<Q>>();
+        let storage = GlobalContexts::get().get_context::<MutationsStorage<Q>>();
         let map = storage.storage.peek();
         let mutation_data = map.get(&self.mutation.read()).cloned().unwrap();
 
@@ -376,7 +373,7 @@ impl<Q: MutationCapability> UseMutation<Q> {
     /// This **will not** automatically subscribe.
     /// If you want a **subscribing** method have a look at [UseMutation::read].
     pub fn peek(&self) -> MutationReader<Q> {
-        let storage = consume_root_context::<MutationsStorage<Q>>();
+        let storage = GlobalContexts::get().get_context::<MutationsStorage<Q>>();
         let map = storage.storage.peek();
         let mutation_data = map.get(&self.mutation.peek()).cloned().unwrap();
 
@@ -389,7 +386,7 @@ impl<Q: MutationCapability> UseMutation<Q> {
     ///
     /// For a `sync` version use [UseMutation::mutate].
     pub async fn mutate_async(&self, keys: Q::Keys) -> MutationReader<Q> {
-        let storage = consume_root_context::<MutationsStorage<Q>>();
+        let storage = GlobalContexts::get().get_context::<MutationsStorage<Q>>();
 
         let mutation = self.mutation.peek();
         let map = storage.storage.peek();
@@ -407,7 +404,7 @@ impl<Q: MutationCapability> UseMutation<Q> {
     ///
     /// For an `async` version use [UseMutation::mutate_async].
     pub fn mutate(&self, keys: Q::Keys) {
-        let storage = consume_root_context::<MutationsStorage<Q>>();
+        let storage = GlobalContexts::get().get_context::<MutationsStorage<Q>>();
 
         let mutation = self.mutation.peek();
         let map = storage.storage.peek();
@@ -426,10 +423,8 @@ impl<Q: MutationCapability> UseMutation<Q> {
 /// See [Mutation::clean_time].
 pub fn use_mutation<Q: MutationCapability>(mutation: impl Into<Mutation<Q>>) -> UseMutation<Q> {
     let mutation = mutation.into();
-    let mut storage = match try_consume_root_context::<MutationsStorage<Q>>() {
-        Some(storage) => storage,
-        None => provide_root_context(MutationsStorage::<Q>::new_in_root()),
-    };
+    let mut storage =
+        GlobalContexts::get().get_context_or_insert(MutationsStorage::<Q>::create_global);
 
     let mut make_mutation = |mutation: &Mutation<Q>, mut prev_mutation: Option<Mutation<Q>>| {
         let _data = storage.insert_or_get_mutation(mutation.clone());

--- a/crates/freya-query/src/query.rs
+++ b/crates/freya-query/src/query.rs
@@ -18,10 +18,6 @@ use std::{
 use async_io::Timer;
 use freya_core::{
     integration::FxHashSet,
-    lifecycle::context::{
-        consume_root_context,
-        try_consume_root_context,
-    },
     prelude::*,
 };
 use futures_util::stream::{
@@ -200,7 +196,7 @@ impl<Q: QueryCapability> Clone for QueryData<Q> {
 }
 
 impl<Q: QueryCapability> QueriesStorage<Q> {
-    fn new_in_root() -> Self {
+    fn create_global() -> Self {
         Self {
             storage: State::create_global(HashMap::default()),
             #[cfg(debug_assertions)]
@@ -210,7 +206,7 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
 
     /// Create a storage whose queries resolve with `mock` instead of [QueryCapability::run].
     ///
-    /// Provide it in the root scope before the app runs any query.
+    /// Insert it into the [GlobalContexts] before the app runs any query.
     #[cfg(debug_assertions)]
     pub fn mocked(mock: impl Fn(Q::Keys) -> Result<Q::Ok, Q::Err> + 'static) -> Self {
         Self::mocked_async(move |keys| {
@@ -325,10 +321,8 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     pub async fn get(get_query: GetQuery<Q>) -> QueryReader<Q> {
         let query: Query<Q> = get_query.into();
 
-        let mut storage = match try_consume_root_context::<QueriesStorage<Q>>() {
-            Some(storage) => storage,
-            None => provide_root_context(QueriesStorage::<Q>::new_in_root()),
-        };
+        let mut storage =
+            GlobalContexts::get().get_context_or_insert(QueriesStorage::<Q>::create_global);
 
         let mut map = storage.storage.write();
         let query_data = map
@@ -363,7 +357,7 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     ///
     /// Returns an empty [Vec] if the query storage is not in context.
     pub fn peek_matching(matching_keys: Q::Keys) -> Vec<QueryReader<Q>> {
-        let Some(storage) = try_consume_root_context::<QueriesStorage<Q>>() else {
+        let Some(storage) = GlobalContexts::get().try_get_context::<QueriesStorage<Q>>() else {
             return Vec::new();
         };
 
@@ -382,7 +376,7 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     ///
     /// Does nothing if the query storage is not in context
     pub async fn invalidate_all() {
-        let Some(storage) = try_consume_root_context::<QueriesStorage<Q>>() else {
+        let Some(storage) = GlobalContexts::get().try_get_context::<QueriesStorage<Q>>() else {
             return;
         };
 
@@ -404,7 +398,7 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     ///
     /// Does nothing if the query storage is not in context
     pub async fn invalidate_matching(matching_keys: Q::Keys) {
-        let Some(storage) = try_consume_root_context::<QueriesStorage<Q>>() else {
+        let Some(storage) = GlobalContexts::get().try_get_context::<QueriesStorage<Q>>() else {
             return;
         };
 
@@ -534,7 +528,8 @@ impl<Q: QueryCapability> Query<Q> {
     async fn run(&self, keys: &Q::Keys) -> Result<Q::Ok, Q::Err> {
         #[cfg(debug_assertions)]
         {
-            let mock = try_consume_root_context::<QueriesStorage<Q>>()
+            let mock = GlobalContexts::get()
+                .try_get_context::<QueriesStorage<Q>>()
                 .and_then(|storage| storage.mock.peek().clone());
 
             if let Some(mock) = mock {
@@ -638,7 +633,7 @@ impl<Q: QueryCapability> UseQuery<Q> {
     /// This **will** automatically subscribe.
     /// If you want a **non-subscribing** method have a look at [UseQuery::peek].
     pub fn read(&self) -> QueryReader<Q> {
-        let storage = consume_root_context::<QueriesStorage<Q>>();
+        let storage = GlobalContexts::get().get_context::<QueriesStorage<Q>>();
         let map = storage.storage.peek();
         let query_data = map.get(&self.query.read()).cloned().unwrap();
 
@@ -657,7 +652,7 @@ impl<Q: QueryCapability> UseQuery<Q> {
     /// This **will not** automatically subscribe.
     /// If you want a **subscribing** method have a look at [UseQuery::read].
     pub fn peek(&self) -> QueryReader<Q> {
-        let storage = consume_root_context::<QueriesStorage<Q>>();
+        let storage = GlobalContexts::get().get_context::<QueriesStorage<Q>>();
         let map = storage.storage.peek();
         let query_data = map.get(&self.query.peek()).cloned().unwrap();
 
@@ -670,7 +665,7 @@ impl<Q: QueryCapability> UseQuery<Q> {
     ///
     /// For a `sync` version use [UseQuery::invalidate].
     pub async fn invalidate_async(&self) -> QueryReader<Q> {
-        let storage = consume_root_context::<QueriesStorage<Q>>();
+        let storage = GlobalContexts::get().get_context::<QueriesStorage<Q>>();
 
         let query = self.query.peek().clone();
         let map = storage.storage.peek();
@@ -688,7 +683,7 @@ impl<Q: QueryCapability> UseQuery<Q> {
     ///
     /// For an `async` version use [UseQuery::invalidate_async].
     pub fn invalidate(&self) {
-        let storage = consume_root_context::<QueriesStorage<Q>>();
+        let storage = GlobalContexts::get().get_context::<QueriesStorage<Q>>();
 
         let query = self.query.peek().clone();
         let map = storage.storage.peek();
@@ -727,10 +722,8 @@ impl<Q: QueryCapability> UseQuery<Q> {
 ///
 /// See [Query::interval_time].
 pub fn use_query<Q: QueryCapability>(query: Query<Q>) -> UseQuery<Q> {
-    let mut storage = match try_consume_root_context::<QueriesStorage<Q>>() {
-        Some(storage) => storage,
-        None => provide_root_context(QueriesStorage::<Q>::new_in_root()),
-    };
+    let mut storage =
+        GlobalContexts::get().get_context_or_insert(QueriesStorage::<Q>::create_global);
 
     let mut reactive_context = use_hook(|| ReactiveContext::new_for_task().1);
 

--- a/crates/freya-query/tests/mutation_tests.rs
+++ b/crates/freya-query/tests/mutation_tests.rs
@@ -197,11 +197,13 @@ fn mocked_mutation_records_the_calls() {
         {
             let calls = calls.clone();
             move |runner| {
-                runner.provide_root_context(move || {
-                    MutationsStorage::<SetUserName>::mocked(move |keys| {
-                        calls.borrow_mut().push(keys);
-                        Ok(())
-                    })
+                runner.run_in(move || {
+                    GlobalContexts::get().insert_context(MutationsStorage::<SetUserName>::mocked(
+                        move |keys| {
+                            calls.borrow_mut().push(keys);
+                            Ok(())
+                        },
+                    ))
                 })
             }
         },

--- a/crates/freya-query/tests/query_tests.rs
+++ b/crates/freya-query/tests/query_tests.rs
@@ -283,8 +283,10 @@ fn mocked_query() {
         app,
         (200., 200.).into(),
         |runner| {
-            runner.provide_root_context(|| {
-                QueriesStorage::<GetUserName>::mocked(|_keys| Ok("Mocked".to_string()))
+            runner.run_in(|| {
+                GlobalContexts::get().insert_context(QueriesStorage::<GetUserName>::mocked(
+                    |_keys| Ok("Mocked".to_string()),
+                ))
             })
         },
         1.,
@@ -320,11 +322,13 @@ fn mocked_async_query() {
         app,
         (200., 200.).into(),
         |runner| {
-            runner.provide_root_context(|| {
-                QueriesStorage::<GetUserName>::mocked_async(|keys| async move {
-                    Timer::after(std::time::Duration::from_millis(20)).await;
-                    Ok(format!("Mocked {keys}"))
-                })
+            runner.run_in(|| {
+                GlobalContexts::get().insert_context(QueriesStorage::<GetUserName>::mocked_async(
+                    |keys| async move {
+                        Timer::after(std::time::Duration::from_millis(20)).await;
+                        Ok(format!("Mocked {keys}"))
+                    },
+                ))
             })
         },
         1.,


### PR DESCRIPTION
Follow up of https://github.com/marc2332/freya/pull/2111

This makes it less prone to error when using e.g the root context api.

If one wants to use the global context then it must use it through its api.