### PR TITLE
fix(core): Announce a11y text on isolated (that are not wrapped) elements like label and paragraph

### DIFF
--- a/crates/freya-core/src/accessibility/tree.rs
+++ b/crates/freya-core/src/accessibility/tree.rs
@@ -357,19 +357,18 @@ impl AccessibilityTree {
     }
 
     fn element_text(element: &dyn Any) -> Option<String> {
-        if let Some(label) = element.downcast_ref::<LabelElement>() {
-            Some(label.text.to_string())
-        } else if let Some(paragraph) = element.downcast_ref::<ParagraphElement>() {
-            Some(
-                paragraph
-                    .spans
-                    .iter()
-                    .map(|span| span.text.as_ref())
-                    .collect(),
-            )
-        } else {
-            None
-        }
+        element
+            .downcast_ref::<LabelElement>()
+            .map(|label| label.text.to_string())
+            .or_else(|| {
+                element.downcast_ref::<ParagraphElement>().map(|paragraph| {
+                    paragraph
+                        .spans
+                        .iter()
+                        .map(|span| span.text.as_ref())
+                        .collect()
+                })
+            })
     }
 
     /// Create an accessibility node

--- a/crates/freya-core/src/accessibility/tree.rs
+++ b/crates/freya-core/src/accessibility/tree.rs
@@ -356,21 +356,6 @@ impl AccessibilityTree {
             .unwrap();
     }
 
-    fn element_text(element: &dyn Any) -> Option<String> {
-        element
-            .downcast_ref::<LabelElement>()
-            .map(|label| label.text.to_string())
-            .or_else(|| {
-                element.downcast_ref::<ParagraphElement>().map(|paragraph| {
-                    paragraph
-                        .spans
-                        .iter()
-                        .map(|span| span.text.as_ref())
-                        .collect()
-                })
-            })
-    }
-
     /// Create an accessibility node
     pub fn create_node(
         node_id: NodeId,
@@ -407,13 +392,18 @@ impl AccessibilityTree {
         });
 
         // Set inner text
-        let inner_text = Self::element_text(element.as_ref() as &dyn Any).or_else(|| {
-            tree.children.get(&node_id).and_then(|children| {
-                children.iter().find_map(|child| {
-                    Self::element_text(tree.elements.get(child).unwrap().as_ref() as &dyn Any)
+        let inner_text = accessibility_data
+            .builder
+            .value()
+            .map(String::from)
+            .or_else(|| {
+                tree.children.get(&node_id).and_then(|children| {
+                    children.iter().find_map(|child| {
+                        let child_accessibility = tree.elements.get(child).unwrap().accessibility();
+                        child_accessibility.builder.value().map(String::from)
+                    })
                 })
-            })
-        });
+            });
 
         if let Some(inner_text) = inner_text {
             // Accesskit derives the name of Role::Label nodes from the value, not the label

--- a/crates/freya-core/src/accessibility/tree.rs
+++ b/crates/freya-core/src/accessibility/tree.rs
@@ -356,6 +356,22 @@ impl AccessibilityTree {
             .unwrap();
     }
 
+    fn element_text(element: &dyn Any) -> Option<String> {
+        if let Some(label) = element.downcast_ref::<LabelElement>() {
+            Some(label.text.to_string())
+        } else if let Some(paragraph) = element.downcast_ref::<ParagraphElement>() {
+            Some(
+                paragraph
+                    .spans
+                    .iter()
+                    .map(|span| span.text.as_ref())
+                    .collect(),
+            )
+        } else {
+            None
+        }
+    }
+
     /// Create an accessibility node
     pub fn create_node(
         node_id: NodeId,
@@ -392,20 +408,20 @@ impl AccessibilityTree {
         });
 
         // Set inner text
-        if let Some(children) = tree.children.get(&node_id) {
-            for child in children {
-                let child_element = tree.elements.get(child).unwrap().as_ref() as &dyn Any;
-                if let Some(label) = child_element.downcast_ref::<LabelElement>() {
-                    accessibility_data.builder.set_label(label.text.as_ref());
-                } else if let Some(paragraph) = child_element.downcast_ref::<ParagraphElement>() {
-                    accessibility_data.builder.set_label(
-                        paragraph
-                            .spans
-                            .iter()
-                            .map(|span| span.text.as_ref())
-                            .collect::<String>(),
-                    );
-                }
+        let inner_text = Self::element_text(element.as_ref() as &dyn Any).or_else(|| {
+            tree.children.get(&node_id).and_then(|children| {
+                children.iter().find_map(|child| {
+                    Self::element_text(tree.elements.get(child).unwrap().as_ref() as &dyn Any)
+                })
+            })
+        });
+
+        if let Some(inner_text) = inner_text {
+            // Accesskit derives the name of Role::Label nodes from the value, not the label
+            if accessibility_data.builder.role() == Role::Label {
+                accessibility_data.builder.set_value(inner_text);
+            } else {
+                accessibility_data.builder.set_label(inner_text);
             }
         }
 

--- a/crates/freya-core/src/accessibility/tree.rs
+++ b/crates/freya-core/src/accessibility/tree.rs
@@ -365,6 +365,7 @@ impl AccessibilityTree {
     ) -> Node {
         let element = tree.elements.get(&node_id).unwrap();
         let mut accessibility_data = element.accessibility().into_owned();
+        element.finish_accessibility(&mut accessibility_data.builder);
 
         if node_id == NodeId::ROOT {
             accessibility_data.builder.set_role(Role::Window);
@@ -399,8 +400,10 @@ impl AccessibilityTree {
             .or_else(|| {
                 tree.children.get(&node_id).and_then(|children| {
                     children.iter().find_map(|child| {
-                        let child_accessibility = tree.elements.get(child).unwrap().accessibility();
-                        child_accessibility.builder.value().map(String::from)
+                        let child_element = tree.elements.get(child).unwrap();
+                        let mut child_builder = child_element.accessibility().builder.clone();
+                        child_element.finish_accessibility(&mut child_builder);
+                        child_builder.value().map(String::from)
                     })
                 })
             });

--- a/crates/freya-core/src/element.rs
+++ b/crates/freya-core/src/element.rs
@@ -163,6 +163,9 @@ pub trait ElementExt: Any {
             ],
         )
     }
+
+    /// Mutate the accessibility node right before it enters the accessibility tree.
+    fn finish_accessibility(&self, _builder: &mut accesskit::Node) {}
 }
 
 #[allow(dead_code)]

--- a/crates/freya-core/src/elements/label.rs
+++ b/crates/freya-core/src/elements/label.rs
@@ -134,6 +134,7 @@ impl ElementExt for LabelElement {
         if self.text != label.text {
             diff.insert(DiffModifies::STYLE);
             diff.insert(DiffModifies::LAYOUT);
+            diff.insert(DiffModifies::ACCESSIBILITY);
         }
 
         if self.accessibility != label.accessibility {
@@ -184,6 +185,10 @@ impl ElementExt for LabelElement {
 
     fn accessibility(&'_ self) -> Cow<'_, AccessibilityData> {
         Cow::Borrowed(&self.accessibility)
+    }
+
+    fn finish_accessibility(&self, builder: &mut accesskit::Node) {
+        builder.set_value(self.text.clone());
     }
 
     fn layer(&self) -> Layer {
@@ -308,10 +313,7 @@ impl ElementExt for LabelElement {
 }
 
 impl From<Label> for Element {
-    fn from(mut value: Label) -> Self {
-        let text = value.element.text.clone();
-        value.element.accessibility.builder.set_value(text);
-
+    fn from(value: Label) -> Self {
         Element::Element {
             key: value.key,
             element: Rc::new(value.element),

--- a/crates/freya-core/src/elements/label.rs
+++ b/crates/freya-core/src/elements/label.rs
@@ -308,7 +308,10 @@ impl ElementExt for LabelElement {
 }
 
 impl From<Label> for Element {
-    fn from(value: Label) -> Self {
+    fn from(mut value: Label) -> Self {
+        let text = value.element.text.clone();
+        value.element.accessibility.builder.set_value(text);
+
         Element::Element {
             key: value.key,
             element: Rc::new(value.element),

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -216,6 +216,7 @@ impl ElementExt for ParagraphElement {
         if self.spans != paragraph.spans || self.contents != paragraph.contents {
             diff.insert(DiffModifies::STYLE);
             diff.insert(DiffModifies::LAYOUT);
+            diff.insert(DiffModifies::ACCESSIBILITY);
         }
 
         if self.accessibility != paragraph.accessibility {
@@ -281,6 +282,15 @@ impl ElementExt for ParagraphElement {
 
     fn accessibility(&'_ self) -> Cow<'_, AccessibilityData> {
         Cow::Borrowed(&self.accessibility)
+    }
+
+    fn finish_accessibility(&self, builder: &mut accesskit::Node) {
+        builder.set_value(
+            self.spans
+                .iter()
+                .map(|span| span.text.as_ref())
+                .collect::<String>(),
+        );
     }
 
     fn layer(&self) -> Layer {
@@ -708,15 +718,7 @@ pub fn cursor_character_rect(
 }
 
 impl From<Paragraph> for Element {
-    fn from(mut value: Paragraph) -> Self {
-        let text = value
-            .element
-            .spans
-            .iter()
-            .map(|span| span.text.as_ref())
-            .collect::<String>();
-        value.element.accessibility.builder.set_value(text);
-
+    fn from(value: Paragraph) -> Self {
         let elements = value
             .children
             .into_iter()

--- a/crates/freya-core/src/elements/paragraph.rs
+++ b/crates/freya-core/src/elements/paragraph.rs
@@ -708,7 +708,15 @@ pub fn cursor_character_rect(
 }
 
 impl From<Paragraph> for Element {
-    fn from(value: Paragraph) -> Self {
+    fn from(mut value: Paragraph) -> Self {
+        let text = value
+            .element
+            .spans
+            .iter()
+            .map(|span| span.text.as_ref())
+            .collect::<String>();
+        value.element.accessibility.builder.set_value(text);
+
         let elements = value
             .children
             .into_iter()
@@ -915,8 +923,6 @@ impl Paragraph {
 
     /// Append every [`Span`] yielded by the iterator to the paragraph.
     pub fn spans_iter(mut self, spans: impl Iterator<Item = Span<'static>>) -> Self {
-        // TODO: Accessible paragraphs
-        // self.element.accessibility.builder.set_value(text.clone());
         for span in spans {
             self.push_span(span);
         }
@@ -925,8 +931,6 @@ impl Paragraph {
 
     /// Append a single [`Span`] of styled text to the paragraph.
     pub fn span(mut self, span: impl Into<Span<'static>>) -> Self {
-        // TODO: Accessible paragraphs
-        // self.element.accessibility.builder.set_value(text.clone());
         self.push_span(span.into());
         self
     }


### PR DESCRIPTION
Isolated (with no accessible wrapper element) elements like label and paragraph also get their a11y text announcted.