### PR TITLE
fix(query): Dont borrow across await when running queries and mutations

### DIFF
--- a/crates/freya-query/src/mutation.rs
+++ b/crates/freya-query/src/mutation.rs
@@ -355,8 +355,12 @@ impl<Q: MutationCapability> UseMutation<Q> {
     /// If you want a **subscribing** method have a look at [UseMutation::peek].
     pub fn read(&self) -> MutationReader<Q> {
         let storage = GlobalContexts::get().get_context::<MutationsStorage<Q>>();
-        let map = storage.storage.peek();
-        let mutation_data = map.get(&self.mutation.read()).cloned().unwrap();
+        let mutation_data = storage
+            .storage
+            .peek()
+            .get(&self.mutation.read())
+            .cloned()
+            .unwrap();
 
         // Subscribe if possible
         if let Some(mut reactive_context) = ReactiveContext::try_current() {
@@ -374,8 +378,12 @@ impl<Q: MutationCapability> UseMutation<Q> {
     /// If you want a **subscribing** method have a look at [UseMutation::read].
     pub fn peek(&self) -> MutationReader<Q> {
         let storage = GlobalContexts::get().get_context::<MutationsStorage<Q>>();
-        let map = storage.storage.peek();
-        let mutation_data = map.get(&self.mutation.peek()).cloned().unwrap();
+        let mutation_data = storage
+            .storage
+            .peek()
+            .get(&self.mutation.peek())
+            .cloned()
+            .unwrap();
 
         MutationReader {
             state: mutation_data.state,
@@ -388,9 +396,8 @@ impl<Q: MutationCapability> UseMutation<Q> {
     pub async fn mutate_async(&self, keys: Q::Keys) -> MutationReader<Q> {
         let storage = GlobalContexts::get().get_context::<MutationsStorage<Q>>();
 
-        let mutation = self.mutation.peek();
-        let map = storage.storage.peek();
-        let mutation_data = map.get(&mutation).cloned().unwrap();
+        let mutation = self.mutation.peek().clone();
+        let mutation_data = storage.storage.peek().get(&mutation).cloned().unwrap();
 
         // Run the mutation
         MutationsStorage::run(&mutation, &mutation_data, keys).await;
@@ -406,9 +413,8 @@ impl<Q: MutationCapability> UseMutation<Q> {
     pub fn mutate(&self, keys: Q::Keys) {
         let storage = GlobalContexts::get().get_context::<MutationsStorage<Q>>();
 
-        let mutation = self.mutation.peek();
-        let map = storage.storage.peek();
-        let mutation_data = map.get(&mutation).cloned().unwrap();
+        let mutation = self.mutation.peek().clone();
+        let mutation_data = storage.storage.peek().get(&mutation).cloned().unwrap();
 
         // Run the mutation
         spawn_forever(async move { MutationsStorage::run(&mutation, &mutation_data, keys).await });

--- a/crates/freya-query/src/query.rs
+++ b/crates/freya-query/src/query.rs
@@ -324,8 +324,9 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
         let mut storage =
             GlobalContexts::get().get_context_or_insert(QueriesStorage::<Q>::create_global);
 
-        let mut map = storage.storage.write();
-        let query_data = map
+        let query_data = storage
+            .storage
+            .write()
             .entry(query.clone())
             .or_insert_with(|| QueryData {
                 state: Rc::new(RefCell::new(QueryStateData::Pending)),
@@ -384,11 +385,17 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
     }
 
     async fn inner_invalidate_all(self) {
-        let mut all_queries = Vec::new();
-        let storage = self.storage.read();
-        for (query, data) in storage.iter() {
-            all_queries.push((query, data));
-        }
+        let all_queries = self
+            .storage
+            .read()
+            .iter()
+            .map(|(query, query_data)| (query.clone(), query_data.clone()))
+            .collect::<Vec<_>>();
+
+        let all_queries = all_queries
+            .iter()
+            .map(|(query, query_data)| (query, query_data))
+            .collect::<Vec<_>>();
 
         // Invalidate the queries
         Self::run_queries(&all_queries).await
@@ -407,13 +414,18 @@ impl<Q: QueryCapability> QueriesStorage<Q> {
 
     async fn inner_invalidate_matching(self, matching_keys: Q::Keys) {
         // Get those queries that match
-        let mut matching_queries = Vec::new();
-        let storage = self.storage.read();
-        for (query, data) in storage.iter() {
-            if query.query.matches(&matching_keys) {
-                matching_queries.push((query, data));
-            }
-        }
+        let matching_queries = self
+            .storage
+            .read()
+            .iter()
+            .filter(|(query, _)| query.query.matches(&matching_keys))
+            .map(|(query, query_data)| (query.clone(), query_data.clone()))
+            .collect::<Vec<_>>();
+
+        let matching_queries = matching_queries
+            .iter()
+            .map(|(query, query_data)| (query, query_data))
+            .collect::<Vec<_>>();
 
         // Invalidate the queries
         Self::run_queries(&matching_queries).await
@@ -634,8 +646,12 @@ impl<Q: QueryCapability> UseQuery<Q> {
     /// If you want a **non-subscribing** method have a look at [UseQuery::peek].
     pub fn read(&self) -> QueryReader<Q> {
         let storage = GlobalContexts::get().get_context::<QueriesStorage<Q>>();
-        let map = storage.storage.peek();
-        let query_data = map.get(&self.query.read()).cloned().unwrap();
+        let query_data = storage
+            .storage
+            .peek()
+            .get(&self.query.read())
+            .cloned()
+            .unwrap();
 
         // Subscribe if possible
         if let Some(mut reactive_context) = ReactiveContext::try_current() {
@@ -653,8 +669,12 @@ impl<Q: QueryCapability> UseQuery<Q> {
     /// If you want a **subscribing** method have a look at [UseQuery::read].
     pub fn peek(&self) -> QueryReader<Q> {
         let storage = GlobalContexts::get().get_context::<QueriesStorage<Q>>();
-        let map = storage.storage.peek();
-        let query_data = map.get(&self.query.peek()).cloned().unwrap();
+        let query_data = storage
+            .storage
+            .peek()
+            .get(&self.query.peek())
+            .cloned()
+            .unwrap();
 
         QueryReader {
             state: query_data.state,
@@ -668,8 +688,7 @@ impl<Q: QueryCapability> UseQuery<Q> {
         let storage = GlobalContexts::get().get_context::<QueriesStorage<Q>>();
 
         let query = self.query.peek().clone();
-        let map = storage.storage.peek();
-        let query_data = map.get(&query).cloned().unwrap();
+        let query_data = storage.storage.peek().get(&query).cloned().unwrap();
 
         // Run the query
         QueriesStorage::run_queries(&[(&query, &query_data)]).await;
@@ -686,8 +705,7 @@ impl<Q: QueryCapability> UseQuery<Q> {
         let storage = GlobalContexts::get().get_context::<QueriesStorage<Q>>();
 
         let query = self.query.peek().clone();
-        let map = storage.storage.peek();
-        let query_data = map.get(&query).cloned().unwrap();
+        let query_data = storage.storage.peek().get(&query).cloned().unwrap();
 
         // Run the query
         spawn_forever(async move { QueriesStorage::run_queries(&[(&query, &query_data)]).await });


### PR DESCRIPTION
I wrongly assumed my own code in https://github.com/marc2332/freya/commit/eafd8a90b7ddc6ca4b11faae14c2aa5b3acc9d5f#diff-9fcf3b9f4d4a7be0eb3ed8fe5c840ed753265da2b9802458f0764e12832a9294R405, this PR reverts it.