### PR TITLE
fix(borderless): Only render shadow on wayland and when not maximized / tiled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ version = "0.5.0-rc.4"
 dependencies = [
  "freya-core",
  "freya-winit",
+ "smithay-client-toolkit 0.19.2",
  "torin",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ rfd = "0.17"
 # Desktop renderer
 raw-window-handle = "0.6.0"
 winit = "0.30.13"
+smithay-client-toolkit = { version = "0.19.2", default-features = false }
 
 # Tray
 tray-icon = "0.21"

--- a/crates/freya-borderless-plugin/Cargo.toml
+++ b/crates/freya-borderless-plugin/Cargo.toml
@@ -18,3 +18,6 @@ workspace = true
 freya-core = { workspace = true }
 freya-winit = { workspace = true }
 torin = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+smithay-client-toolkit = { workspace = true }

--- a/crates/freya-borderless-plugin/src/lib.rs
+++ b/crates/freya-borderless-plugin/src/lib.rs
@@ -6,7 +6,10 @@ use freya_winit::{
         PluginEvent,
         PluginHandle,
     },
-    winit::window::ResizeDirection,
+    winit::window::{
+        ResizeDirection,
+        Window,
+    },
 };
 use torin::{
     position::Position,
@@ -36,7 +39,8 @@ const DIRECTIONS: [ResizeDirection; 8] = [
 /// - **Linux** and **Windows**: overlays [ResizeBands] on top of the app, so dragging
 ///   the window borders resizes it and hovering them shows the resize cursors.
 /// - **macOS**: no bands, resizing is left to the system.
-/// - **All**: an optional corner radius rounds the app and a drop shadow is painted around it.
+/// - **All**: an optional corner radius rounds the app.
+/// - **Linux Wayland**: a drop shadow is painted around the app.
 ///
 /// # Example
 ///
@@ -108,8 +112,9 @@ struct BorderlessRoot {
 
 impl Component for BorderlessRoot {
     fn render(&self) -> impl IntoElement {
-        let maximized = use_maximized();
-        let inset = if maximized() { 0. } else { 12. };
+        let info = use_window_info();
+        let shadow = info.wayland && !info.edge_to_edge;
+        let inset = if shadow { 12. } else { 0. };
 
         rect()
             .expanded()
@@ -118,14 +123,11 @@ impl Component for BorderlessRoot {
                 rect()
                     .expanded()
                     .overflow(Overflow::Clip)
-                    .maybe(!maximized(), |el| {
-                        el.corner_radius(self.corner_radius).shadow((
-                            0.,
-                            0.,
-                            inset,
-                            0.,
-                            Color::BLACK.with_a(90),
-                        ))
+                    .maybe(!info.edge_to_edge, |el| {
+                        el.corner_radius(self.corner_radius)
+                    })
+                    .maybe(shadow, |el| {
+                        el.shadow((0., 0., inset, 0., Color::BLACK.with_a(90)))
                     })
                     .child(self.inner.clone()),
             )
@@ -135,20 +137,89 @@ impl Component for BorderlessRoot {
     }
 }
 
-/// Whether the window is fullscreen or maximized.
-pub fn use_maximized() -> State<bool> {
-    let mut maximized = use_state(|| false);
+#[derive(Clone, Copy, Default, PartialEq)]
+pub struct WindowInfo {
+    /// The window is fullscreen, maximized or snapped to a side of the monitor.
+    pub edge_to_edge: bool,
+    pub wayland: bool,
+}
+
+impl WindowInfo {
+    fn read(window: &Window) -> Self {
+        let tiled = wayland_tiled(window);
+        Self {
+            edge_to_edge: window.fullscreen().is_some()
+                || window.is_maximized()
+                || tiled == Some(true),
+            wayland: tiled.is_some(),
+        }
+    }
+}
+
+pub fn use_window_info() -> WindowInfo {
+    let mut info = use_state(WindowInfo::default);
 
     use_side_effect(move || {
         let _ = Platform::get().root_size.read();
         Platform::get().with_window(Platform::window_id(), move |window| {
-            if let Some(mut maximized) = maximized.try_write() {
-                *maximized = window.fullscreen().is_some() || window.is_maximized();
+            if let Some(mut info) = info.try_write() {
+                *info = WindowInfo::read(window);
             }
         });
     });
 
-    maximized
+    info()
+}
+
+/// Whether a Wayland window is tiled, `None` on any other backend.
+#[cfg(target_os = "linux")]
+fn wayland_tiled(window: &Window) -> Option<bool> {
+    use freya_winit::winit::{
+        platform::wayland::WindowExtWayland,
+        raw_window_handle::{
+            HasDisplayHandle,
+            RawDisplayHandle,
+        },
+    };
+    use smithay_client_toolkit::{
+        reexports::{
+            client::{
+                Connection,
+                Proxy,
+                backend::{
+                    Backend,
+                    ObjectId,
+                },
+            },
+            protocols::xdg::shell::client::xdg_toplevel::XdgToplevel,
+        },
+        shell::xdg::window::Window as XdgWindow,
+    };
+
+    let toplevel = window.xdg_toplevel()?;
+    let Ok(display) = window.display_handle() else {
+        return Some(false);
+    };
+    let RawDisplayHandle::Wayland(display) = display.as_raw() else {
+        return Some(false);
+    };
+
+    // Both pointers belong to the live winit window and outlive this call.
+    let backend = unsafe { Backend::from_foreign_display(display.display.as_ptr().cast()) };
+    let connection = Connection::from_backend(backend);
+    let id = unsafe { ObjectId::from_ptr(XdgToplevel::interface(), toplevel.as_ptr().cast()) };
+
+    let tiled = id
+        .ok()
+        .and_then(|id| XdgToplevel::from_id(&connection, id).ok())
+        .and_then(|toplevel| XdgWindow::from_xdg_toplevel(&toplevel))
+        .is_some_and(|xdg_window| format!("{xdg_window:?}").contains("TILED"));
+    Some(tiled)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn wayland_tiled(_window: &Window) -> Option<bool> {
+    None
 }
 
 /// Invisible bands along the window borders that drive a native resize.
@@ -185,14 +256,14 @@ impl ResizeBands {
 
 impl Component for ResizeBands {
     fn render(&self) -> impl IntoElement {
-        let maximized = use_maximized();
+        let info = use_window_info();
         let size = *Platform::get().root_size.read();
 
         rect()
             .layer(Layer::Overlay)
             .width(Size::px(0.))
             .height(Size::px(0.))
-            .maybe(!maximized(), |el| {
+            .maybe(!info.edge_to_edge, |el| {
                 el.children(
                     DIRECTIONS
                         .iter()


### PR DESCRIPTION
Working around winit's limitations..