### PR TITLE
feat(winit): Winit window dragging movement threshold

### DIFF
--- a/crates/freya-core/src/events_combos.rs
+++ b/crates/freya-core/src/events_combos.rs
@@ -36,6 +36,7 @@ const MULTI_PRESS_ELAPSED: Duration = Duration::from_millis(500);
 #[derive(Clone, Copy, PartialEq)]
 pub struct EventsCombos {
     pub(crate) last_press: State<Option<(Instant, CursorPoint, u8)>>,
+    pub(crate) pressing: State<bool>,
 }
 
 impl EventsCombos {
@@ -46,6 +47,7 @@ impl EventsCombos {
             None => {
                 let combos = EventsCombos {
                     last_press: State::create_in_scope(None, ScopeId::ROOT),
+                    pressing: State::create_in_scope(false, ScopeId::ROOT),
                 };
                 provide_context_for_scope_id(combos, ScopeId::ROOT);
                 combos
@@ -53,16 +55,24 @@ impl EventsCombos {
         }
     }
 
-    /// Break the combo when the pointer drags away from the last press.
-    pub fn moved(location: CursorPoint) {
+    /// Break the combo when the held pointer drags away from the last press.
+    pub fn moved(location: CursorPoint) -> bool {
         let mut combos = Self::get();
-        let dragged_away = matches!(
-            &*combos.last_press.read(),
-            Some((_, last_location, _)) if last_location.distance_to(location) > LOCATION_THRESHOLD
-        );
+        let dragged_away = *combos.pressing.read()
+            && matches!(
+                &*combos.last_press.read(),
+                Some((_, last_location, _)) if last_location.distance_to(location) > LOCATION_THRESHOLD
+            );
         if dragged_away {
             combos.last_press.set(None);
+            combos.pressing.set(false);
         }
+        dragged_away
+    }
+
+    /// Mark the pointer as released.
+    pub fn released() {
+        Self::get().pressing.set(false);
     }
 
     /// Register a press and get its position in the combo.
@@ -86,6 +96,7 @@ impl EventsCombos {
         combos
             .last_press
             .set(Some((Instant::now(), location, click_count)));
+        combos.pressing.set(true);
         event_type
     }
 }

--- a/crates/freya-winit/src/extensions.rs
+++ b/crates/freya-winit/src/extensions.rs
@@ -4,9 +4,9 @@ use freya_core::{
         Event,
         EventHandlersExt,
         EventsCombos,
+        MouseButton,
         Platform,
         PointerEventData,
-        PressEventType,
         UserEvent,
         consume_root_context,
     },
@@ -158,30 +158,30 @@ pub trait WinitPlatformExt {
 }
 
 pub trait WindowDragExt {
+    /// Drag the window on left press and move, toggle maximize on double press.
     fn window_drag(self) -> Self;
 }
 
 impl WindowDragExt for Rect {
     fn window_drag(self) -> Self {
-        self.on_pointer_down(move |e: Event<PointerEventData>| {
-            match EventsCombos::pressed(e.global_location()) {
-                PressEventType::Single => {
-                    Platform::get().with_window(Platform::window_id(), |window| {
-                        let _ = window.drag_window();
-                    });
-                }
-                PressEventType::Double => {
-                    Platform::get().with_window(Platform::window_id(), |window| {
-                        if window.is_maximized() {
-                            window.set_maximized(false);
-                        } else {
-                            window.set_maximized(true);
-                        }
-                    });
-                }
-                _ => {}
+        self.on_pointer_down(|e: Event<PointerEventData>| {
+            if e.button() != Some(MouseButton::Left) {
+                return;
+            }
+            if EventsCombos::pressed(e.global_location()).is_double() {
+                Platform::get().with_window(Platform::window_id(), |window| {
+                    window.set_maximized(!window.is_maximized());
+                });
             }
         })
+        .on_global_pointer_move(|e: Event<PointerEventData>| {
+            if EventsCombos::moved(e.global_location()) {
+                Platform::get().with_window(Platform::window_id(), |window| {
+                    let _ = window.drag_window();
+                });
+            }
+        })
+        .on_global_pointer_press(|_: Event<PointerEventData>| EventsCombos::released())
     }
 }
 


### PR DESCRIPTION
This way you can use it on top of stuff like, e.g., a button.